### PR TITLE
Update ReScript documentation for S.nullish to use correct type

### DIFF
--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -420,7 +420,7 @@ The `S.null` schema represents a data of a specific type that might be null.
 
 ### **`nullish`**
 
-`S.t<'value> => S.t<option<'value>>`
+`S.t<'value> => S.t<Nullable.t<'value>>`
 
 ```rescript
 let schema = S.nullish(S.string)
@@ -428,14 +428,12 @@ let schema = S.nullish(S.string)
 "Hello World!"->S.parseOrThrow(schema)
 // Some("Hello World!")
 %raw(`null`)->S.parseOrThrow(schema)
-// None
+// Null
 %raw(`undefined`)->S.parseOrThrow(schema)
-// None
+// Undefined
 ```
 
 The `S.nullish` schema represents a data of a specific type that might be null or undefined.
-
-> 🧠 Since `S.nullish` transforms value into `option` type, you can use `Option.getOr`/`Option.getOrWith` for it as well.
 
 ### **`unit`**
 


### PR DESCRIPTION
Managed to port my codebase from v9.3.0 to v10.0.0-rc.5. Was relatively smooth since the release notes for various RCs are very detailed & helpful :smiley: 

Only major hiccup I had was that I assumed `S.nullable` was simply renamed to `S.nullish`, but turns out the type changed too. Hopefully this PR should prevent anyone else migrating from making the same mistake I did :crossed_fingers: 