### PR TITLE
Refactor refiner functions to accept only input parameter

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -455,9 +455,9 @@ and internal = {
   // Logic for built-in encoding from the schema type
   mutable encoder?: builder,
   // Custom validations on input (before decoder)
-  mutable inputRefiner?: builder,
+  mutable inputRefiner?: (~input: val, ~selfSchema: internal) => string,
   // Custom validations on output (after decoder)
-  mutable refiner?: builder,
+  mutable refiner?: (~input: val, ~selfSchema: internal) => string,
   // A schema we transform to
   mutable to?: internal,
   // When transforming with changing shape,
@@ -2038,12 +2038,16 @@ let rec parse = (input: val, ~withEncoder: bool=false) => {
 
       // FIXME: inputRefiner should correctly be run for schema input (before decoder)
       switch expected.inputRefiner {
-      | Some(inputRefiner) => output := inputRefiner(~input=output.contents, ~selfSchema=expected)
+      | Some(inputRefiner) =>
+        output.contents.codeAfterValidation =
+          output.contents.codeAfterValidation ++ inputRefiner(~input=output.contents, ~selfSchema=expected)
       | None => ()
       }
       // Call refiner after decoder
       switch expected.refiner {
-      | Some(refiner) => output := refiner(~input=output.contents, ~selfSchema=expected)
+      | Some(refiner) =>
+        output.contents.codeAfterValidation =
+          output.contents.codeAfterValidation ++ refiner(~input=output.contents, ~selfSchema=expected)
       | None => ()
       }
 
@@ -3101,16 +3105,13 @@ let internalRefine = (schema, refiner) => {
   let schema = schema->castToInternal
   updateOutput(schema, mut => {
     let refinerCode = refiner(mut)
-    let existingRefiner = mut.refiner
     mut.refiner = Some(
-      (~input, ~selfSchema) => {
-        let output = switch existingRefiner {
-        | Some(existing) => existing(~input, ~selfSchema)
-        | None => input
+      switch mut.refiner {
+      | Some(existingRefiner) =>
+        (~input, ~selfSchema) => {
+          existingRefiner(~input, ~selfSchema) ++ refinerCode(~input, ~selfSchema)
         }
-        output.codeAfterValidation =
-          output.codeAfterValidation ++ refinerCode(~input=output, ~selfSchema)
-        output
+      | None => refinerCode
       },
     )
   })

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3093,14 +3093,6 @@ let noValidation = (schema, value) => {
   mut->castToPublic
 }
 
-let appendRefiner = (~existingDecoder: builder, refiner) => {
-  (~input, ~selfSchema) => {
-    let output = existingDecoder(~input, ~selfSchema)
-    output.codeAfterValidation = output.codeAfterValidation ++ refiner(~input=output, ~selfSchema)
-    output
-  }
-}
-
 let internalRefine = (schema, makeRefiner) => {
   let schema = schema->castToInternal
   updateOutput(schema, mut => {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3101,18 +3101,18 @@ let appendRefiner = (~existingDecoder: builder, refiner) => {
   }
 }
 
-let internalRefine = (schema, refiner) => {
+let internalRefine = (schema, makeRefiner) => {
   let schema = schema->castToInternal
   updateOutput(schema, mut => {
-    let refinerCode = refiner(mut)
+    let refiner = makeRefiner(mut)
     switch mut.refiner {
     | Some(existingRefiner) =>
       mut.refiner = Some(
         (~input) => {
-          existingRefiner(~input) ++ refinerCode(~input)
+          existingRefiner(~input) ++ refiner(~input)
         },
       )
-    | None => mut.refiner = Some(refinerCode)
+    | None => mut.refiner = Some(refiner)
     }
   })
 }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3100,7 +3100,19 @@ let appendRefiner = (~existingDecoder: builder, refiner) => {
 let internalRefine = (schema, refiner) => {
   let schema = schema->castToInternal
   updateOutput(schema, mut => {
-    mut.decoder = appendRefiner(~existingDecoder=mut.decoder, refiner(mut))
+    let refinerCode = refiner(mut)
+    let existingRefiner = mut.refiner
+    mut.refiner = Some(
+      (~input, ~selfSchema) => {
+        let output = switch existingRefiner {
+        | Some(existing) => existing(~input, ~selfSchema)
+        | None => input
+        }
+        output.codeAfterValidation =
+          output.codeAfterValidation ++ refinerCode(~input=output, ~selfSchema)
+        output
+      },
+    )
   })
 }
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -455,9 +455,9 @@ and internal = {
   // Logic for built-in encoding from the schema type
   mutable encoder?: builder,
   // Custom validations on input (before decoder)
-  mutable inputRefiner?: (~input: val, ~selfSchema: internal) => string,
+  mutable inputRefiner?: (~input: val) => string,
   // Custom validations on output (after decoder)
-  mutable refiner?: (~input: val, ~selfSchema: internal) => string,
+  mutable refiner?: (~input: val) => string,
   // A schema we transform to
   mutable to?: internal,
   // When transforming with changing shape,
@@ -2040,14 +2040,14 @@ let rec parse = (input: val, ~withEncoder: bool=false) => {
       switch expected.inputRefiner {
       | Some(inputRefiner) =>
         output.contents.codeAfterValidation =
-          output.contents.codeAfterValidation ++ inputRefiner(~input=output.contents, ~selfSchema=expected)
+          output.contents.codeAfterValidation ++ inputRefiner(~input=output.contents)
       | None => ()
       }
       // Call refiner after decoder
       switch expected.refiner {
       | Some(refiner) =>
         output.contents.codeAfterValidation =
-          output.contents.codeAfterValidation ++ refiner(~input=output.contents, ~selfSchema=expected)
+          output.contents.codeAfterValidation ++ refiner(~input=output.contents)
       | None => ()
       }
 
@@ -3105,21 +3105,21 @@ let internalRefine = (schema, refiner) => {
   let schema = schema->castToInternal
   updateOutput(schema, mut => {
     let refinerCode = refiner(mut)
-    mut.refiner = Some(
-      switch mut.refiner {
-      | Some(existingRefiner) =>
-        (~input, ~selfSchema) => {
-          existingRefiner(~input, ~selfSchema) ++ refinerCode(~input, ~selfSchema)
-        }
-      | None => refinerCode
-      },
-    )
+    switch mut.refiner {
+    | Some(existingRefiner) =>
+      mut.refiner = Some(
+        (~input) => {
+          existingRefiner(~input) ++ refinerCode(~input)
+        },
+      )
+    | None => mut.refiner = Some(refinerCode)
+    }
   })
 }
 
 let refine: (t<'value>, s<'value> => 'value => unit) => t<'value> = (schema, refiner) => {
   schema->internalRefine(_ =>
-    (~input, ~selfSchema as _) => {
+    (~input) => {
       `${input->B.embed(refiner(input->B.effectCtx))}(${input.var()});`
     }
   )
@@ -5775,7 +5775,7 @@ let intMin = (schema, minValue, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Int.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}<${input->B.embed(minValue)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5792,7 +5792,7 @@ let intMax = (schema, maxValue, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Int.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}>${input->B.embed(maxValue)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5805,7 +5805,7 @@ let intMax = (schema, maxValue, ~message as maybeMessage=?) => {
 let port = (schema, ~message=?) => {
   schema->internalRefine(mut => {
     mut.format = Some(Port)
-    (~input, ~selfSchema as _) => {
+    (~input) => {
       let inputVar = input.var()
       `${inputVar}>0&&${inputVar}<65536&&${inputVar}%1===0||${switch message {
         | Some(m) => input->B.fail(~message=m)
@@ -5822,7 +5822,7 @@ let floatMin = (schema, minValue, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Float.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}<${input->B.embed(minValue)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5839,7 +5839,7 @@ let floatMax = (schema, maxValue, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Float.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}>${input->B.embed(maxValue)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5856,7 +5856,7 @@ let arrayMinLength = (schema, length, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Array.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}.length<${input->B.embed(length)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5873,7 +5873,7 @@ let arrayMaxLength = (schema, length, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Array.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}.length>${input->B.embed(length)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5890,7 +5890,7 @@ let arrayLength = (schema, length, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=Array.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}.length!==${input->B.embed(length)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5907,7 +5907,7 @@ let stringMinLength = (schema, length, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}.length<${input->B.embed(length)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5924,7 +5924,7 @@ let stringMaxLength = (schema, length, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}.length>${input->B.embed(length)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5941,7 +5941,7 @@ let stringLength = (schema, length, ~message as maybeMessage=?) => {
   }
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(${input.var()}.length!==${input->B.embed(length)}){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5954,7 +5954,7 @@ let stringLength = (schema, length, ~message as maybeMessage=?) => {
 let email = (schema, ~message=`Invalid email address`) => {
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(!${input->B.embed(String.emailRegex)}.test(${input.var()})){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5967,7 +5967,7 @@ let email = (schema, ~message=`Invalid email address`) => {
 let uuid = (schema, ~message=`Invalid UUID`) => {
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(!${input->B.embed(String.uuidRegex)}.test(${input.var()})){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5980,7 +5980,7 @@ let uuid = (schema, ~message=`Invalid UUID`) => {
 let cuid = (schema, ~message=`Invalid CUID`) => {
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `if(!${input->B.embed(String.cuidRegex)}.test(${input.var()})){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -5993,7 +5993,7 @@ let cuid = (schema, ~message=`Invalid CUID`) => {
 let url = (schema, ~message=`Invalid url`) => {
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       `try{new URL(${input.var()})}catch(_){${input->B.fail(~message)}}`
     },
     ~refinement={
@@ -6006,7 +6006,7 @@ let url = (schema, ~message=`Invalid url`) => {
 let pattern = (schema, re, ~message=`Invalid pattern`) => {
   schema->addRefinement(
     ~metadataId=String.Refinement.metadataId,
-    ~refiner=(~input, ~selfSchema as _) => {
+    ~refiner=(~input) => {
       let embededRe = input->B.embed(re)
       if re->Js.Re.global {
         // TODO Write a regression test when it's needed

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1216,11 +1216,11 @@ function parse$1(input, withEncoderOpt) {
     output = expected.decoder(output, expected);
     let inputRefiner = expected.inputRefiner;
     if (inputRefiner !== undefined) {
-      output = inputRefiner(output, expected);
+      output.c = output.c + inputRefiner(output, expected);
     }
     let refiner = expected.refiner;
     if (refiner !== undefined) {
-      output = refiner(output, expected);
+      output.c = output.c + refiner(output, expected);
     }
     let to = output.e.to;
     if (to !== undefined) {
@@ -2034,11 +2034,7 @@ function internalRefine(schema, refiner) {
   return updateOutput(schema, mut => {
     let refinerCode = refiner(mut);
     let existingRefiner = mut.refiner;
-    mut.refiner = (input, selfSchema) => {
-      let output = existingRefiner !== undefined ? existingRefiner(input, selfSchema) : input;
-      output.c = output.c + refinerCode(output, selfSchema);
-      return output;
-    };
+    mut.refiner = existingRefiner !== undefined ? (input, selfSchema) => existingRefiner(input, selfSchema) + refinerCode(input, selfSchema) : refinerCode;
   });
 }
 
@@ -3189,60 +3185,96 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
       }
     } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
       } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
       }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
     }
-    accAtFrom.val = input;
-    return;
+    v = complete(output);
   }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
+  v.prev = undefined;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
   }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
   }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3326,82 +3358,70 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   return complete(v$2);
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
+function shapedSerializer(input, param) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
       }
     } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
+      accAtFrom = acc;
     }
-    v = complete(output);
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
   }
-  v.prev = undefined;
-  return v;
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function nested(fieldName) {
@@ -3476,28 +3496,10 @@ function definitionToSchema(definition) {
   });
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function shapedSerializer(input, param) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shapedParser(input, selfSchema) {
@@ -3517,12 +3519,6 @@ function shapedParser(input, selfSchema) {
   output.prev = input;
   output.k = targetSchema.to === undefined;
   return output;
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2030,14 +2030,14 @@ function noValidation(schema, value) {
   return mut;
 }
 
-function internalRefine(schema, refiner) {
+function internalRefine(schema, makeRefiner) {
   return updateOutput(schema, mut => {
-    let refinerCode = refiner(mut);
+    let refiner = makeRefiner(mut);
     let existingRefiner = mut.refiner;
     if (existingRefiner !== undefined) {
-      mut.refiner = input => existingRefiner(input) + refinerCode(input);
+      mut.refiner = input => existingRefiner(input) + refiner(input);
     } else {
-      mut.refiner = refinerCode;
+      mut.refiner = refiner;
     }
   });
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3189,62 +3189,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== "object" || definition === null) {
     return parse(definition);
@@ -3284,67 +3228,6 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
-}
-
-function shapedSerializer(input, param) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = complete(output);
-  }
-  v.prev = undefined;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
 }
 
 function nested(fieldName) {
@@ -3417,6 +3300,113 @@ function definitionToSchema(definition) {
     }
     
   });
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = complete(output);
+  }
+  v.prev = undefined;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3498,6 +3488,16 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
     }
   }
   return complete(v$2);
+}
+
+function shapedSerializer(input, param) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input, selfSchema) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2030,17 +2030,15 @@ function noValidation(schema, value) {
   return mut;
 }
 
-function appendRefiner(existingDecoder, refiner) {
-  return (input, selfSchema) => {
-    let output = existingDecoder(input, selfSchema);
-    output.c = output.c + refiner(output, selfSchema);
-    return output;
-  };
-}
-
 function internalRefine(schema, refiner) {
   return updateOutput(schema, mut => {
-    mut.decoder = appendRefiner(mut.decoder, refiner(mut));
+    let refinerCode = refiner(mut);
+    let existingRefiner = mut.refiner;
+    mut.refiner = (input, selfSchema) => {
+      let output = existingRefiner !== undefined ? existingRefiner(input, selfSchema) : input;
+      output.c = output.c + refinerCode(output, selfSchema);
+      return output;
+    };
   });
 }
 
@@ -3369,6 +3367,43 @@ function traverseDefinition(definition, onNode) {
   return mut$2;
 }
 
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = complete(output);
+  }
+  v.prev = undefined;
+  return v;
+}
+
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = "~" + fieldName;
@@ -3463,43 +3498,6 @@ function shapedSerializer(input, param) {
   output.t = true;
   output.prev = input;
   return output;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = complete(output);
-  }
-  v.prev = undefined;
-  return v;
 }
 
 function shapedParser(input, selfSchema) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1216,11 +1216,11 @@ function parse$1(input, withEncoderOpt) {
     output = expected.decoder(output, expected);
     let inputRefiner = expected.inputRefiner;
     if (inputRefiner !== undefined) {
-      output.c = output.c + inputRefiner(output, expected);
+      output.c = output.c + inputRefiner(output);
     }
     let refiner = expected.refiner;
     if (refiner !== undefined) {
-      output.c = output.c + refiner(output, expected);
+      output.c = output.c + refiner(output);
     }
     let to = output.e.to;
     if (to !== undefined) {
@@ -2034,12 +2034,16 @@ function internalRefine(schema, refiner) {
   return updateOutput(schema, mut => {
     let refinerCode = refiner(mut);
     let existingRefiner = mut.refiner;
-    mut.refiner = existingRefiner !== undefined ? (input, selfSchema) => existingRefiner(input, selfSchema) + refinerCode(input, selfSchema) : refinerCode;
+    if (existingRefiner !== undefined) {
+      mut.refiner = input => existingRefiner(input) + refinerCode(input);
+    } else {
+      mut.refiner = refinerCode;
+    }
   });
 }
 
 function refine$1(schema, refiner) {
-  return internalRefine(schema, param => ((input, param) => embed(input, refiner(effectCtx(input))) + "(" + input.v() + ");"));
+  return internalRefine(schema, param => (input => embed(input, refiner(effectCtx(input))) + "(" + input.v() + ");"));
 }
 
 function addRefinement(schema, metadataId, refinement, refiner) {
@@ -3185,6 +3189,113 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input, param) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
 function getShapedParserOutput(input, targetSchema) {
   let from = targetSchema.from;
   let fromFlattened = targetSchema.fromFlattened;
@@ -3236,45 +3347,76 @@ function getValByFrom(_input, from, _idx) {
   };
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
   }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
+  let properties = {};
+  let schema = base(objectTag, false);
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
     }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3358,150 +3500,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   return complete(v$2);
 }
 
-function shapedSerializer(input, param) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let schema = base(objectTag, false);
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
-}
-
 function shapedParser(input, selfSchema) {
   let flattened = selfSchema.flattened;
   if (flattened !== undefined) {
@@ -3519,6 +3517,12 @@ function shapedParser(input, selfSchema) {
   output.prev = input;
   output.k = targetSchema.to === undefined;
   return output;
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {
@@ -3806,7 +3810,7 @@ function intMin(schema, minValue, maybeMessage) {
       value: minValue
     },
     message: message
-  }, (input, param) => "if(" + input.v() + "<" + embed(input, minValue) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + "<" + embed(input, minValue) + "){" + fail(input, message) + "}");
 }
 
 function intMax(schema, maxValue, maybeMessage) {
@@ -3817,13 +3821,13 @@ function intMax(schema, maxValue, maybeMessage) {
       value: maxValue
     },
     message: message
-  }, (input, param) => "if(" + input.v() + ">" + embed(input, maxValue) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + ">" + embed(input, maxValue) + "){" + fail(input, message) + "}");
 }
 
 function port(schema, message) {
   return internalRefine(schema, mut => {
     mut.format = "port";
-    return (input, param) => {
+    return input => {
       let inputVar = input.v();
       return inputVar + ">0&&" + inputVar + "<65536&&" + inputVar + "%1===0||" + (
         message !== undefined ? fail(input, message) : embedInvalidInput(input, undefined)
@@ -3840,7 +3844,7 @@ function floatMin(schema, minValue, maybeMessage) {
       value: minValue
     },
     message: message
-  }, (input, param) => "if(" + input.v() + "<" + embed(input, minValue) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + "<" + embed(input, minValue) + "){" + fail(input, message) + "}");
 }
 
 function floatMax(schema, maxValue, maybeMessage) {
@@ -3851,7 +3855,7 @@ function floatMax(schema, maxValue, maybeMessage) {
       value: maxValue
     },
     message: message
-  }, (input, param) => "if(" + input.v() + ">" + embed(input, maxValue) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + ">" + embed(input, maxValue) + "){" + fail(input, message) + "}");
 }
 
 function arrayMinLength(schema, length, maybeMessage) {
@@ -3862,7 +3866,7 @@ function arrayMinLength(schema, length, maybeMessage) {
       length: length
     },
     message: message
-  }, (input, param) => "if(" + input.v() + ".length<" + embed(input, length) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + ".length<" + embed(input, length) + "){" + fail(input, message) + "}");
 }
 
 function arrayMaxLength(schema, length, maybeMessage) {
@@ -3873,7 +3877,7 @@ function arrayMaxLength(schema, length, maybeMessage) {
       length: length
     },
     message: message
-  }, (input, param) => "if(" + input.v() + ".length>" + embed(input, length) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + ".length>" + embed(input, length) + "){" + fail(input, message) + "}");
 }
 
 function stringMinLength(schema, length, maybeMessage) {
@@ -3884,7 +3888,7 @@ function stringMinLength(schema, length, maybeMessage) {
       length: length
     },
     message: message
-  }, (input, param) => "if(" + input.v() + ".length<" + embed(input, length) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + ".length<" + embed(input, length) + "){" + fail(input, message) + "}");
 }
 
 function stringMaxLength(schema, length, maybeMessage) {
@@ -3895,7 +3899,7 @@ function stringMaxLength(schema, length, maybeMessage) {
       length: length
     },
     message: message
-  }, (input, param) => "if(" + input.v() + ".length>" + embed(input, length) + "){" + fail(input, message) + "}");
+  }, input => "if(" + input.v() + ".length>" + embed(input, length) + "){" + fail(input, message) + "}");
 }
 
 function email(schema, messageOpt) {
@@ -3903,7 +3907,7 @@ function email(schema, messageOpt) {
   return addRefinement(schema, metadataId$1, {
     kind: "Email",
     message: message
-  }, (input, param) => "if(!" + embed(input, emailRegex) + ".test(" + input.v() + ")){" + fail(input, message) + "}");
+  }, input => "if(!" + embed(input, emailRegex) + ".test(" + input.v() + ")){" + fail(input, message) + "}");
 }
 
 function uuid(schema, messageOpt) {
@@ -3911,7 +3915,7 @@ function uuid(schema, messageOpt) {
   return addRefinement(schema, metadataId$1, {
     kind: "Uuid",
     message: message
-  }, (input, param) => "if(!" + embed(input, uuidRegex) + ".test(" + input.v() + ")){" + fail(input, message) + "}");
+  }, input => "if(!" + embed(input, uuidRegex) + ".test(" + input.v() + ")){" + fail(input, message) + "}");
 }
 
 function cuid(schema, messageOpt) {
@@ -3919,7 +3923,7 @@ function cuid(schema, messageOpt) {
   return addRefinement(schema, metadataId$1, {
     kind: "Cuid",
     message: message
-  }, (input, param) => "if(!" + embed(input, cuidRegex) + ".test(" + input.v() + ")){" + fail(input, message) + "}");
+  }, input => "if(!" + embed(input, cuidRegex) + ".test(" + input.v() + ")){" + fail(input, message) + "}");
 }
 
 function url(schema, messageOpt) {
@@ -3927,7 +3931,7 @@ function url(schema, messageOpt) {
   return addRefinement(schema, metadataId$1, {
     kind: "Url",
     message: message
-  }, (input, param) => "try{new URL(" + input.v() + ")}catch(_){" + fail(input, message) + "}");
+  }, input => "try{new URL(" + input.v() + ")}catch(_){" + fail(input, message) + "}");
 }
 
 function pattern(schema, re, messageOpt) {
@@ -3938,7 +3942,7 @@ function pattern(schema, re, messageOpt) {
       re: re
     },
     message: message
-  }, (input, param) => {
+  }, input => {
     let embededRe = embed(input, re);
     return (
       re.global ? embededRe + ".lastIndex=0;" : ""
@@ -4743,7 +4747,7 @@ function length(schema, length$1, maybeMessage) {
           length: length$1
         },
         message: message
-      }, (input, param) => "if(" + input.v() + ".length!==" + embed(input, length$1) + "){" + fail(input, message) + "}");
+      }, input => "if(" + input.v() + ".length!==" + embed(input, length$1) + "){" + fail(input, message) + "}");
     case "array" :
       let message$1 = maybeMessage !== undefined ? maybeMessage : "Array must be exactly " + length$1 + " items long";
       return addRefinement(schema, metadataId, {
@@ -4752,7 +4756,7 @@ function length(schema, length$1, maybeMessage) {
           length: length$1
         },
         message: message$1
-      }, (input, param) => "if(" + input.v() + ".length!==" + embed(input, length$1) + "){" + fail(input, message$1) + "}");
+      }, input => "if(" + input.v() + ".length!==" + embed(input, length$1) + "){" + fail(input, message$1) + "}");
     default:
       let message$2 = "S.length is not supported for " + toExpression(schema) + " schema. Coerce the schema to string or array using S.to first.";
       throw new Error("[Sury] " + message$2);


### PR DESCRIPTION
## Summary
This PR refactors the refiner function signatures throughout the codebase to simplify their interface. Refiner functions now accept only the `input` parameter instead of both `input` and `selfSchema`, reducing unnecessary coupling and simplifying the API.

## Key Changes

- **Updated refiner type signatures**: Changed `inputRefiner` and `refiner` field types from `builder` to `(~input: val) => string` in the `internal` record
- **Simplified refiner invocation**: Modified the `parse` function to append refiner output to `codeAfterValidation` instead of replacing the entire output object
- **Refactored `internalRefine` function**: Now properly chains multiple refiners by concatenating their outputs rather than wrapping them in the decoder
- **Updated all refinement functions**: Removed the unused `~selfSchema` parameter from all built-in refinement functions including:
  - `intMin`, `intMax`, `floatMin`, `floatMax`
  - `arrayMinLength`, `arrayMaxLength`, `arrayLength`
  - `stringMinLength`, `stringMaxLength`, `stringLength`
  - `email`, `uuid`, `cuid`, `url`, `pattern`
  - `port` and custom `refine` function

## Implementation Details

- Refiners now return validation code as strings that are concatenated to the `codeAfterValidation` field
- Multiple refiners on the same schema are properly chained by concatenating their validation code
- The `appendRefiner` function was removed as it's no longer needed with the new approach
- This change maintains backward compatibility in behavior while simplifying the internal API

https://claude.ai/code/session_01LPsNZxPJdRczdL94YEHccc