### PR TITLE
Fix shaped serializer output for discriminant fields with schema transformations

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5261,15 +5261,27 @@ module Schema = {
         v.isOutput = Some(true)
         v->parse
       } else {
-        let v = makeObjectVal(input, ~schema=targetSchema)
-        v.expected = targetSchema
+        // When acc is None (discriminant field with no input), follow the to chain
+        // to get the actual output schema properties (e.g., for reversed transformed objects)
+        let resolvedTargetSchema =
+          if acc === None {
+            targetSchema->getOutputSchema
+          } else {
+            targetSchema
+          }
+        let v = makeObjectVal(input, ~schema=resolvedTargetSchema)
+        v.expected = resolvedTargetSchema
         v.isOutput = Some(true)
         v.prev = None
         v.parent = Some(input)
         v.var = B._notVarAtParent
 
-        switch targetSchema {
-        | {items} =>
+        switch resolvedTargetSchema {
+        | {items}
+          if !(
+            acc === None &&
+              resolvedTargetSchema.additionalItems->Js.typeof === (objectTag :> string)
+          ) =>
           for idx in 0 to items->Js.Array2.length - 1 {
             let location = idx->Js.Int.toString
             v->B.Val.Object.add(
@@ -5287,7 +5299,11 @@ module Schema = {
               ),
             )
           }
-        | {properties, ?flattened} => {
+        | {properties, ?flattened}
+          if !(
+            acc === None &&
+              resolvedTargetSchema.additionalItems->Js.typeof === (objectTag :> string)
+          ) => {
             switch (flattened, acc) {
             | (Some(flattenedSchemas), Some({flattened: flattenedAcc})) =>
               flattenedAcc->Js.Array2.forEachi((acc, idx) => {
@@ -5332,7 +5348,7 @@ module Schema = {
           }
           input->B.invalidOperation(
             ~description={
-              `Missing input for ${targetSchema->castToPublic->toExpression}` ++
+              `Missing input for ${targetSchema->reverse->castToPublic->toExpression}` ++
               switch path {
               | "" => ""
               | _ => ` at ${path}`

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3412,6 +3412,7 @@ function prepareShapedSerializerAcc(acc, input) {
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
+  let exit = 0;
   if (acc !== undefined) {
     let val = acc.val;
     if (val !== undefined) {
@@ -3421,79 +3422,93 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
       v.e = targetSchema;
       return parse$1(v);
     }
-    
-  }
-  if (constField in targetSchema) {
-    let v$1 = nextConst(input, targetSchema, targetSchema);
-    v$1.prev = undefined;
-    v$1.p = input;
-    v$1.v = _notVarAtParent;
-    v$1.io = true;
-    return parse$1(v$1);
-  }
-  let v$2 = makeObjectVal(input, targetSchema);
-  v$2.e = targetSchema;
-  v$2.io = true;
-  v$2.prev = undefined;
-  v$2.p = input;
-  v$2.v = _notVarAtParent;
-  let flattened = targetSchema.flattened;
-  let items = targetSchema.items;
-  if (items !== undefined) {
-    for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-      let location = idx.toString();
-      let tmp;
-      if (acc !== undefined) {
-        let properties = acc.properties;
-        tmp = properties !== undefined ? properties[location] : undefined;
-      } else {
-        tmp = undefined;
-      }
-      let inlinedLocation = inlineLocation(input.g, location);
-      add(v$2, location, getShapedSerializerOutput(input, tmp, items[idx], path + ("[" + inlinedLocation + "]")));
-    }
+    exit = 1;
   } else {
-    let properties$1 = targetSchema.properties;
-    if (properties$1 !== undefined) {
-      if (flattened !== undefined && acc !== undefined) {
-        let flattenedAcc = acc.flattened;
-        if (flattenedAcc !== undefined) {
-          flattenedAcc.forEach((acc, idx) => {
-            let flattenedOutput = getShapedSerializerOutput(input, acc, reverse(flattened[idx]), path);
-            let vals = flattenedOutput.d;
-            let locations = Object.keys(vals);
-            for (let idx$1 = 0, idx_finish = locations.length; idx$1 < idx_finish; ++idx$1) {
-              let location = locations[idx$1];
-              add(v$2, location, vals[location]);
-            }
-          });
+    exit = 1;
+  }
+  if (exit === 1) {
+    if (constField in targetSchema) {
+      let v$1 = nextConst(input, targetSchema, targetSchema);
+      v$1.prev = undefined;
+      v$1.p = input;
+      v$1.v = _notVarAtParent;
+      v$1.io = true;
+      return parse$1(v$1);
+    }
+    let resolvedTargetSchema = acc === undefined ? getOutputSchema(targetSchema) : targetSchema;
+    let v$2 = makeObjectVal(input, resolvedTargetSchema);
+    v$2.e = resolvedTargetSchema;
+    v$2.io = true;
+    v$2.prev = undefined;
+    v$2.p = input;
+    v$2.v = _notVarAtParent;
+    let flattened = resolvedTargetSchema.flattened;
+    let items = resolvedTargetSchema.items;
+    let exit$1 = 0;
+    let exit$2 = 0;
+    if (items !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        let tmp;
+        if (acc !== undefined) {
+          let properties = acc.properties;
+          tmp = properties !== undefined ? properties[location] : undefined;
+        } else {
+          tmp = undefined;
         }
-        
-      }
-      let keys = Object.keys(properties$1);
-      for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-        let location$1 = keys[idx$1];
-        if (!(location$1 in v$2.d)) {
-          let tmp$1;
-          if (acc !== undefined) {
-            let properties$2 = acc.properties;
-            tmp$1 = properties$2 !== undefined ? properties$2[location$1] : undefined;
-          } else {
-            tmp$1 = undefined;
-          }
-          let inlinedLocation$1 = inlineLocation(input.g, location$1);
-          add(v$2, location$1, getShapedSerializerOutput(input, tmp$1, properties$1[location$1], path + ("[" + inlinedLocation$1 + "]")));
-        }
-        
+        let inlinedLocation = inlineLocation(input.g, location);
+        add(v$2, location, getShapedSerializerOutput(input, tmp, items[idx], path + ("[" + inlinedLocation + "]")));
       }
     } else {
+      exit$2 = 3;
+    }
+    if (exit$2 === 3) {
+      let properties$1 = resolvedTargetSchema.properties;
+      if (properties$1 !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
+        if (flattened !== undefined && acc !== undefined) {
+          let flattenedAcc = acc.flattened;
+          if (flattenedAcc !== undefined) {
+            flattenedAcc.forEach((acc, idx) => {
+              let flattenedOutput = getShapedSerializerOutput(input, acc, reverse(flattened[idx]), path);
+              let vals = flattenedOutput.d;
+              let locations = Object.keys(vals);
+              for (let idx$1 = 0, idx_finish = locations.length; idx$1 < idx_finish; ++idx$1) {
+                let location = locations[idx$1];
+                add(v$2, location, vals[location]);
+              }
+            });
+          }
+          
+        }
+        let keys = Object.keys(properties$1);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          if (!(location$1 in v$2.d)) {
+            let tmp$1;
+            if (acc !== undefined) {
+              let properties$2 = acc.properties;
+              tmp$1 = properties$2 !== undefined ? properties$2[location$1] : undefined;
+            } else {
+              tmp$1 = undefined;
+            }
+            let inlinedLocation$1 = inlineLocation(input.g, location$1);
+            add(v$2, location$1, getShapedSerializerOutput(input, tmp$1, properties$1[location$1], path + ("[" + inlinedLocation$1 + "]")));
+          }
+          
+        }
+      } else {
+        exit$1 = 2;
+      }
+    }
+    if (exit$1 === 2) {
       let from = targetSchema.from;
       let path$1 = from !== undefined ? path + from.map(item => "[\"" + item + "\"]").join("") : path;
       let tmp$2 = path$1 === "" ? "" : " at " + path$1;
-      invalidOperation(input, "Missing input for " + toExpression(targetSchema) + tmp$2);
+      invalidOperation(input, "Missing input for " + toExpression(reverse(targetSchema)) + tmp$2);
     }
+    return completeObjectVal(v$2);
   }
-  return completeObjectVal(v$2);
+  
 }
 
 function getShapedParserOutput(input, targetSchema) {


### PR DESCRIPTION
## Summary
This PR fixes the shaped serializer output generation for discriminant fields that use schema transformations (via the `to` chain). When a discriminant field has no input accumulator, the serializer now correctly follows the output schema chain to resolve the actual properties that should be serialized.

## Key Changes
- **Schema resolution for discriminant fields**: When `acc` is `None` (indicating a discriminant field with no input), the code now calls `getOutputSchema` to resolve the target schema through any transformations before building the object value.
- **Conditional item/property processing**: Added guards to prevent processing items or properties when dealing with a discriminant field (`acc === None`) that has `additionalItems` defined, ensuring correct behavior for transformed schemas.
- **Error message improvement**: Updated the error message for missing input to use the reversed (original) schema via `reverse(targetSchema)` for more accurate error reporting.
- **Control flow refactoring**: Introduced explicit exit flags to better manage the conditional logic paths and improve code clarity.

## Implementation Details
The fix addresses a scenario where discriminant fields with schema transformations (e.g., reversed transformed objects) were not properly resolving their output schema properties. By checking if the accumulator is `None` and following the `to` chain via `getOutputSchema`, the serializer now correctly identifies which properties should be included in the output, even when the input schema has been transformed.

https://claude.ai/code/session_01SQyDujzZHCRhovQJoSKHcz