### PR TITLE
Document JSON encoding behavior for undefined fields

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -20,6 +20,7 @@
 - TS: Updated `S.Error` type to use variants instead of code property
 - ReScript: `S.null` -> `S.nullAsOption`
 - Updated union conversion logic - it now always performs exhaustive validation
+- Encoding to JSON now strips undefined fields
 
 ### TS
 


### PR DESCRIPTION
## Summary
Updated the IDEAS.md changelog to document a change in JSON encoding behavior where undefined fields are now stripped during serialization.

## Changes
- Added entry to the unreleased changes section noting that "Encoding to JSON now strips undefined fields"

## Details
This documentation update reflects a behavioral change in how the library handles undefined values when encoding to JSON. Previously, undefined fields may have been included in the output, but now they are filtered out during the encoding process, resulting in cleaner JSON output without null/undefined entries.

https://claude.ai/code/session_017MrTwv79eP6BsWCUSpa19T