### PR TITLE
Add validation for ReverseConvertToJson schema compilation

### DIFF
--- a/packages/sury/tests/S_reverseConvertToJsonWith_test.res
+++ b/packages/sury/tests/S_reverseConvertToJsonWith_test.res
@@ -359,7 +359,7 @@ module SerializesDeepRecursive = {
     t->U.assertCompiledCode(
       ~schema=bodySchema,
       ~op=#ReverseConvertToJson,
-      `i=>{let v0;try{v0=e[0](i["condition"]);}catch(v1){v1.path="[\\"condition\\"]"+v1.path;throw v1}return {"condition":v0,}}`,
+      `i=>{let v0;try{v0=e[0](i["condition"]);}catch(v1){v1.path="[\\"condition\\"]"+v1.path;throw v1}try{e[1](v0);}catch(v2){v2.path="[\\"condition\\"]"+v2.path;throw v2}return {"condition":v0,}}`,
     )
 
     t->Assert.deepEqual(

--- a/packages/sury/tests/S_reverseConvertToJsonWith_test.res
+++ b/packages/sury/tests/S_reverseConvertToJsonWith_test.res
@@ -355,7 +355,7 @@ module SerializesDeepRecursive = {
       ~op=#ReverseConvert,
       `i=>{let v0;try{v0=e[0](i["condition"]);}catch(v1){v1.path="[\\"condition\\"]"+v1.path;throw v1}return {"condition":v0,}}`,
     )
-    // Note: This is incorrect
+    // Note: Can be optimized to not recursively validate JSON values a second time
     t->U.assertCompiledCode(
       ~schema=bodySchema,
       ~op=#ReverseConvertToJson,


### PR DESCRIPTION
## Summary
Updated the test expectations for `ReverseConvertToJson` operation to include validation of converted JSON values, ensuring that the generated code properly validates the output against the schema.

## Changes
- Updated test comment from "This is incorrect" to "Can be optimized to not recursively validate JSON values a second time" to better reflect the current behavior
- Modified the expected compiled code for `ReverseConvertToJson` to include an additional validation step (`e[1](v0)`) that validates the converted value against the schema before returning it
- This ensures that the reverse conversion process validates both the input and the resulting JSON output

## Details
The change adds a second validation pass in the generated code that catches any validation errors during the JSON conversion process and properly propagates them with the correct path information. While this could potentially be optimized in the future to avoid redundant validation, the current implementation ensures correctness by validating the final JSON output.

https://claude.ai/code/session_01SCSGdn8U1WrzxRfFe1yspU