### PR TITLE
Improve compactColumns validation with per-field parsing and error paths

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5550,34 +5550,10 @@ let compactColumnsEncoder = Builder.encoder((~input, ~target) => {
       for idx in 0 to keys->Js.Array2.length - 1 {
         let key = keys->Js.Array2.unsafe_get(idx)
         let rawValueCode = `${inputVar}[${iteratorVar}][${key->X.Inlined.Value.fromString}]`
-        let fieldSchema = properties->Js.Dict.unsafeGet(key)
-        // Check if this field converts undefined to null (reversed nullAsOption)
-        let hasUndefinedToNullTransform = switch fieldSchema.anyOf {
-        | Some(anyOf) =>
-          anyOf->Js.Array2.some(item => {
-            let itemTagFlag = item.tag->TagFlag.get
-            if itemTagFlag->Flag.unsafeHas(TagFlag.undefined) {
-              switch item.to {
-              | Some(toSchema) =>
-                let toTagFlag = toSchema.tag->TagFlag.get
-                toTagFlag->Flag.unsafeHas(TagFlag.null)
-              | None => false
-              }
-            } else {
-              false
-            }
-          })
-        | None => false
-        }
-        let fieldValueCode = if hasUndefinedToNullTransform {
-          `${rawValueCode}===void 0?null:${rawValueCode}`
-        } else {
-          rawValueCode
-        }
         initialArraysCode := initialArraysCode.contents ++ `new Array(${inputVar}.length),`
         settingCode :=
           settingCode.contents ++
-          `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${fieldValueCode};`
+          `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${rawValueCode};`
       }
 
       input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
@@ -5669,28 +5645,30 @@ let compactColumnsDecoder = (~input) => {
 
         let lengthCode = ref("")
         let itemBuildCode = ref("")
+        let itemParseCode = ref("")
         for idx in 0 to keys->Js.Array2.length - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
           let rawValueCode = `${inputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]`
           let fieldSchema = properties->Js.Dict.unsafeGet(key)
-          // Check if this field has a null variant (e.g., nullAsOption)
-          let hasNullVariant = switch fieldSchema.has {
-          | Some(has) =>
-            switch has->X.Dict.getUnsafeOption((nullTag :> string)) {
-            | Some(_) => true
-            | None => false
-            }
-          | None => false
-          }
-          let fieldValueCode = if hasNullVariant {
-            `${rawValueCode}===null?void 0:${rawValueCode}`
-          } else {
-            rawValueCode
-          }
+
+          // Use parse on the field schema to handle transformations (e.g. null->undefined)
+          let itemInput = input->B.Val.scope
+          itemInput.inline = rawValueCode
+          itemInput.schema = unknown
+          itemInput.expected = fieldSchema
+          itemInput.var = B._notVarBeforeValidation
+          itemInput.isInput = Some(false)
+          itemInput.isOutput = Some(false)
+          itemInput.path = Path.empty
+
+          let itemOutput = itemInput->parse
+          let itemCode = itemOutput->B.merge
+
+          itemParseCode := itemParseCode.contents ++ itemCode
           lengthCode := lengthCode.contents ++ `${inputVar}[${idx->X.Int.unsafeToString}].length,`
           itemBuildCode :=
             itemBuildCode.contents ++
-            `${key->X.Inlined.Value.fromString}:${fieldValueCode},`
+            `${key->X.Inlined.Value.fromString}:${itemOutput.inline},`
         }
 
         input.allocate(`${outputVar}=new Array(Math.max(${lengthCode.contents}))`)
@@ -5701,10 +5679,12 @@ let compactColumnsDecoder = (~input) => {
         output.isOutput = Some(true)
         output.codeFromPrev =
           output.codeFromPrev ++
-          `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${outputVar}[${iteratorVar}]={${itemBuildCode.contents}};}`
+          `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${itemParseCode.contents}${outputVar}[${iteratorVar}]={${itemBuildCode.contents}};}`
         output
       } else {
         // Reverse direction: rows → columnar
+        // The field values have already been transformed by the earlier parse pipeline step
+        // (the object schema's reverse parse), so we can just copy them directly.
         let inputVar = input->B.Val.var
         let iteratorVar = input.global->B.varWithoutAllocation
         let outputVar = input.global->B.varWithoutAllocation
@@ -5714,34 +5694,10 @@ let compactColumnsDecoder = (~input) => {
         for idx in 0 to keys->Js.Array2.length - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
           let rawValueCode = `${inputVar}[${iteratorVar}][${key->X.Inlined.Value.fromString}]`
-          let fieldSchema = properties->Js.Dict.unsafeGet(key)
-          // Check if this field converts undefined to null (reversed nullAsOption)
-          let hasUndefinedToNullTransform = switch fieldSchema.anyOf {
-          | Some(anyOf) =>
-            anyOf->Js.Array2.some(item => {
-              let itemTagFlag = item.tag->TagFlag.get
-              if itemTagFlag->Flag.unsafeHas(TagFlag.undefined) {
-                switch item.to {
-                | Some(toSchema) =>
-                  let toTagFlag = toSchema.tag->TagFlag.get
-                  toTagFlag->Flag.unsafeHas(TagFlag.null)
-                | None => false
-                }
-              } else {
-                false
-              }
-            })
-          | None => false
-          }
-          let fieldValueCode = if hasUndefinedToNullTransform {
-            `${rawValueCode}===void 0?null:${rawValueCode}`
-          } else {
-            rawValueCode
-          }
           initialArraysCode := initialArraysCode.contents ++ `new Array(${inputVar}.length),`
           settingCode :=
             settingCode.contents ++
-            `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${fieldValueCode};`
+            `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${rawValueCode};`
         }
 
         input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5655,6 +5655,8 @@ let compactColumnsDecoder = (~input) => {
         let lengthCode = ref("")
         let itemBuildCode = ref("")
         let itemParseCode = ref("")
+        let itemInlines = []
+        let hasAsync = ref(false)
         for idx in 0 to keys->Js.Array2.length - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
           let fieldSchema = properties->Js.Dict.unsafeGet(key)
@@ -5668,12 +5670,18 @@ let compactColumnsDecoder = (~input) => {
           itemInput.var = B._notVarBeforeValidation
           itemInput.isInput = Some(false)
           itemInput.isOutput = Some(false)
+          // Path like ["bar"] so validation errors carry the field location.
+          itemInput.path = Path.fromInlinedLocation(input.global->B.inlineLocation(key))
 
           let itemOutput = itemInput->parse
+          if itemOutput.flag->Flag.unsafeHas(ValFlag.async) {
+            hasAsync := true
+          }
           let itemCode = itemOutput->B.merge
 
           itemParseCode := itemParseCode.contents ++ itemCode
           lengthCode := lengthCode.contents ++ `${inputVar}[${idx->X.Int.unsafeToString}].length,`
+          itemInlines->Js.Array2.push(itemOutput.inline)->ignore
           itemBuildCode :=
             itemBuildCode.contents ++
             `${key->X.Inlined.Value.fromString}:${itemOutput.inline},`
@@ -5685,10 +5693,46 @@ let compactColumnsDecoder = (~input) => {
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
         output.isOutput = Some(true)
-        output.codeFromPrev =
-          output.codeFromPrev ++
-          `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${itemParseCode.contents}${outputVar}[${iteratorVar}]={${itemBuildCode.contents}};}`
-        output
+
+        // Wrap the row body in a single try/catch that prepends the row index to
+        // any thrown error — giving paths like ["0"]["bar"]. A single wrapper is
+        // used (rather than per-field) so that `let` variables declared while
+        // parsing one field remain in scope for the object construction.
+        let errorVar = input.global->B.varWithoutAllocation
+        let wrapRowBody = body =>
+          if itemParseCode.contents === "" {
+            body
+          } else {
+            `try{${body}}catch(${errorVar}){${errorVar}.path='["'+${iteratorVar}+'"]'+${errorVar}.path;throw ${errorVar}}`
+          }
+
+        if hasAsync.contents {
+          // For async fields, each row becomes a promise that awaits all field values
+          // via Promise.all, and the final output is Promise.all of all row promises.
+          let rowResultVar = input.global->B.varWithoutAllocation
+          let asyncBuildCode =
+            keys
+            ->Js.Array2.mapi((key, idx) =>
+              `${key->X.Inlined.Value.fromString}:${rowResultVar}[${idx->X.Int.unsafeToString}]`
+            )
+            ->Js.Array2.joinWith(",")
+          let promisesCode = itemInlines->Js.Array2.joinWith(",")
+          let rowBody = `${itemParseCode.contents}${outputVar}[${iteratorVar}]=Promise.all([${promisesCode}]).then(${rowResultVar}=>({${asyncBuildCode},}));`
+          output.codeFromPrev =
+            output.codeFromPrev ++
+            `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrapRowBody(
+                rowBody,
+              )}}`
+          output->B.asyncVal(`Promise.all(${outputVar})`)
+        } else {
+          let rowBody = `${itemParseCode.contents}${outputVar}[${iteratorVar}]={${itemBuildCode.contents}};`
+          output.codeFromPrev =
+            output.codeFromPrev ++
+            `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrapRowBody(
+                rowBody,
+              )}}`
+          output
+        }
       } else {
         // Reverse direction: rows → columnar
         // The field values have already been transformed by the earlier parse pipeline step

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5643,10 +5643,12 @@ let compactColumnsDecoder = (~input) => {
         let iteratorVar = input.global->B.varWithoutAllocation
         let outputVar = input.global->B.varWithoutAllocation
 
-        // selfSchema is array(array(inputSchema)); derive the inner inputSchema,
-        // which is the schema of each raw column value.
-        let itemSchema: internal = {
-          let innerArray: internal = selfSchema.additionalItems->Obj.magic
+        // Schema of each raw column value. When input is unknown, items are unknown.
+        // When input is array(array(inputSchema)), derive inputSchema from input.schema.
+        let itemSchema: internal = if isUnknownInput {
+          unknown
+        } else {
+          let innerArray: internal = input.schema.additionalItems->Obj.magic
           innerArray.additionalItems->Obj.magic
         }
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5643,23 +5643,29 @@ let compactColumnsDecoder = (~input) => {
         let iteratorVar = input.global->B.varWithoutAllocation
         let outputVar = input.global->B.varWithoutAllocation
 
+        // selfSchema is array(array(inputSchema)); derive the inner inputSchema,
+        // which is the schema of each raw column value.
+        let itemSchema: internal = {
+          let innerArray: internal = selfSchema.additionalItems->Obj.magic
+          innerArray.additionalItems->Obj.magic
+        }
+
         let lengthCode = ref("")
         let itemBuildCode = ref("")
         let itemParseCode = ref("")
         for idx in 0 to keys->Js.Array2.length - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
-          let rawValueCode = `${inputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]`
           let fieldSchema = properties->Js.Dict.unsafeGet(key)
+          let rawValueCode = `${inputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]`
 
-          // Use parse on the field schema to handle transformations (e.g. null->undefined)
+          // Use parse on the field schema to handle transformations (e.g. null->undefined).
           let itemInput = input->B.Val.scope
           itemInput.inline = rawValueCode
-          itemInput.schema = unknown
+          itemInput.schema = itemSchema
           itemInput.expected = fieldSchema
           itemInput.var = B._notVarBeforeValidation
           itemInput.isInput = Some(false)
           itemInput.isOutput = Some(false)
-          itemInput.path = Path.empty
 
           let itemOutput = itemInput->parse
           let itemCode = itemOutput->B.merge

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3933,7 +3933,11 @@ function compactColumnsDecoder(input) {
       let itemSchema = isUnknownInput ? unknown : input.s.additionalItems.additionalItems;
       let lengthCode = "";
       let itemBuildCode = "";
-      let itemParseCode = "";
+      let itemParseCode = {
+        contents: ""
+      };
+      let itemInlines = [];
+      let hasAsync = false;
       for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
         let key = keys[idx];
         let fieldSchema = maybeProperties$1[key];
@@ -3945,10 +3949,16 @@ function compactColumnsDecoder(input) {
         itemInput.v = _notVarBeforeValidation;
         itemInput.ii = false;
         itemInput.io = false;
+        let inlinedLocation = inlineLocation(input.g, key);
+        itemInput.path = "[" + inlinedLocation + "]";
         let itemOutput = parse$1(itemInput);
+        if (itemOutput.f & 1) {
+          hasAsync = true;
+        }
         let itemCode = merge(itemOutput);
-        itemParseCode = itemParseCode + itemCode;
+        itemParseCode.contents = itemParseCode.contents + itemCode;
         lengthCode = lengthCode + (inputVar + "[" + idx + "].length,");
+        itemInlines.push(itemOutput.i);
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
@@ -3956,7 +3966,24 @@ function compactColumnsDecoder(input) {
       let output$1 = next(input, outputVar, outputSchema$1, outputSchema$1);
       output$1.v = _var;
       output$1.io = true;
-      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + itemParseCode + outputVar + "[" + iteratorVar + "]={" + itemBuildCode + "};}");
+      let errorVar = varWithoutAllocation(input.g);
+      let wrapRowBody = body => {
+        if (itemParseCode.contents === "") {
+          return body;
+        } else {
+          return "try{" + body + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
+        }
+      };
+      if (hasAsync) {
+        let rowResultVar = varWithoutAllocation(input.g);
+        let asyncBuildCode = keys.map((key, idx) => fromString(key) + ":" + rowResultVar + "[" + idx + "]").join(",");
+        let promisesCode = itemInlines.join(",");
+        let rowBody = itemParseCode.contents + outputVar + "[" + iteratorVar + "]=Promise.all([" + promisesCode + "]).then(" + rowResultVar + "=>({" + asyncBuildCode + ",}));";
+        output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrapRowBody(rowBody) + "}");
+        return asyncVal(output$1, "Promise.all(" + outputVar + ")");
+      }
+      let rowBody$1 = itemParseCode.contents + outputVar + "[" + iteratorVar + "]={" + itemBuildCode + "};";
+      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrapRowBody(rowBody$1) + "}");
       return output$1;
     }
     let inputVar$1 = input.v();

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3831,23 +3831,8 @@ function compactColumnsEncoder(input, target) {
   for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
     let key = keys[idx];
     let rawValueCode = inputVar + "[" + iteratorVar + "][" + fromString(key) + "]";
-    let fieldSchema = maybeProperties[key];
-    let anyOf = fieldSchema.anyOf;
-    let hasUndefinedToNullTransform = anyOf !== undefined ? anyOf.some(item => {
-        let itemTagFlag = flags[item.type];
-        if (!(itemTagFlag & 16)) {
-          return false;
-        }
-        let toSchema = item.to;
-        if (toSchema === undefined) {
-          return false;
-        }
-        let toTagFlag = flags[toSchema.type];
-        return toTagFlag & 32;
-      }) : false;
-    let fieldValueCode = hasUndefinedToNullTransform ? rawValueCode + "===void 0?null:" + rawValueCode : rawValueCode;
     initialArraysCode = initialArraysCode + ("new Array(" + inputVar + ".length),");
-    settingCode = settingCode + (outputVar + "[" + idx + "][" + iteratorVar + "]=" + fieldValueCode + ";");
+    settingCode = settingCode + (outputVar + "[" + idx + "][" + iteratorVar + "]=" + rawValueCode + ";");
   }
   input.a(outputVar + "=[" + initialArraysCode + "]");
   let output = next(input, outputVar, base(arrayTag, false), undefined);
@@ -3947,22 +3932,31 @@ function compactColumnsDecoder(input) {
       let outputVar = varWithoutAllocation(input.g);
       let lengthCode = "";
       let itemBuildCode = "";
+      let itemParseCode = "";
       for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
         let key = keys[idx];
         let rawValueCode = inputVar + "[" + idx + "][" + iteratorVar + "]";
         let fieldSchema = maybeProperties$1[key];
-        let has = fieldSchema.has;
-        let hasNullVariant = has !== undefined ? has[nullTag] !== undefined : false;
-        let fieldValueCode = hasNullVariant ? rawValueCode + "===null?void 0:" + rawValueCode : rawValueCode;
+        let itemInput = scope(input);
+        itemInput.i = rawValueCode;
+        itemInput.s = unknown;
+        itemInput.e = fieldSchema;
+        itemInput.v = _notVarBeforeValidation;
+        itemInput.ii = false;
+        itemInput.io = false;
+        itemInput.path = "";
+        let itemOutput = parse$1(itemInput);
+        let itemCode = merge(itemOutput);
+        itemParseCode = itemParseCode + itemCode;
         lengthCode = lengthCode + (inputVar + "[" + idx + "].length,");
-        itemBuildCode = itemBuildCode + (fromString(key) + ":" + fieldValueCode + ",");
+        itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
       let outputSchema$1 = base(arrayTag, false);
       let output$1 = next(input, outputVar, outputSchema$1, outputSchema$1);
       output$1.v = _var;
       output$1.io = true;
-      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + outputVar + "[" + iteratorVar + "]={" + itemBuildCode + "};}");
+      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + itemParseCode + outputVar + "[" + iteratorVar + "]={" + itemBuildCode + "};}");
       return output$1;
     }
     let inputVar$1 = input.v();
@@ -3973,23 +3967,8 @@ function compactColumnsDecoder(input) {
     for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
       let key$1 = keys[idx$1];
       let rawValueCode$1 = inputVar$1 + "[" + iteratorVar$1 + "][" + fromString(key$1) + "]";
-      let fieldSchema$1 = maybeProperties$1[key$1];
-      let anyOf = fieldSchema$1.anyOf;
-      let hasUndefinedToNullTransform = anyOf !== undefined ? anyOf.some(item => {
-          let itemTagFlag = flags[item.type];
-          if (!(itemTagFlag & 16)) {
-            return false;
-          }
-          let toSchema = item.to;
-          if (toSchema === undefined) {
-            return false;
-          }
-          let toTagFlag = flags[toSchema.type];
-          return toTagFlag & 32;
-        }) : false;
-      let fieldValueCode$1 = hasUndefinedToNullTransform ? rawValueCode$1 + "===void 0?null:" + rawValueCode$1 : rawValueCode$1;
       initialArraysCode = initialArraysCode + ("new Array(" + inputVar$1 + ".length),");
-      settingCode = settingCode + (outputVar$1 + "[" + idx$1 + "][" + iteratorVar$1 + "]=" + fieldValueCode$1 + ";");
+      settingCode = settingCode + (outputVar$1 + "[" + idx$1 + "][" + iteratorVar$1 + "]=" + rawValueCode$1 + ";");
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
     let outputSchema$2 = base(arrayTag, false);

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3930,8 +3930,7 @@ function compactColumnsDecoder(input) {
       let inputVar = input.v();
       let iteratorVar = varWithoutAllocation(input.g);
       let outputVar = varWithoutAllocation(input.g);
-      let innerArray = selfSchema.additionalItems;
-      let itemSchema = innerArray.additionalItems;
+      let itemSchema = isUnknownInput ? unknown : input.s.additionalItems.additionalItems;
       let lengthCode = "";
       let itemBuildCode = "";
       let itemParseCode = "";

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3930,21 +3930,22 @@ function compactColumnsDecoder(input) {
       let inputVar = input.v();
       let iteratorVar = varWithoutAllocation(input.g);
       let outputVar = varWithoutAllocation(input.g);
+      let innerArray = selfSchema.additionalItems;
+      let itemSchema = innerArray.additionalItems;
       let lengthCode = "";
       let itemBuildCode = "";
       let itemParseCode = "";
       for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
         let key = keys[idx];
-        let rawValueCode = inputVar + "[" + idx + "][" + iteratorVar + "]";
         let fieldSchema = maybeProperties$1[key];
+        let rawValueCode = inputVar + "[" + idx + "][" + iteratorVar + "]";
         let itemInput = scope(input);
         itemInput.i = rawValueCode;
-        itemInput.s = unknown;
+        itemInput.s = itemSchema;
         itemInput.e = fieldSchema;
         itemInput.v = _notVarBeforeValidation;
         itemInput.ii = false;
         itemInput.io = false;
-        itemInput.path = "";
         let itemOutput = parse$1(itemInput);
         let itemCode = merge(itemOutput);
         itemParseCode = itemParseCode + itemCode;

--- a/packages/sury/tests/S_compactColumns_test.res
+++ b/packages/sury/tests/S_compactColumns_test.res
@@ -135,10 +135,6 @@ test("Schema has format field set to compactColumns", t => {
   t->Assert.deepEqual((schema->S.untag).format, Some(CompactColumns))
 })
 
-// ──────────────────────────────────────────────────────────────
-// Tests added from review — exercising gaps in coverage
-// ──────────────────────────────────────────────────────────────
-
 test("Typed input schema (non-unknown inputSchema branch)", t => {
   // Exercises the non-unknown branch of itemSchema derivation,
   // where input.schema.additionalItems is walked twice.

--- a/packages/sury/tests/S_compactColumns_test.res
+++ b/packages/sury/tests/S_compactColumns_test.res
@@ -134,3 +134,274 @@ test("Schema has format field set to compactColumns", t => {
   let schema = S.compactColumns(S.unknown)
   t->Assert.deepEqual((schema->S.untag).format, Some(CompactColumns))
 })
+
+// ──────────────────────────────────────────────────────────────
+// Tests added from review — exercising gaps in coverage
+// ──────────────────────────────────────────────────────────────
+
+test("Typed input schema (non-unknown inputSchema branch)", t => {
+  // Exercises the non-unknown branch of itemSchema derivation,
+  // where input.schema.additionalItems is walked twice.
+  let schema =
+    S.compactColumns(S.string)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+            "bar": s.matches(S.string),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`[["a", "b"], ["c", "d"]]`)->S.parseOrThrow(schema),
+    %raw(`[{"foo": "a", "bar": "c"}, {"foo": "b", "bar": "d"}]`),
+  )
+
+  t->Assert.deepEqual(
+    %raw(`[{"foo": "a", "bar": "c"}, {"foo": "b", "bar": "d"}]`)->S.reverseConvertOrThrow(schema),
+    %raw(`[["a", "b"], ["c", "d"]]`),
+  )
+})
+
+test("Invalid field value reports error with path", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+            "bar": s.matches(S.int),
+          }
+        ),
+      ),
+    )
+
+  // Second row, bar column contains a non-int value.
+  t->U.assertThrowsMessage(
+    () => %raw(`[["a", "b"], [0, "not-an-int"]]`)->S.parseOrThrow(schema),
+    `Expected int32, received "not-an-int"`,
+  )
+})
+
+test("Error path reporting for invalid column value", t => {
+  // Asserts that validation errors carry a useful path to the offending cell.
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+            "bar": s.matches(S.int),
+          }
+        ),
+      ),
+    )
+
+  switch %raw(`[["a"], ["not-an-int"]]`)->S.parseOrThrow(schema) {
+  | _ => t->Assert.fail("Should have thrown")
+  | exception S.Exn(error) =>
+    // Should have a non-empty path pointing into the failing cell.
+    let path = (error->Obj.magic)["path"]
+    t->Assert.notDeepEqual(path, "", ~message="Error path should not be empty")
+  }
+})
+
+asyncTest("Async field schema", async t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string->S.transform(_ => {asyncParser: async i => i})),
+            "bar": s.matches(S.int),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    await %raw(`[["a", "b"], [0, 1]]`)->S.parseAsyncOrThrow(schema),
+    %raw(`[{"foo": "a", "bar": 0}, {"foo": "b", "bar": 1}]`),
+  )
+})
+
+test("Field schema with S.transform", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string->S.transform(_ => {parser: v => v->Js.String2.toUpperCase})),
+            "bar": s.matches(S.int),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`[["a", "b"], [0, 1]]`)->S.parseOrThrow(schema),
+    %raw(`[{"foo": "A", "bar": 0}, {"foo": "B", "bar": 1}]`),
+  )
+})
+
+test("Nullable field (null | undefined)", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.nullable(S.string)),
+            "bar": s.matches(S.int),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`[["a", null], [0, 1]]`)->S.parseOrThrow(schema),
+    %raw(`[{"foo": "a", "bar": 0}, {"foo": null, "bar": 1}]`),
+  )
+
+  t->Assert.deepEqual(
+    %raw(`[{"foo": "a", "bar": 0}, {"foo": null, "bar": 1}]`)->S.reverseConvertOrThrow(schema),
+    %raw(`[["a", null], [0, 1]]`),
+  )
+})
+
+test("More than 2 fields", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "a": s.matches(S.string),
+            "b": s.matches(S.int),
+            "c": s.matches(S.bool),
+            "d": s.matches(S.float),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`[["x", "y"], [1, 2], [true, false], [1.5, 2.5]]`)->S.parseOrThrow(schema),
+    %raw(`[{"a": "x", "b": 1, "c": true, "d": 1.5}, {"a": "y", "b": 2, "c": false, "d": 2.5}]`),
+  )
+
+  t->Assert.deepEqual(
+    %raw(`[{"a": "x", "b": 1, "c": true, "d": 1.5}, {"a": "y", "b": 2, "c": false, "d": 2.5}]`)->S.reverseConvertOrThrow(
+      schema,
+    ),
+    %raw(`[["x", "y"], [1, 2], [true, false], [1.5, 2.5]]`),
+  )
+})
+
+test("Single-field object", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "only": s.matches(S.string),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`[["a", "b", "c"]]`)->S.parseOrThrow(schema),
+    %raw(`[{"only": "a"}, {"only": "b"}, {"only": "c"}]`),
+  )
+
+  t->Assert.deepEqual(
+    %raw(`[{"only": "a"}, {"only": "b"}, {"only": "c"}]`)->S.reverseConvertOrThrow(schema),
+    %raw(`[["a", "b", "c"]]`),
+  )
+})
+
+test("Union field", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.union([S.int->S.castToUnknown, S.string->S.castToUnknown])),
+            "bar": s.matches(S.bool),
+          }
+        ),
+      ),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`[[1, "two"], [true, false]]`)->S.parseOrThrow(schema),
+    %raw(`[{"foo": 1, "bar": true}, {"foo": "two", "bar": false}]`),
+  )
+})
+
+test("Field with S.refine", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "age": s.matches(S.int->S.refine(age => age >= 0, ~error="Age must be non-negative")),
+            "name": s.matches(S.string),
+          }
+        ),
+      ),
+    )
+
+  // Valid row parses successfully.
+  t->Assert.deepEqual(
+    %raw(`[[10, 20], ["alice", "bob"]]`)->S.parseOrThrow(schema),
+    %raw(`[{"age": 10, "name": "alice"}, {"age": 20, "name": "bob"}]`),
+  )
+
+  // Negative age triggers the refinement error.
+  t->U.assertThrowsMessage(
+    () => %raw(`[[-5], ["bad"]]`)->S.parseOrThrow(schema),
+    `Age must be non-negative`,
+  )
+})
+
+test("reverseConvertToJsonOrThrow with nullable field", t => {
+  S.enableJson()
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+            "bar": s.matches(S.nullAsOption(S.int)),
+          }
+        ),
+      ),
+    )
+
+  let value = %raw(`[{"foo": "a", "bar": 0}, {"foo": "b", "bar": undefined}]`)
+  t->Assert.deepEqual(
+    value->S.reverseConvertToJsonOrThrow(schema),
+    %raw(`[["a", "b"], [0, null]]`),
+  )
+})
+
+test("Roundtrip: parse -> reverseConvert -> parse", t => {
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+            "bar": s.matches(S.nullAsOption(S.int)),
+          }
+        ),
+      ),
+    )
+
+  let columnar = %raw(`[["a", "b", "c"], [0, null, 2]]`)
+  let rows = columnar->S.parseOrThrow(schema)
+  let roundtripped = rows->S.reverseConvertOrThrow(schema)->S.parseOrThrow(schema)
+  t->Assert.deepEqual(rows, roundtripped)
+})

--- a/packages/sury/tests/S_compactColumns_test.res
+++ b/packages/sury/tests/S_compactColumns_test.res
@@ -195,13 +195,10 @@ test("Error path reporting for invalid column value", t => {
       ),
     )
 
-  switch %raw(`[["a"], ["not-an-int"]]`)->S.parseOrThrow(schema) {
-  | _ => t->Assert.fail("Should have thrown")
-  | exception S.Exn(error) =>
-    // Should have a non-empty path pointing into the failing cell.
-    let path = (error->Obj.magic)["path"]
-    t->Assert.notDeepEqual(path, "", ~message="Error path should not be empty")
-  }
+  t->U.assertThrowsMessage(
+    () => %raw(`[["a"], ["not-an-int"]]`)->S.parseOrThrow(schema),
+    `Failed at ["0"]["bar"]: Expected int32, received "not-an-int"`,
+  )
 })
 
 asyncTest("Async field schema", async t => {

--- a/packages/sury/tests/S_compactColumns_test.res
+++ b/packages/sury/tests/S_compactColumns_test.res
@@ -16,7 +16,7 @@ test("Successfully parses and reverse converts a simple object with compactColum
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[0](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){v1[v0]={"foo":i[0][v0],"bar":i[1][v0],};}return v1}`,
+    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){let v2=i[0][v0];if(typeof v2!=="string"){e[0](v2)}let v3=i[1][v0];if(typeof v3!=="number"||v3>2147483647||v3<-2147483648||v3%1!==0){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}return v1}`,
   )
   t->U.assertCompiledCode(
     ~schema,
@@ -51,12 +51,12 @@ test("Transforms nullable fields", t => {
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[0](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){v1[v0]={"foo":i[0][v0],"bar":i[1][v0]===null?void 0:i[1][v0],};}return v1}`,
+    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){let v2=i[0][v0];if(typeof v2!=="string"){e[0](v2)}let v3=i[1][v0];if(v3===null){v3=void 0}else if(!(typeof v3==="number"&&!Number.isNaN(v3)&&(v3<2147483647&&v3>-2147483648&&v3%1===0))){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}return v1}`,
   )
   t->U.assertCompiledCode(
     ~schema,
     ~op=#ReverseConvert,
-    `i=>{let v4=new Array(i.length);for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];let v2=v1["bar"];if(v2===void 0){v2=null}else if(!(typeof v2==="number"&&!Number.isNaN(v2)&&(v2<2147483647&&v2>-2147483648&&v2%1===0))){e[0](v2)}v4[v0]={"foo":v1["foo"],"bar":v2,}}catch(v3){v3.path='["'+v0+'"]'+v3.path;throw v3}}let v6=[new Array(v4.length),new Array(v4.length),];for(let v5=0;v5<v4.length;++v5){v6[0][v5]=v4[v5]["foo"];v6[1][v5]=v4[v5]["bar"]===void 0?null:v4[v5]["bar"];}return v6}`,
+    `i=>{let v4=new Array(i.length);for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];let v2=v1["bar"];if(v2===void 0){v2=null}else if(!(typeof v2==="number"&&!Number.isNaN(v2)&&(v2<2147483647&&v2>-2147483648&&v2%1===0))){e[0](v2)}v4[v0]={"foo":v1["foo"],"bar":v2,}}catch(v3){v3.path='["'+v0+'"]'+v3.path;throw v3}}let v6=[new Array(v4.length),new Array(v4.length),];for(let v5=0;v5<v4.length;++v5){v6[0][v5]=v4[v5]["foo"];v6[1][v5]=v4[v5]["bar"];}return v6}`,
   )
 
   t->Assert.deepEqual(
@@ -86,7 +86,7 @@ test("Case with missing item at the end", t => {
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[0](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){v1[v0]={"foo":i[0][v0],"bar":i[1][v0],};}return v1}`,
+    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){let v2=i[0][v0];if(!(typeof v2==="string"||v2===void 0)){e[0](v2)}let v3=i[1][v0];if(typeof v3!=="boolean"){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}return v1}`,
   )
   t->U.assertCompiledCode(
     ~schema,

--- a/packages/sury/tests/S_compactColumns_test.res
+++ b/packages/sury/tests/S_compactColumns_test.res
@@ -16,7 +16,7 @@ test("Successfully parses and reverse converts a simple object with compactColum
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){let v2=i[0][v0];if(typeof v2!=="string"){e[0](v2)}let v3=i[1][v0];if(typeof v3!=="number"||v3>2147483647||v3<-2147483648||v3%1!==0){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}return v1}`,
+    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];if(typeof v2!=="string"){e[0](v2)}let v3=i[1][v0];if(typeof v3!=="number"||v3>2147483647||v3<-2147483648||v3%1!==0){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}catch(v4){v4.path='["'+v0+'"]'+v4.path;throw v4}}return v1}`,
   )
   t->U.assertCompiledCode(
     ~schema,
@@ -51,7 +51,7 @@ test("Transforms nullable fields", t => {
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){let v2=i[0][v0];if(typeof v2!=="string"){e[0](v2)}let v3=i[1][v0];if(v3===null){v3=void 0}else if(!(typeof v3==="number"&&!Number.isNaN(v3)&&(v3<2147483647&&v3>-2147483648&&v3%1===0))){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}return v1}`,
+    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];if(typeof v2!=="string"){e[0](v2)}let v3=i[1][v0];if(v3===null){v3=void 0}else if(!(typeof v3==="number"&&!Number.isNaN(v3)&&(v3<2147483647&&v3>-2147483648&&v3%1===0))){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}catch(v4){v4.path='["'+v0+'"]'+v4.path;throw v4}}return v1}`,
   )
   t->U.assertCompiledCode(
     ~schema,
@@ -86,7 +86,7 @@ test("Case with missing item at the end", t => {
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){let v2=i[0][v0];if(!(typeof v2==="string"||v2===void 0)){e[0](v2)}let v3=i[1][v0];if(typeof v3!=="boolean"){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}return v1}`,
+    `i=>{if(!Array.isArray(i)||i.length!==2||!Array.isArray(i[0])||!Array.isArray(i[1])){e[2](i)}let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];if(!(typeof v2==="string"||v2===void 0)){e[0](v2)}let v3=i[1][v0];if(typeof v3!=="boolean"){e[1](v3)}v1[v0]={"foo":v2,"bar":v3,};}catch(v4){v4.path='["'+v0+'"]'+v4.path;throw v4}}return v1}`,
   )
   t->U.assertCompiledCode(
     ~schema,
@@ -181,7 +181,7 @@ test("Invalid field value reports error with path", t => {
   // Second row, bar column contains a non-int value.
   t->U.assertThrowsMessage(
     () => %raw(`[["a", "b"], [0, "not-an-int"]]`)->S.parseOrThrow(schema),
-    `Expected int32, received "not-an-int"`,
+    `Failed at ["1"]["bar"]: Expected int32, received "not-an-int"`,
   )
 })
 
@@ -362,7 +362,7 @@ test("Field with S.refine", t => {
   // Negative age triggers the refinement error.
   t->U.assertThrowsMessage(
     () => %raw(`[[-5], ["bad"]]`)->S.parseOrThrow(schema),
-    `Age must be non-negative`,
+    `Failed at ["0"]["age"]: Age must be non-negative`,
   )
 })
 


### PR DESCRIPTION
## Summary
Enhanced the `compactColumns` decoder to properly validate individual field values during parsing, rather than just copying raw column values. This ensures field schemas (including transformations, refinements, and async validators) are applied correctly, and validation errors now include precise paths to the offending cell.

## Key Changes

- **Per-field validation**: Field values are now parsed through their respective schemas during the decode phase, enabling proper handling of:
  - Field transformations (e.g., `S.transform`)
  - Refinements (e.g., `S.refine`)
  - Async field schemas
  - Nullable/optional fields with proper null/undefined conversions

- **Improved error reporting**: Validation errors now include path information pointing to the specific cell (e.g., `["1"]["bar"]`), making it easier to identify which row and field failed validation

- **Async field support**: Added proper async handling for field schemas that use async parsers, wrapping row construction in `Promise.all` when needed

- **Simplified reverse conversion**: Removed special-case handling for null/undefined conversions in the encoder and reverse decoder, since field values are already properly transformed by the earlier parse pipeline

- **Better error handling**: Wrapped row body execution in try/catch blocks that prepend the row index to error paths, providing context for validation failures

## Implementation Details

- The decoder now derives the item schema from `input.schema.additionalItems.additionalItems` when input is typed (non-unknown), enabling proper field schema derivation
- Each field is parsed using the standard `parse` function with appropriate path context
- Async detection is performed per-field, and if any field is async, the entire row becomes a promise
- Error path construction uses inline location information to generate readable paths like `["0"]["bar"]`

https://claude.ai/code/session_01ARBVzzgGwNCNAs376obw96