### PR TITLE
Remove compactColumns encoder and refactor decoder

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5519,108 +5519,60 @@ let literal = js_schema
 
 let enum = values => Union.factory(values->Js.Array2.map(literal))
 
-let compactColumnsEncoder = Builder.encoder((~input, ~target) => {
-  // target is the compactColumns schema
-  // target.to = S.array(objectSchema), so properties are in target.to.additionalItems.properties
-  let maybeProperties = switch target.to {
-  | Some({additionalItems: ?Some(Schema(itemSchema))}) =>
-    let itemInternal = itemSchema->castToInternal
-    itemInternal.properties
-  | _ => None
-  }
-
-  switch maybeProperties {
-  | Some(properties) => {
-      let keys = properties->Js.Dict.keys
-      let inputVar = input->B.Val.var
-      let iteratorVar = input.global->B.varWithoutAllocation
-      let outputVar = input.global->B.varWithoutAllocation
-
-      let initialArraysCode = ref("")
-      let settingCode = ref("")
-      for idx in 0 to keys->Js.Array2.length - 1 {
-        let key = keys->Js.Array2.unsafe_get(idx)
-        let rawValueCode = `${inputVar}[${iteratorVar}][${key->X.Inlined.Value.fromString}]`
-        initialArraysCode := initialArraysCode.contents ++ `new Array(${inputVar}.length),`
-        settingCode :=
-          settingCode.contents ++
-          `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${rawValueCode};`
-      }
-
-      input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
-
-      let output = input->B.next(outputVar, ~schema=base(arrayTag, ~selfReverse=false))
-      output.var = B._var
-      output.codeFromPrev =
-        output.codeFromPrev ++
-        `for(let ${iteratorVar}=0;${iteratorVar}<${inputVar}.length;++${iteratorVar}){${settingCode.contents}}`
-      output
-    }
-  | None => input->B.unsupportedConversion(~from=input.schema, ~target)
-  }
-})
-
 let compactColumnsDecoder = (~input) => {
   let selfSchema = input.expected
-  let inputTagFlag = input.schema.tag->TagFlag.get
-  let isUnknownInput = inputTagFlag->Flag.unsafeHas(TagFlag.unknown)
+  let isUnknownInput = input.schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.unknown)
 
-  // Get properties and determine direction
-  // Forward: properties come from selfSchema.to.additionalItems (S.array(objectSchema))
-  // Reverse: properties come from input.schema.additionalItems (array of objects)
-  let (maybeProperties, isForwardDirection) = switch selfSchema.to {
-  | Some({additionalItems: ?Some(Schema(itemSchema))}) =>
-    let itemInternal = itemSchema->castToInternal
-    switch itemInternal.properties {
-    | Some(_) as p => (p, true)
-    | None => (None, true)
+  // Find the object schema whose properties define the columns.
+  // Forward (columnar → rows): props come from selfSchema.to.additionalItems.
+  // Reverse (rows → columnar): props come from input.schema.additionalItems (the
+  // object schema left over after the preceding parse pipeline step).
+  let getItemProps = (s: internal) =>
+    switch s.additionalItems {
+    | Some(Schema(item)) => (item->castToInternal).properties
+    | _ => None
     }
-  | _ => (None, true)
+  let forwardProps = switch selfSchema.to {
+  | Some(to) => getItemProps(to)
+  | None => None
   }
-  // If forward didn't find properties, try reverse direction
-  let (maybeProperties, isForwardDirection) = switch maybeProperties {
-  | Some(_) => (maybeProperties, isForwardDirection)
-  | None =>
-    switch input.schema.additionalItems {
-    | Some(Schema(itemSchema)) =>
-      let itemInternal = itemSchema->castToInternal
-      switch itemInternal.properties {
-      | Some(_) as p => (p, false)
-      | None => (None, true)
-      }
-    | _ => (None, true)
-    }
-  }
+  let isForwardDirection = forwardProps->Obj.magic
+  let maybeProperties = isForwardDirection ? forwardProps : getItemProps(input.schema)
 
   switch maybeProperties {
+  | None =>
+    InternalError.panic(
+      "S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).",
+    )
   | Some(properties) => {
       let keys = properties->Js.Dict.keys
+      let keysLen = keys->Js.Array2.length
 
-      if keys->Js.Array2.length === 0 {
-        if isUnknownInput {
-          input.validation = Some(
-            (~inputVar) => {
-              `Array.isArray(${inputVar})&&${inputVar}.length===0`
-            },
-          )
-        }
-        let outputSchema = base(arrayTag, ~selfReverse=false)
-        let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
+      // Common output schema/val setup shared by all branches below.
+      let outputSchema = base(arrayTag, ~selfReverse=false)
+      let makeOutput = initial => {
+        let output = input->B.next(initial, ~schema=outputSchema, ~expected=outputSchema)
         output.isOutput = Some(true)
         output
+      }
+
+      if keysLen === 0 {
+        if isUnknownInput {
+          input.validation = Some(
+            (~inputVar) => `Array.isArray(${inputVar})&&${inputVar}.length===0`,
+          )
+        }
+        makeOutput("[]")
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         if isUnknownInput {
           input.validation = Some(
             (~inputVar) => {
-              `Array.isArray(${inputVar})&&${inputVar}.length===${keys
-                ->Js.Array2.length
-                ->X.Int.unsafeToString}` ++
-              `${keys
-                ->Js.Array2.mapi((_, idx) => {
-                  `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
-                })
-                ->Js.Array2.joinWith("")}`
+              let check = ref(`Array.isArray(${inputVar})&&${inputVar}.length===${keysLen->X.Int.unsafeToString}`)
+              for idx in 0 to keysLen - 1 {
+                check := check.contents ++ `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
+              }
+              check.contents
             },
           )
         }
@@ -5641,18 +5593,17 @@ let compactColumnsDecoder = (~input) => {
         let lengthCode = ref("")
         let itemBuildCode = ref("")
         let itemParseCode = ref("")
-        let itemInlines = []
+        let asyncInlines = ref("")
         let hasAsync = ref(false)
-        for idx in 0 to keys->Js.Array2.length - 1 {
+        for idx in 0 to keysLen - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
-          let fieldSchema = properties->Js.Dict.unsafeGet(key)
-          let rawValueCode = `${inputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]`
+          let idxStr = idx->X.Int.unsafeToString
 
           // Use parse on the field schema to handle transformations (e.g. null->undefined).
           let itemInput = input->B.Val.scope
-          itemInput.inline = rawValueCode
+          itemInput.inline = `${inputVar}[${idxStr}][${iteratorVar}]`
           itemInput.schema = itemSchema
-          itemInput.expected = fieldSchema
+          itemInput.expected = properties->Js.Dict.unsafeGet(key)
           itemInput.var = B._notVarBeforeValidation
           itemInput.isInput = Some(false)
           itemInput.isOutput = Some(false)
@@ -5663,11 +5614,10 @@ let compactColumnsDecoder = (~input) => {
           if itemOutput.flag->Flag.unsafeHas(ValFlag.async) {
             hasAsync := true
           }
-          let itemCode = itemOutput->B.merge
 
-          itemParseCode := itemParseCode.contents ++ itemCode
-          lengthCode := lengthCode.contents ++ `${inputVar}[${idx->X.Int.unsafeToString}].length,`
-          itemInlines->Js.Array2.push(itemOutput.inline)->ignore
+          itemParseCode := itemParseCode.contents ++ itemOutput->B.merge
+          lengthCode := lengthCode.contents ++ `${inputVar}[${idxStr}].length,`
+          asyncInlines := asyncInlines.contents ++ `${itemOutput.inline},`
           itemBuildCode :=
             itemBuildCode.contents ++
             `${key->X.Inlined.Value.fromString}:${itemOutput.inline},`
@@ -5675,48 +5625,43 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=new Array(Math.max(${lengthCode.contents}))`)
 
-        let outputSchema = base(arrayTag, ~selfReverse=false)
-        let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
+        let output = makeOutput(outputVar)
         output.var = B._var
-        output.isOutput = Some(true)
 
         // Wrap the row body in a single try/catch that prepends the row index to
         // any thrown error — giving paths like ["0"]["bar"]. A single wrapper is
         // used (rather than per-field) so that `let` variables declared while
         // parsing one field remain in scope for the object construction.
-        let errorVar = input.global->B.varWithoutAllocation
-        let wrapRowBody = body =>
-          if itemParseCode.contents === "" {
-            body
-          } else {
-            `try{${body}}catch(${errorVar}){${errorVar}.path='["'+${iteratorVar}+'"]'+${errorVar}.path;throw ${errorVar}}`
-          }
-
-        if hasAsync.contents {
+        let rowAssign = if hasAsync.contents {
           // For async fields, each row becomes a promise that awaits all field values
           // via Promise.all, and the final output is Promise.all of all row promises.
           let rowResultVar = input.global->B.varWithoutAllocation
-          let asyncBuildCode =
-            keys
-            ->Js.Array2.mapi((key, idx) =>
-              `${key->X.Inlined.Value.fromString}:${rowResultVar}[${idx->X.Int.unsafeToString}]`
-            )
-            ->Js.Array2.joinWith(",")
-          let promisesCode = itemInlines->Js.Array2.joinWith(",")
-          let rowBody = `${itemParseCode.contents}${outputVar}[${iteratorVar}]=Promise.all([${promisesCode}]).then(${rowResultVar}=>({${asyncBuildCode},}));`
-          output.codeFromPrev =
-            output.codeFromPrev ++
-            `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrapRowBody(
-                rowBody,
-              )}}`
+          let asyncBuildCode = ref("")
+          for idx in 0 to keysLen - 1 {
+            let key = keys->Js.Array2.unsafe_get(idx)
+            asyncBuildCode :=
+              asyncBuildCode.contents ++
+              `${key->X.Inlined.Value.fromString}:${rowResultVar}[${idx->X.Int.unsafeToString}],`
+          }
+          `${outputVar}[${iteratorVar}]=Promise.all([${asyncInlines.contents}]).then(${rowResultVar}=>({${asyncBuildCode.contents}}));`
+        } else {
+          `${outputVar}[${iteratorVar}]={${itemBuildCode.contents}};`
+        }
+
+        let rowBody = itemParseCode.contents ++ rowAssign
+        let wrappedBody = if itemParseCode.contents === "" {
+          rowBody
+        } else {
+          let errorVar = input.global->B.varWithoutAllocation
+          `try{${rowBody}}catch(${errorVar}){${errorVar}.path='["'+${iteratorVar}+'"]'+${errorVar}.path;throw ${errorVar}}`
+        }
+        output.codeFromPrev =
+          output.codeFromPrev ++
+          `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrappedBody}}`
+
+        if hasAsync.contents {
           output->B.asyncVal(`Promise.all(${outputVar})`)
         } else {
-          let rowBody = `${itemParseCode.contents}${outputVar}[${iteratorVar}]={${itemBuildCode.contents}};`
-          output.codeFromPrev =
-            output.codeFromPrev ++
-            `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrapRowBody(
-                rowBody,
-              )}}`
           output
         }
       } else {
@@ -5729,31 +5674,24 @@ let compactColumnsDecoder = (~input) => {
 
         let initialArraysCode = ref("")
         let settingCode = ref("")
-        for idx in 0 to keys->Js.Array2.length - 1 {
+        for idx in 0 to keysLen - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
-          let rawValueCode = `${inputVar}[${iteratorVar}][${key->X.Inlined.Value.fromString}]`
           initialArraysCode := initialArraysCode.contents ++ `new Array(${inputVar}.length),`
           settingCode :=
             settingCode.contents ++
-            `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${rawValueCode};`
+            `${outputVar}[${idx->X.Int.unsafeToString}][${iteratorVar}]=${inputVar}[${iteratorVar}][${key->X.Inlined.Value.fromString}];`
         }
 
         input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
 
-        let outputSchema = base(arrayTag, ~selfReverse=false)
-        let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
+        let output = makeOutput(outputVar)
         output.var = B._var
-        output.isOutput = Some(true)
         output.codeFromPrev =
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${inputVar}.length;++${iteratorVar}){${settingCode.contents}}`
         output
       }
     }
-  | None =>
-    InternalError.panic(
-      "S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).",
-    )
   }
 }
 
@@ -5762,7 +5700,6 @@ let compactColumns = inputSchema => {
   let mut = array(innerArray)->castToInternal
   mut.format = Some(CompactColumns)
   mut.decoder = compactColumnsDecoder
-  mut.encoder = Some(compactColumnsEncoder)
   mut->castToPublic
 }
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5527,17 +5527,19 @@ let compactColumnsDecoder = (~input) => {
   // Forward (columnar → rows): props come from selfSchema.to.additionalItems.
   // Reverse (rows → columnar): props come from input.schema.additionalItems (the
   // object schema left over after the preceding parse pipeline step).
-  let getItemProps = (s: internal) =>
-    switch s.additionalItems {
+  let forwardProps = switch selfSchema.to {
+  | Some({additionalItems: ?Some(Schema(item))}) => (item->castToInternal).properties
+  | _ => None
+  }
+  let isForwardDirection = forwardProps->Obj.magic
+  let maybeProperties = if isForwardDirection {
+    forwardProps
+  } else {
+    switch input.schema.additionalItems {
     | Some(Schema(item)) => (item->castToInternal).properties
     | _ => None
     }
-  let forwardProps = switch selfSchema.to {
-  | Some(to) => getItemProps(to)
-  | None => None
   }
-  let isForwardDirection = forwardProps->Obj.magic
-  let maybeProperties = isForwardDirection ? forwardProps : getItemProps(input.schema)
 
   switch maybeProperties {
   | None =>
@@ -5548,7 +5550,7 @@ let compactColumnsDecoder = (~input) => {
       let keys = properties->Js.Dict.keys
       let keysLen = keys->Js.Array2.length
 
-      // Common output schema/val setup shared by all branches below.
+      // Common output schema setup shared by all branches below.
       // In reverse direction we propagate the original chain's .to so that
       // subsequent steps (e.g. json validation) continue to run.
       let outputSchema = if isForwardDirection {
@@ -5558,11 +5560,6 @@ let compactColumnsDecoder = (~input) => {
         s.to = selfSchema.to
         s
       }
-      let makeOutput = initial => {
-        let output = input->B.next(initial, ~schema=outputSchema, ~expected=outputSchema)
-        output.isOutput = Some(true)
-        output
-      }
 
       if keysLen === 0 {
         if isUnknownInput {
@@ -5570,7 +5567,9 @@ let compactColumnsDecoder = (~input) => {
             (~inputVar) => `Array.isArray(${inputVar})&&${inputVar}.length===0`,
           )
         }
-        makeOutput("[]")
+        let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
+        output.isOutput = Some(true)
+        output
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         if isUnknownInput {
@@ -5633,8 +5632,9 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=new Array(Math.max(${lengthCode.contents}))`)
 
-        let output = makeOutput(outputVar)
+        let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
+        output.isOutput = Some(true)
 
         // Wrap the row body in a single try/catch that prepends the row index to
         // any thrown error — giving paths like ["0"]["bar"]. A single wrapper is
@@ -5692,8 +5692,9 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
 
-        let output = makeOutput(outputVar)
+        let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
+        output.isOutput = Some(true)
         output.codeFromPrev =
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${inputVar}.length;++${iteratorVar}){${settingCode.contents}}`

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5549,7 +5549,15 @@ let compactColumnsDecoder = (~input) => {
       let keysLen = keys->Js.Array2.length
 
       // Common output schema/val setup shared by all branches below.
-      let outputSchema = base(arrayTag, ~selfReverse=false)
+      // In reverse direction we propagate the original chain's .to so that
+      // subsequent steps (e.g. json validation) continue to run.
+      let outputSchema = if isForwardDirection {
+        base(arrayTag, ~selfReverse=false)
+      } else {
+        let s = array(array(unknown->castToPublic))->castToInternal
+        s.to = selfSchema.to
+        s
+      }
       let makeOutput = initial => {
         let output = input->B.next(initial, ~schema=outputSchema, ~expected=outputSchema)
         output.isOutput = Some(true)

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3758,16 +3758,21 @@ function $$enum(values) {
 function compactColumnsDecoder(input) {
   let selfSchema = input.e;
   let isUnknownInput = flags[input.s.type] & 1;
-  let getItemProps = s => {
-    let match = s.additionalItems;
-    if (match !== undefined && match !== "strip" && match !== "strict") {
-      return match.properties;
-    }
-    
-  };
-  let to = selfSchema.to;
-  let forwardProps = to !== undefined ? getItemProps(to) : undefined;
-  let maybeProperties = forwardProps ? forwardProps : getItemProps(input.s);
+  let match = selfSchema.to;
+  let forwardProps;
+  if (match !== undefined) {
+    let match$1 = match.additionalItems;
+    forwardProps = match$1 !== undefined && match$1 !== "strip" && match$1 !== "strict" ? match$1.properties : undefined;
+  } else {
+    forwardProps = undefined;
+  }
+  let maybeProperties;
+  if (forwardProps) {
+    maybeProperties = forwardProps;
+  } else {
+    let match$2 = input.s.additionalItems;
+    maybeProperties = match$2 !== undefined && match$2 !== "strip" && match$2 !== "strict" ? match$2.properties : undefined;
+  }
   if (maybeProperties !== undefined) {
     let keys = Object.keys(maybeProperties);
     let keysLen = keys.length;
@@ -3779,16 +3784,13 @@ function compactColumnsDecoder(input) {
       s.to = selfSchema.to;
       outputSchema = s;
     }
-    let makeOutput = initial => {
-      let output = next(input, initial, outputSchema, outputSchema);
-      output.io = true;
-      return output;
-    };
     if (keysLen === 0) {
       if (isUnknownInput) {
         input.validation = inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0";
       }
-      return makeOutput("[]");
+      let output = next(input, "[]", outputSchema, outputSchema);
+      output.io = true;
+      return output;
     }
     if (forwardProps) {
       if (isUnknownInput) {
@@ -3830,8 +3832,9 @@ function compactColumnsDecoder(input) {
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
-      let output = makeOutput(outputVar);
-      output.v = _var;
+      let output$1 = next(input, outputVar, outputSchema, outputSchema);
+      output$1.v = _var;
+      output$1.io = true;
       let rowAssign;
       if (hasAsync) {
         let rowResultVar = varWithoutAllocation(input.g);
@@ -3852,11 +3855,11 @@ function compactColumnsDecoder(input) {
         let errorVar = varWithoutAllocation(input.g);
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
-      output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
+      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
       if (hasAsync) {
-        return asyncVal(output, "Promise.all(" + outputVar + ")");
+        return asyncVal(output$1, "Promise.all(" + outputVar + ")");
       } else {
-        return output;
+        return output$1;
       }
     }
     let inputVar$1 = input.v();
@@ -3870,10 +3873,11 @@ function compactColumnsDecoder(input) {
       settingCode = settingCode + (outputVar$1 + "[" + idx$2 + "][" + iteratorVar$1 + "]=" + inputVar$1 + "[" + iteratorVar$1 + "][" + fromString(key$2) + "];");
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
-    let output$1 = makeOutput(outputVar$1);
-    output$1.v = _var;
-    output$1.cp = output$1.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + settingCode + "}");
-    return output$1;
+    let output$2 = next(input, outputVar$1, outputSchema, outputSchema);
+    output$2.v = _var;
+    output$2.io = true;
+    output$2.cp = output$2.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + settingCode + "}");
+    return output$2;
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3771,7 +3771,14 @@ function compactColumnsDecoder(input) {
   if (maybeProperties !== undefined) {
     let keys = Object.keys(maybeProperties);
     let keysLen = keys.length;
-    let outputSchema = base(arrayTag, false);
+    let outputSchema;
+    if (forwardProps) {
+      outputSchema = base(arrayTag, false);
+    } else {
+      let s = array(array(unknown));
+      s.to = selfSchema.to;
+      outputSchema = s;
+    }
     let makeOutput = initial => {
       let output = next(input, initial, outputSchema, outputSchema);
       output.io = true;

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3755,106 +3755,43 @@ function $$enum(values) {
   return factory$1(values.map(js_schema));
 }
 
-function compactColumnsEncoder(input, target) {
-  let match = target.to;
-  let maybeProperties;
-  if (match !== undefined) {
-    let match$1 = match.additionalItems;
-    maybeProperties = match$1 !== undefined && match$1 !== "strip" && match$1 !== "strict" ? match$1.properties : undefined;
-  } else {
-    maybeProperties = undefined;
-  }
-  if (maybeProperties === undefined) {
-    return unsupportedConversion(input, input.s, target);
-  }
-  let keys = Object.keys(maybeProperties);
-  let inputVar = input.v();
-  let iteratorVar = varWithoutAllocation(input.g);
-  let outputVar = varWithoutAllocation(input.g);
-  let initialArraysCode = "";
-  let settingCode = "";
-  for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
-    let key = keys[idx];
-    let rawValueCode = inputVar + "[" + iteratorVar + "][" + fromString(key) + "]";
-    initialArraysCode = initialArraysCode + ("new Array(" + inputVar + ".length),");
-    settingCode = settingCode + (outputVar + "[" + idx + "][" + iteratorVar + "]=" + rawValueCode + ";");
-  }
-  input.a(outputVar + "=[" + initialArraysCode + "]");
-  let output = next(input, outputVar, base(arrayTag, false), undefined);
-  output.v = _var;
-  output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + inputVar + ".length;++" + iteratorVar + "){" + settingCode + "}");
-  return output;
-}
-
 function compactColumnsDecoder(input) {
   let selfSchema = input.e;
-  let inputTagFlag = flags[input.s.type];
-  let isUnknownInput = inputTagFlag & 1;
-  let match = selfSchema.to;
-  let match$1;
-  if (match !== undefined) {
-    let match$2 = match.additionalItems;
-    if (match$2 !== undefined && match$2 !== "strip" && match$2 !== "strict") {
-      let p = match$2.properties;
-      match$1 = p !== undefined ? [
-          p,
-          true
-        ] : [
-          undefined,
-          true
-        ];
-    } else {
-      match$1 = [
-        undefined,
-        true
-      ];
+  let isUnknownInput = flags[input.s.type] & 1;
+  let getItemProps = s => {
+    let match = s.additionalItems;
+    if (match !== undefined && match !== "strip" && match !== "strict") {
+      return match.properties;
     }
-  } else {
-    match$1 = [
-      undefined,
-      true
-    ];
-  }
-  let maybeProperties = match$1[0];
-  let match$3;
+    
+  };
+  let to = selfSchema.to;
+  let forwardProps = to !== undefined ? getItemProps(to) : undefined;
+  let maybeProperties = forwardProps ? forwardProps : getItemProps(input.s);
   if (maybeProperties !== undefined) {
-    match$3 = [
-      maybeProperties,
-      match$1[1]
-    ];
-  } else {
-    let match$4 = input.s.additionalItems;
-    if (match$4 !== undefined && match$4 !== "strip" && match$4 !== "strict") {
-      let p$1 = match$4.properties;
-      match$3 = p$1 !== undefined ? [
-          p$1,
-          false
-        ] : [
-          undefined,
-          true
-        ];
-    } else {
-      match$3 = [
-        undefined,
-        true
-      ];
-    }
-  }
-  let maybeProperties$1 = match$3[0];
-  if (maybeProperties$1 !== undefined) {
-    let keys = Object.keys(maybeProperties$1);
-    if (keys.length === 0) {
+    let keys = Object.keys(maybeProperties);
+    let keysLen = keys.length;
+    let outputSchema = base(arrayTag, false);
+    let makeOutput = initial => {
+      let output = next(input, initial, outputSchema, outputSchema);
+      output.io = true;
+      return output;
+    };
+    if (keysLen === 0) {
       if (isUnknownInput) {
         input.validation = inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0";
       }
-      let outputSchema = base(arrayTag, false);
-      let output = next(input, "[]", outputSchema, outputSchema);
-      output.io = true;
-      return output;
+      return makeOutput("[]");
     }
-    if (match$3[1]) {
+    if (forwardProps) {
       if (isUnknownInput) {
-        input.validation = inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===" + keys.length + keys.map((param, idx) => "&&Array.isArray(" + inputVar + "[" + idx + "])").join("");
+        input.validation = inputVar => {
+          let check = "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===" + keysLen;
+          for (let idx = 0; idx < keysLen; ++idx) {
+            check = check + ("&&Array.isArray(" + inputVar + "[" + idx + "])");
+          }
+          return check;
+        };
       }
       let inputVar = input.v();
       let iteratorVar = varWithoutAllocation(input.g);
@@ -3862,19 +3799,15 @@ function compactColumnsDecoder(input) {
       let itemSchema = isUnknownInput ? unknown : input.s.additionalItems.additionalItems;
       let lengthCode = "";
       let itemBuildCode = "";
-      let itemParseCode = {
-        contents: ""
-      };
-      let itemInlines = [];
+      let itemParseCode = "";
+      let asyncInlines = "";
       let hasAsync = false;
-      for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
+      for (let idx = 0; idx < keysLen; ++idx) {
         let key = keys[idx];
-        let fieldSchema = maybeProperties$1[key];
-        let rawValueCode = inputVar + "[" + idx + "][" + iteratorVar + "]";
         let itemInput = scope(input);
-        itemInput.i = rawValueCode;
+        itemInput.i = inputVar + "[" + idx + "][" + iteratorVar + "]";
         itemInput.s = itemSchema;
-        itemInput.e = fieldSchema;
+        itemInput.e = maybeProperties[key];
         itemInput.v = _notVarBeforeValidation;
         itemInput.ii = false;
         itemInput.io = false;
@@ -3884,55 +3817,56 @@ function compactColumnsDecoder(input) {
         if (itemOutput.f & 1) {
           hasAsync = true;
         }
-        let itemCode = merge(itemOutput);
-        itemParseCode.contents = itemParseCode.contents + itemCode;
+        itemParseCode = itemParseCode + merge(itemOutput);
         lengthCode = lengthCode + (inputVar + "[" + idx + "].length,");
-        itemInlines.push(itemOutput.i);
+        asyncInlines = asyncInlines + (itemOutput.i + ",");
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
-      let outputSchema$1 = base(arrayTag, false);
-      let output$1 = next(input, outputVar, outputSchema$1, outputSchema$1);
-      output$1.v = _var;
-      output$1.io = true;
-      let errorVar = varWithoutAllocation(input.g);
-      let wrapRowBody = body => {
-        if (itemParseCode.contents === "") {
-          return body;
-        } else {
-          return "try{" + body + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
-        }
-      };
+      let output = makeOutput(outputVar);
+      output.v = _var;
+      let rowAssign;
       if (hasAsync) {
         let rowResultVar = varWithoutAllocation(input.g);
-        let asyncBuildCode = keys.map((key, idx) => fromString(key) + ":" + rowResultVar + "[" + idx + "]").join(",");
-        let promisesCode = itemInlines.join(",");
-        let rowBody = itemParseCode.contents + outputVar + "[" + iteratorVar + "]=Promise.all([" + promisesCode + "]).then(" + rowResultVar + "=>({" + asyncBuildCode + ",}));";
-        output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrapRowBody(rowBody) + "}");
-        return asyncVal(output$1, "Promise.all(" + outputVar + ")");
+        let asyncBuildCode = "";
+        for (let idx$1 = 0; idx$1 < keysLen; ++idx$1) {
+          let key$1 = keys[idx$1];
+          asyncBuildCode = asyncBuildCode + (fromString(key$1) + ":" + rowResultVar + "[" + idx$1 + "],");
+        }
+        rowAssign = outputVar + "[" + iteratorVar + "]=Promise.all([" + asyncInlines + "]).then(" + rowResultVar + "=>({" + asyncBuildCode + "}));";
+      } else {
+        rowAssign = outputVar + "[" + iteratorVar + "]={" + itemBuildCode + "};";
       }
-      let rowBody$1 = itemParseCode.contents + outputVar + "[" + iteratorVar + "]={" + itemBuildCode + "};";
-      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrapRowBody(rowBody$1) + "}");
-      return output$1;
+      let rowBody = itemParseCode + rowAssign;
+      let wrappedBody;
+      if (itemParseCode === "") {
+        wrappedBody = rowBody;
+      } else {
+        let errorVar = varWithoutAllocation(input.g);
+        wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
+      }
+      output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
+      if (hasAsync) {
+        return asyncVal(output, "Promise.all(" + outputVar + ")");
+      } else {
+        return output;
+      }
     }
     let inputVar$1 = input.v();
     let iteratorVar$1 = varWithoutAllocation(input.g);
     let outputVar$1 = varWithoutAllocation(input.g);
     let initialArraysCode = "";
     let settingCode = "";
-    for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-      let key$1 = keys[idx$1];
-      let rawValueCode$1 = inputVar$1 + "[" + iteratorVar$1 + "][" + fromString(key$1) + "]";
+    for (let idx$2 = 0; idx$2 < keysLen; ++idx$2) {
+      let key$2 = keys[idx$2];
       initialArraysCode = initialArraysCode + ("new Array(" + inputVar$1 + ".length),");
-      settingCode = settingCode + (outputVar$1 + "[" + idx$1 + "][" + iteratorVar$1 + "]=" + rawValueCode$1 + ";");
+      settingCode = settingCode + (outputVar$1 + "[" + idx$2 + "][" + iteratorVar$1 + "]=" + inputVar$1 + "[" + iteratorVar$1 + "][" + fromString(key$2) + "];");
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
-    let outputSchema$2 = base(arrayTag, false);
-    let output$2 = next(input, outputVar$1, outputSchema$2, outputSchema$2);
-    output$2.v = _var;
-    output$2.io = true;
-    output$2.cp = output$2.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + settingCode + "}");
-    return output$2;
+    let output$1 = makeOutput(outputVar$1);
+    output$1.v = _var;
+    output$1.cp = output$1.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + settingCode + "}");
+    return output$1;
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }
@@ -3942,7 +3876,6 @@ function compactColumns(inputSchema) {
   let mut = array(innerArray);
   mut.format = "compactColumns";
   mut.decoder = compactColumnsDecoder;
-  mut.encoder = compactColumnsEncoder;
   return mut;
 }
 

--- a/packages/sury/tests/S_compactColumns_test.res
+++ b/packages/sury/tests/S_compactColumns_test.res
@@ -398,3 +398,32 @@ test("Roundtrip: parse -> reverseConvert -> parse", t => {
   let roundtripped = rows->S.reverseConvertOrThrow(schema)->S.parseOrThrow(schema)
   t->Assert.deepEqual(rows, roundtripped)
 })
+
+test("reverseConvertToJsonOrThrow validates non-JSON-able unknown field values", t => {
+  S.enableJson()
+  let schema =
+    S.compactColumns(S.unknown)->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.unknown),
+          }
+        ),
+      ),
+    )
+
+  // JSON-compatible values round-trip through the columnar form unchanged.
+  t->Assert.deepEqual(
+    %raw(`[{"foo": "hello"}, {"foo": 42}]`)->S.reverseConvertToJsonOrThrow(schema),
+    %raw(`[["hello", 42]]`),
+  )
+
+  // Non-JSON-able values (e.g. bigint) are rejected by the json step that
+  // runs after the rows → columnar conversion. The path ["0"]["0"] points
+  // at column 0, row 0 of the columnar output (i.e. the "foo" value of the
+  // first row).
+  t->U.assertThrowsMessage(
+    () => %raw(`[{"foo": 123n}]`)->S.reverseConvertToJsonOrThrow(schema),
+    `Failed at ["0"]["0"]: Expected JSON, received 123n`,
+  )
+})


### PR DESCRIPTION
## Summary
This PR removes the encoder implementation for `S.compactColumns` and refactors the decoder to improve code clarity and maintainability. The encoder is no longer needed as the reverse conversion pipeline now properly handles the columnar-to-rows transformation through the decoder's reverse direction logic.

## Key Changes

- **Removed `compactColumnsEncoder`**: The dedicated encoder function has been deleted entirely. The reverse conversion (rows → columnar) is now handled exclusively through the decoder's reverse direction branch.

- **Refactored decoder direction detection**: Simplified the logic for determining forward vs. reverse direction:
  - Forward direction (columnar → rows): properties come from `selfSchema.to.additionalItems`
  - Reverse direction (rows → columnar): properties come from `input.schema.additionalItems`
  - Uses `Obj.magic` to convert the properties check into a boolean flag

- **Unified output schema handling**: The output schema is now computed once at the beginning of the properties branch and reused across all code paths, with special handling in reverse direction to preserve the `.to` chain for subsequent validation steps (e.g., JSON validation).

- **Improved code organization**: 
  - Consolidated variable declarations and reduced intermediate allocations
  - Simplified the async row building logic by constructing the assignment code inline
  - Refactored error wrapping to be clearer about when try-catch is needed
  - Replaced array-based inlines tracking with string concatenation for async promises

- **Added test coverage**: New test validates that non-JSON-able values in reverse conversion are properly rejected by the JSON validation step that runs after the rows → columnar transformation, with correct error paths.

## Implementation Details

The decoder now handles both directions within a single code path:
- In forward direction, it validates columnar input and transforms to rows
- In reverse direction, it validates row input and transforms to columnar format, preserving the schema chain so downstream validators (like JSON) continue to work correctly

This eliminates code duplication and makes the bidirectional transformation logic more maintainable.

https://claude.ai/code/session_016JypkwRYziQDfVrok3pTBr