### PR TITLE
Refactor validation from functions to structured check arrays

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -134,6 +134,36 @@ S.parseOrThrow(data, userSchema)
 - Make `S.record` accept two args
 - Update docs
 
+### Known bugs left over from the validation refactor (`val.validation: array<validationCheck>`)
+
+- **Refiners run before type guards when coerced via `.to`.** `parse` appends
+  refiner code to `val.codeFromPrev`, and `merge` emits `codeFromPrev ++
+  validation_code`, so `S.string->S.refine(...)->S.to(S.literal(false))` runs
+  the refiner on raw unknown input. A numeric input fails with the refinement
+  message instead of "Expected string, received 123". Fix: migrate refinements
+  off `codeFromPrev` onto `val.validation` as a distinct check kind. Failing
+  regression test already in place: `S_to_test.res › S.string->S.refine->S.to(S.literal)
+  reports type error before refinement error`.
+- **`noValidation` on a literal inside a union silently breaks dispatch.**
+  `literalDecoder` short-circuits when `expectedSchema.noValidation` is set
+  and emits no check at all, so there's nothing for the union discriminant
+  hoister to lift — that case becomes a catch-all. Fix: either emit the
+  equality check regardless of `noValidation` when the val ends up inside a
+  union, or reject `S.noValidation` on a literal-in-union at schema
+  construction time. Failing regression test: `S_noValidation_test.res ›
+  Union dispatch still works when a case has noValidation`.
+- **`err.received` is wrong for refine-chain vals on type failures.** Because
+  `B.refine` sets `~schema=prev.expected`, `val.schema` on a refined val
+  equals the target schema, and `failInvalidType` reads `val.schema` for
+  `received`. So `err.received === err.expected` on a primitive type failure.
+  User-visible reason text is unaffected (it uses `input->stringify`) but
+  programmatic consumers reading `err.received` get the target schema instead
+  of the source type. Fix: either have the fail function reach through
+  `val.prev.schema` (with a comment on the invariant that validation-owning
+  vals always have a prev) or stop mutating `val.schema` to the target in
+  `refine` and walk the chain differently for "Expected X" messages.
+  FIXME is tagged at `Sury.res:failInvalidType`.
+
 ## v11 initial
 
 - Add `s.parseChild` to EffectContext ???

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1285,6 +1285,10 @@ module Builder = {
     // Pass this as `fail` on every check that wants "expected X, received Y"
     // error semantics. Stable reference → adjacent checks fuse.
     let failInvalidType = (~input: val) => {
+      // Snapshot the three fields up front so the returned closure doesn't
+      // retain `input` — otherwise the compiled decoder's embed array would
+      // pin the entire val chain (prev, global, schemas) for its lifetime.
+      //
       // FIXME: `input.schema` is the target schema for refine-chain vals
       // (refine sets `~schema=prev.expected`), so `err.received` ends up
       // equal to `err.expected` on a primitive type failure. Reason text is
@@ -1324,6 +1328,11 @@ module Builder = {
 
     // Caller must verify `val.validation->unsafeToBool` first — the unwrap
     // below is unchecked. `inputVar` is usually `val.prev.var()`.
+    //
+    // `noValidation` suppresses the entire list here. Union codegen's
+    // discriminant path (see Union module) deliberately bypasses this — its
+    // conds route between cases instead of rejecting, so suppressing them
+    // would break dispatch. Don't try to "unify" the two paths.
     let emitValidation = (val: val, ~inputVar: string): string => {
       if val.expected.noValidation === Some(true) {
         ""
@@ -1393,7 +1402,7 @@ module Builder = {
 
     // AND-joins every check's cond — caller guarantees `checks` is non-empty.
     // Used by union codegen to hoist a val's validation into a dispatch discriminant.
-    let mergeChecksCond = (checks: array<validationCheck>, ~inputVar: string): string => {
+    let andJoinChecks = (checks: array<validationCheck>, ~inputVar: string): string => {
       let result = ref((checks->Js.Array2.unsafe_get(0)).cond(~inputVar))
       for i in 1 to checks->Js.Array2.length - 1 {
         result :=
@@ -1459,6 +1468,25 @@ module Builder = {
       switch val.validation {
       | Some(arr) => arr->Js.Array2.push(check)->ignore
       | None => val.validation = Some([check])
+      }
+    }
+
+    // Used in union codegen: splice a literal child's checks into the parent
+    // as dispatch discriminants. Each cond's `inputVar` is rewritten to
+    // `parent[key]`; `fail` stays shared so lifted checks fuse with the
+    // parent's own type guard. No-op if the child has no checks.
+    let hoistChildChecks = (parent: val, ~child: val, ~key: string) => {
+      if child.validation->X.Option.unsafeToBool {
+        let pathAppend = parent.global->inlineLocation(key)->Path.fromInlinedLocation
+        child.validation
+        ->X.Option.getUnsafe
+        ->Js.Array2.forEach(check => {
+          parent->pushCheck({
+            cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
+            fail: check.fail,
+          })
+        })
+        child.validation = None
       }
     }
 
@@ -2715,22 +2743,8 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
       let itemOutput = itemInput->parse
 
-      // Hoist a child literal's check onto the parent so union dispatch can
-      // use it as a discriminant. The rewritten cond patches `inputVar` to
-      // `parent[key]`; `fail` stays as the shared `B.failInvalidType` so the
-      // lifted check fuses with the parent's own type guard.
-      if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
-        let pathAppend =
-          input.global->B.inlineLocation(key)->Path.fromInlinedLocation
-        itemOutput.validation
-        ->X.Option.getUnsafe
-        ->Js.Array2.forEach(check => {
-          input->B.pushCheck({
-            cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
-            fail: check.fail,
-          })
-        })
-        itemOutput.validation = None
+      if isUnion && schema->isLiteral {
+        input->B.hoistChildChecks(~child=itemOutput, ~key)
       }
 
       objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -2876,19 +2890,8 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
         let itemOutput = itemInput->parse
 
-        // Same literal-check hoist as arrayDecoder above — see comment there.
-        if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
-          let pathAppend =
-            input.global->B.inlineLocation(key)->Path.fromInlinedLocation
-          itemOutput.validation
-          ->X.Option.getUnsafe
-          ->Js.Array2.forEach(check => {
-            input->B.pushCheck({
-              cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
-              fail: check.fail,
-            })
-          })
-          itemOutput.validation = None
+        if isUnion && schema->isLiteral {
+          input->B.hoistChildChecks(~child=itemOutput, ~key)
         }
 
         objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -3631,7 +3634,7 @@ module Union = {
                   let input = current.contents->X.Option.getUnsafe
                   let inputVar = input.var()
                   let condCode =
-                    val.validation->X.Option.getUnsafe->B.mergeChecksCond(~inputVar)
+                    val.validation->X.Option.getUnsafe->B.andJoinChecks(~inputVar)
                   if itemCond.contents->X.String.unsafeToBool {
                     itemCond := `${condCode}&&${itemCond.contents}`
                   } else {
@@ -3897,6 +3900,8 @@ module Union = {
               typeValidationInput->parse
             } catch {
             | _ => {
+                // Discard any checks parse managed to push before throwing,
+                // so the deopt path doesn't see leftover partial state.
                 typeValidationInput.validation = None
                 typeValidationInput
               }
@@ -4000,7 +4005,7 @@ module Union = {
                 let input = current.contents->X.Option.getUnsafe
                 let inputVar = input.var()
                 let condCode =
-                  val.validation->X.Option.getUnsafe->B.mergeChecksCond(~inputVar)
+                  val.validation->X.Option.getUnsafe->B.andJoinChecks(~inputVar)
                 if blockCond.contents->X.String.unsafeToBool {
                   blockCond := `${condCode}&&${blockCond.contents}`
                 } else {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -589,7 +589,7 @@ and val = {
   // Invariant: absent iff no checks. Never stored as `Some([])` so callers
   // can test presence with `->unsafeToBool` instead of length.
   @as("vc")
-  mutable validation?: array<validationCheck>,
+  mutable checks?: array<check>,
   @as("u")
   mutable isUnion?: bool,
   // Whether the chain starting from the root prev has a transformation
@@ -614,9 +614,9 @@ and bGlobal = {
   mutable defs?: dict<internal>,
 }
 // Adjacent checks sharing `fail` by reference equality are fused with `&&`
-// in `emitValidation`, so pass the same helper (e.g. `B.failInvalidType`) to
+// in `emitChecks`, so pass the same helper (e.g. `B.failInvalidType`) to
 // every check on a val if you want them to emit as one `||`-throw line.
-and validationCheck = {
+and check = {
   @as("c")
   cond: (~inputVar: string) => string,
   @as("f")
@@ -1309,7 +1309,7 @@ module Builder = {
 
     // Inline variant: emits the throw expression directly. Used by decoders
     // that splice errors into custom JS (e.g. `catch(_){${embedInvalidInput}}`),
-    // not via the `validationCheck` pipeline.
+    // not via the `check` pipeline.
     let embedInvalidInput = (~input: val, ~expected=input.expected) => {
       let received = input.schema->castToPublic
       let path = input.path
@@ -1326,45 +1326,37 @@ module Builder = {
       )
     }
 
-    // Caller must verify `val.validation->unsafeToBool` first — the unwrap
-    // below is unchecked. `inputVar` is usually `val.prev.var()`.
-    //
-    // `noValidation` suppresses the entire list here. Union codegen's
-    // discriminant path (see Union module) deliberately bypasses this — its
-    // conds route between cases instead of rejecting, so suppressing them
-    // would break dispatch. Don't try to "unify" the two paths.
-    let emitValidation = (val: val, ~inputVar: string): string => {
-      if val.expected.noValidation === Some(true) {
-        ""
+    // Caller must verify `val.checks->unsafeToBool` and
+    // `val.expected.noValidation !== Some(true)` first — the unwrap below
+    // is unchecked. `inputVar` is usually `val.prev.var()`.
+    let emitChecks = (val: val, ~inputVar: string): string => {
+      let checks = val.checks->X.Option.getUnsafe
+      let len = checks->Js.Array2.length
+      if len === 1 {
+        let check = checks->Js.Array2.unsafe_get(0)
+        `${check.cond(~inputVar)}||${val->failWithArg(check.fail(~input=val), inputVar)};`
       } else {
-        let checks = val.validation->X.Option.getUnsafe
-        let len = checks->Js.Array2.length
-        if len === 1 {
-          let check = checks->Js.Array2.unsafe_get(0)
-          `${check.cond(~inputVar)}||${val->failWithArg(check.fail(~input=val), inputVar)};`
-        } else {
-          let out = ref("")
-          let i = ref(0)
-          while i.contents < len {
-            let head = checks->Js.Array2.unsafe_get(i.contents)
-            let fail = head.fail
-            let cond = ref(head.cond(~inputVar))
+        let out = ref("")
+        let i = ref(0)
+        while i.contents < len {
+          let head = checks->Js.Array2.unsafe_get(i.contents)
+          let fail = head.fail
+          let cond = ref(head.cond(~inputVar))
+          i := i.contents + 1
+          // Extend the fused cond while the next check shares this `fail`.
+          while (
+            i.contents < len && (checks->Js.Array2.unsafe_get(i.contents)).fail === fail
+          ) {
+            cond :=
+              cond.contents ++
+              "&&" ++ (checks->Js.Array2.unsafe_get(i.contents)).cond(~inputVar)
             i := i.contents + 1
-            // Extend the fused cond while the next check shares this `fail`.
-            while (
-              i.contents < len && (checks->Js.Array2.unsafe_get(i.contents)).fail === fail
-            ) {
-              cond :=
-                cond.contents ++
-                "&&" ++ (checks->Js.Array2.unsafe_get(i.contents)).cond(~inputVar)
-              i := i.contents + 1
-            }
-            out :=
-              out.contents ++
-              `${cond.contents}||${val->failWithArg(fail(~input=val), inputVar)};`
           }
-          out.contents
+          out :=
+            out.contents ++
+            `${cond.contents}||${val->failWithArg(fail(~input=val), inputVar)};`
         }
+        out.contents
       }
     }
 
@@ -1378,9 +1370,9 @@ module Builder = {
 
         let currentCode = ref("")
 
-        if val.validation->X.Option.unsafeToBool {
+        if val.checks->X.Option.unsafeToBool && val.expected.noValidation !== Some(true) {
           let prev = current.contents->X.Option.getUnsafe
-          currentCode := val->emitValidation(~inputVar=prev.var())
+          currentCode := val->emitChecks(~inputVar=prev.var())
         }
 
         if val.varsAllocation !== "" {
@@ -1401,8 +1393,8 @@ module Builder = {
     }
 
     // AND-joins every check's cond — caller guarantees `checks` is non-empty.
-    // Used by union codegen to hoist a val's validation into a dispatch discriminant.
-    let andJoinChecks = (checks: array<validationCheck>, ~inputVar: string): string => {
+    // Used by union codegen to hoist a val's checks into a dispatch discriminant.
+    let andJoinChecks = (checks: array<check>, ~inputVar: string): string => {
       let result = ref((checks->Js.Array2.unsafe_get(0)).cond(~inputVar))
       for i in 1 to checks->Js.Array2.length - 1 {
         result :=
@@ -1431,7 +1423,7 @@ module Builder = {
     }
 
     // Pass a non-empty `~checks` or omit it. Never pass `~checks=[]` —
-    // that would break the val.validation "absent iff no checks" invariant.
+    // that would break the val.checks "absent iff no checks" invariant.
     let refine = (val: val, ~schema=val.schema, ~checks=?, ~expected=val.expected) => {
       let shouldLink = val.var !== _var
       let nextVal = {
@@ -1444,7 +1436,7 @@ module Builder = {
         codeFromPrev: "",
         varsAllocation: "",
         allocate: initialAllocate,
-        validation: ?checks,
+        checks: ?checks,
         path: val.path,
         global: val.global,
         hasTransform: ?val.hasTransform,
@@ -1464,10 +1456,10 @@ module Builder = {
 
     // Lazy-allocate helper for mutating an existing val (as opposed to
     // building a local array and passing it through `refine`).
-    let pushCheck = (val: val, check: validationCheck) => {
-      switch val.validation {
+    let pushCheck = (val: val, check: check) => {
+      switch val.checks {
       | Some(arr) => arr->Js.Array2.push(check)->ignore
-      | None => val.validation = Some([check])
+      | None => val.checks = Some([check])
       }
     }
 
@@ -1476,9 +1468,9 @@ module Builder = {
     // `parent[key]`; `fail` stays shared so lifted checks fuse with the
     // parent's own type guard. No-op if the child has no checks.
     let hoistChildChecks = (parent: val, ~child: val, ~key: string) => {
-      if child.validation->X.Option.unsafeToBool {
+      if child.checks->X.Option.unsafeToBool {
         let pathAppend = parent.global->inlineLocation(key)->Path.fromInlinedLocation
-        child.validation
+        child.checks
         ->X.Option.getUnsafe
         ->Js.Array2.forEach(check => {
           parent->pushCheck({
@@ -1486,7 +1478,7 @@ module Builder = {
             fail: check.fail,
           })
         })
-        child.validation = None
+        child.checks = None
       }
     }
 
@@ -1841,7 +1833,7 @@ let numberDecoder = Builder.make((~input) => {
     let output = input->B.next(outputVar, ~schema=input.expected)
     output.var = B._var
 
-    output.validation = Some([
+    output.checks = Some([
       {
         cond: (~inputVar as _) =>
           switch input.expected.format {
@@ -2060,7 +2052,7 @@ module Literal = {
         // FIXME: Test, that when from item has a refinement
         // and we need to keep existing validation
         // S.string->S.check->S.to(S.literal(false))
-        stringConstVal.validation = Some([
+        stringConstVal.checks = Some([
           {
             cond: (~inputVar) => `${inputVar}==="${stringConstSchema.const->Obj.magic}"`,
             fail: B.failInvalidType,
@@ -2631,7 +2623,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     } else {
       unknownInput.schema
     }
-    let checks: array<validationCheck> = []
+    let checks: array<check> = []
     if !isArrayInput {
       checks
       ->Js.Array2.push({
@@ -2782,7 +2774,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     } else {
       unknownInput.schema
     }
-    let checks: array<validationCheck> = []
+    let checks: array<check> = []
     if !isObjectInput {
       checks
       ->Js.Array2.push({
@@ -3621,7 +3613,7 @@ module Union = {
 
               let currentCode = ref("")
 
-              if val.validation->X.Option.unsafeToBool {
+              if val.checks->X.Option.unsafeToBool {
                 if (
                   val.hasTransform === Some(true)
                     ? (val.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
@@ -3634,15 +3626,15 @@ module Union = {
                   let input = current.contents->X.Option.getUnsafe
                   let inputVar = input.var()
                   let condCode =
-                    val.validation->X.Option.getUnsafe->B.andJoinChecks(~inputVar)
+                    val.checks->X.Option.getUnsafe->B.andJoinChecks(~inputVar)
                   if itemCond.contents->X.String.unsafeToBool {
                     itemCond := `${condCode}&&${itemCond.contents}`
                   } else {
                     itemCond := condCode
                   }
-                } else {
+                } else if val.expected.noValidation !== Some(true) {
                   let prev = current.contents->X.Option.getUnsafe
-                  currentCode := val->B.emitValidation(~inputVar=prev.var())
+                  currentCode := val->B.emitChecks(~inputVar=prev.var())
                 }
               }
 
@@ -3902,7 +3894,7 @@ module Union = {
             | _ => {
                 // Discard any checks parse managed to push before throwing,
                 // so the deopt path doesn't see leftover partial state.
-                typeValidationInput.validation = None
+                typeValidationInput.checks = None
                 typeValidationInput
               }
             }
@@ -3931,7 +3923,7 @@ module Union = {
               valRef := v.prev
               shouldDeopt :=
                 !(
-                  v.validation->X.Option.unsafeToBool && (
+                  v.checks->X.Option.unsafeToBool && (
                       v.hasTransform === Some(true)
                         ? (v.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                             v.codeFromPrev === ""
@@ -3994,7 +3986,7 @@ module Union = {
 
             let currentCode = ref("")
 
-            if val.validation->X.Option.unsafeToBool {
+            if val.checks->X.Option.unsafeToBool {
               if (
                 val.hasTransform === Some(true)
                   ? (val.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
@@ -4005,15 +3997,15 @@ module Union = {
                 let input = current.contents->X.Option.getUnsafe
                 let inputVar = input.var()
                 let condCode =
-                  val.validation->X.Option.getUnsafe->B.andJoinChecks(~inputVar)
+                  val.checks->X.Option.getUnsafe->B.andJoinChecks(~inputVar)
                 if blockCond.contents->X.String.unsafeToBool {
                   blockCond := `${condCode}&&${blockCond.contents}`
                 } else {
                   blockCond := condCode
                 }
-              } else {
+              } else if val.expected.noValidation !== Some(true) {
                 let prev = current.contents->X.Option.getUnsafe
-                currentCode := val->B.emitValidation(~inputVar=prev.var())
+                currentCode := val->B.emitChecks(~inputVar=prev.var())
               }
             }
 
@@ -5713,7 +5705,7 @@ let compactColumnsDecoder = (~input) => {
 
       if keysLen === 0 {
         if isUnknownInput {
-          input.validation = Some([
+          input.checks = Some([
             {
               cond: (~inputVar) =>
                 `Array.isArray(${inputVar})&&${inputVar}.length===0`,
@@ -5727,7 +5719,7 @@ let compactColumnsDecoder = (~input) => {
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         if isUnknownInput {
-          input.validation = Some([
+          input.checks = Some([
             {
               cond: (~inputVar) => {
                 let check = ref(

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1471,10 +1471,11 @@ module Builder = {
       }
     }
 
-    // Clear a val's validation list back to absent.
-    // Done via %raw since ReScript may rename locals in the compiled output,
-    // which would break a literal `delete val.vc`.
-    let clearChecks: val => unit = %raw(`function(v){delete v.vc}`)
+    // Clear a val's validation list. Sets the optional field to None,
+    // which compiles to `val.vc = undefined` — same truthy-check semantics
+    // as an absent field (undefined is falsy), without the engine-level
+    // shape churn of a full `delete`.
+    let clearChecks = (val: val) => val.validation = None
 
     let dynamicScope = (from: val, ~locationVar): val => {
       {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -20,7 +20,7 @@ module X = {
   module Option = {
     external getUnsafe: option<'a> => 'a = "%identity"
 
-    // external unsafeToBool: option<'a> => bool = "%identity"
+    external unsafeToBool: option<'a> => bool = "%identity"
   }
 
   module Promise = {
@@ -586,8 +586,11 @@ and val = {
   mutable varsAllocation: string,
   @as("a")
   mutable allocate: string => unit,
+  // Absent when the val has no checks. We deliberately never store an empty
+  // array here: a missing field is a cheaper "no validation" than `Some([])`,
+  // and lets hot paths test `val.validation->unsafeToBool` instead of len.
   @as("vc")
-  mutable validation: array<validationCheck>,
+  mutable validation?: array<validationCheck>,
   @as("u")
   mutable isUnion?: bool,
   // Whether the chain starting from the root prev has a transformation
@@ -1182,7 +1185,6 @@ module Builder = {
         // Measure performance
         // TODO: Also try setting values to embed without allocation
         // (Is it memory leak?)
-        validation: [],
         path: Path.empty,
         global: {
           ?defs,
@@ -1315,9 +1317,11 @@ module Builder = {
     // short-circuit statement, so hot-path primitives keep producing the same
     // single `||`-throw line as before.
     let emitValidation = (val: val, ~input: val, ~inputVar: string): string => {
-      if val.expected.noValidation === Some(true) || val.validation->Js.Array2.length === 0 {
+      // Optional field invariant: if `validation` is present, it's non-empty.
+      if val.expected.noValidation === Some(true) || !(val.validation->X.Option.unsafeToBool) {
         ""
       } else {
+        let checks = val.validation->X.Option.getUnsafe
         let out = ref("")
         let pendingCond = ref("")
         let pendingFail = ref(None)
@@ -1335,7 +1339,6 @@ module Builder = {
           | None => ()
           }
 
-        let checks = val.validation
         for i in 0 to checks->Js.Array2.length - 1 {
           let check = checks->Js.Array2.unsafe_get(i)
           let condCode = check.cond(~inputVar)
@@ -1364,7 +1367,7 @@ module Builder = {
 
         let currentCode = ref("")
 
-        if val.validation->Js.Array2.length > 0 {
+        if val.validation->X.Option.unsafeToBool {
           // Validation must be used only when there's a prev value
           let input = current.contents->X.Option.getUnsafe
           currentCode := val->emitValidation(~input, ~inputVar=input.var())
@@ -1417,7 +1420,6 @@ module Builder = {
         codeFromPrev: "",
         varsAllocation: "",
         allocate: initialAllocate,
-        validation: [],
         path: prev.path,
         global: prev.global,
         hasTransform: true,
@@ -1425,7 +1427,10 @@ module Builder = {
       }
     }
 
-    let refine = (val: val, ~schema=val.schema, ~checks=[], ~expected=val.expected) => {
+    // `~checks` is optional so callers can omit it entirely (which keeps
+    // `validation` absent on the resulting val) or pass a non-empty array.
+    // An empty array would break the "absent iff no checks" invariant.
+    let refine = (val: val, ~schema=val.schema, ~checks=?, ~expected=val.expected) => {
       let shouldLink = val.var !== _var
       let nextVal = {
         prev: val,
@@ -1437,7 +1442,7 @@ module Builder = {
         codeFromPrev: "",
         varsAllocation: "",
         allocate: initialAllocate,
-        validation: checks,
+        validation: ?checks,
         path: val.path,
         global: val.global,
         hasTransform: ?val.hasTransform,
@@ -1455,6 +1460,22 @@ module Builder = {
       nextVal
     }
 
+    // Append a check to a val's validation list, allocating the list lazily.
+    // Used by discriminant hoisting and the union synthetic-check emitter —
+    // i.e. places that mutate an existing val rather than building a local
+    // array to pass through `refine`.
+    let pushCheck = (val: val, check: validationCheck) => {
+      switch val.validation {
+      | Some(arr) => arr->Js.Array2.push(check)->ignore
+      | None => val.validation = Some([check])
+      }
+    }
+
+    // Clear a val's validation list back to absent.
+    // Done via %raw since ReScript may rename locals in the compiled output,
+    // which would break a literal `delete val.vc`.
+    let clearChecks: val => unit = %raw(`function(v){delete v.vc}`)
+
     let dynamicScope = (from: val, ~locationVar): val => {
       {
         var: _notVarBeforeValidation,
@@ -1466,7 +1487,6 @@ module Builder = {
         varsAllocation: "",
         parent: from,
         allocate: initialAllocate,
-        validation: [],
         path: Path.empty,
         global: from.global,
       }
@@ -1538,7 +1558,6 @@ module Builder = {
           varsAllocation: "",
           hasTransform: false,
           allocate: initialAllocate,
-          validation: [],
           isInput: ?val.isInput,
           isOutput: ?val.isOutput,
           vals: ?val.vals, // TODO: Is this correct?
@@ -1600,7 +1619,6 @@ module Builder = {
               codeFromPrev: "",
               varsAllocation: "",
               allocate: initialAllocate,
-              validation: [],
               path: parent.path->Path.concat(pathAppend),
               global: parent.global,
               parent,
@@ -1810,7 +1828,7 @@ let numberDecoder = Builder.make((~input) => {
     let output = input->B.next(outputVar, ~schema=input.expected)
     output.var = B._var
 
-    output.validation = [
+    output.validation = Some([
       {
         cond: (~inputVar as _) =>
           switch input.expected.format {
@@ -1819,7 +1837,7 @@ let numberDecoder = Builder.make((~input) => {
           },
         fail: B.failInvalidType(~expected=input.expected),
       },
-    ]
+    ])
     output
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.number)) {
     input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
@@ -2029,12 +2047,12 @@ module Literal = {
         // FIXME: Test, that when from item has a refinement
         // and we need to keep existing validation
         // S.string->S.check->S.to(S.literal(false))
-        stringConstVal.validation = [
+        stringConstVal.validation = Some([
           {
             cond: (~inputVar) => `${inputVar}==="${stringConstSchema.const->Obj.magic}"`,
             fail: B.failInvalidType(~expected=stringConstSchema),
           },
-        ]
+        ])
 
         stringConstVal->B.nextConst(~schema=expectedSchema, ~expected=expectedSchema)
       } else if schemaTagFlag->Flag.unsafeHas(TagFlag.nan) {
@@ -2498,7 +2516,6 @@ let rec makeObjectVal = (prev: val, ~schema): B.Val.Object.t => {
     codeFromPrev: "",
     varsAllocation: "",
     allocate: B.initialAllocate,
-    validation: [],
     path: prev.path,
     global: prev.global,
   }
@@ -2639,7 +2656,11 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     // Apply refine also when there are no checks,
     // so literals for union cases don't mutate input
     // FIXME: This should be removed and validation be attached to output
-    unknownInput->B.refine(~schema, ~checks)
+    if checks->Js.Array2.length > 0 {
+      unknownInput->B.refine(~schema, ~checks)
+    } else {
+      unknownInput->B.refine(~schema)
+    }
   } else {
     unknownInput->B.unsupportedConversion(~from=unknownInput.schema, ~target=expectedSchema)
   }
@@ -2711,23 +2732,23 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       // We rewrite the check's `cond` to patch the inputVar with the element path,
       // and we reuse the parent's existing fail reference so the hoisted check
       // fuses with the parent's own type check in a single `||` emission.
-      if isUnion && schema->isLiteral && itemOutput.validation->Js.Array2.length > 0 {
+      if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
         let pathAppend =
           input.global->B.inlineLocation(key)->Path.fromInlinedLocation
-        let parentFail = if input.validation->Js.Array2.length > 0 {
-          (input.validation->Js.Array2.unsafe_get(0)).fail
-        } else {
-          B.failInvalidType(~expected=input.expected)
+        let parentFail = switch input.validation {
+        | Some(arr) => (arr->Js.Array2.unsafe_get(0)).fail
+        | None => B.failInvalidType(~expected=input.expected)
         }
-        itemOutput.validation->Js.Array2.forEach(check => {
-          input.validation
-          ->Js.Array2.push({
+        itemOutput.validation
+        ->X.Option.getUnsafe
+        ->Js.Array2.forEach(check => {
+          input->B.pushCheck({
             cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
             fail: parentFail,
           })
-          ->ignore
         })
-        itemOutput.validation = []
+        // Invariant: `validation` is absent iff there are no checks.
+        itemOutput->B.clearChecks
       }
 
       objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -2790,7 +2811,11 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
 
     // Apply refine also when there are no checks,
     // so literals for union cases don't mutate input
-    unknownInput->B.refine(~schema, ~checks)
+    if checks->Js.Array2.length > 0 {
+      unknownInput->B.refine(~schema, ~checks)
+    } else {
+      unknownInput->B.refine(~schema)
+    }
   } else {
     unknownInput->B.unsupportedConversion(~from=unknownInput.schema, ~target=expectedSchema)
   }
@@ -2873,23 +2898,23 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         // Hoist the child's literal check into the parent as a union discriminant.
         // Reuse the parent's existing fail so the hoisted check fuses with the
         // parent's own type check in a single `||` emission.
-        if isUnion && schema->isLiteral && itemOutput.validation->Js.Array2.length > 0 {
+        if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
           let pathAppend =
             input.global->B.inlineLocation(key)->Path.fromInlinedLocation
-          let parentFail = if input.validation->Js.Array2.length > 0 {
-            (input.validation->Js.Array2.unsafe_get(0)).fail
-          } else {
-            B.failInvalidType(~expected=input.expected)
+          let parentFail = switch input.validation {
+          | Some(arr) => (arr->Js.Array2.unsafe_get(0)).fail
+          | None => B.failInvalidType(~expected=input.expected)
           }
-          itemOutput.validation->Js.Array2.forEach(check => {
-            input.validation
-            ->Js.Array2.push({
+          itemOutput.validation
+          ->X.Option.getUnsafe
+          ->Js.Array2.forEach(check => {
+            input->B.pushCheck({
               cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
               fail: parentFail,
             })
-            ->ignore
           })
-          itemOutput.validation = []
+          // Invariant: `validation` is absent iff there are no checks.
+          itemOutput->B.clearChecks
         }
 
         objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -3619,17 +3644,21 @@ module Union = {
 
               let currentCode = ref("")
 
-              if val.validation->Js.Array2.length > 0 {
+              if val.validation->X.Option.unsafeToBool {
                 if (
                   val.hasTransform === Some(true)
                     ? (val.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                         val.codeFromPrev === ""
                     : true
                 ) {
-                  // Cheap enough to hoist as a union dispatch discriminant
+                  // Cheap enough to hoist as a union dispatch discriminant.
+                  // Note: we intentionally bypass `noValidation` here — the
+                  // condition is used to route between union cases, not to
+                  // reject input, so suppressing it would break dispatch.
                   let input = current.contents->X.Option.getUnsafe
                   let inputVar = input.var()
-                  let condCode = val.validation->B.mergeChecksCond(~inputVar)
+                  let condCode =
+                    val.validation->X.Option.getUnsafe->B.mergeChecksCond(~inputVar)
                   if itemCond.contents->X.String.unsafeToBool {
                     itemCond := `${condCode}&&${itemCond.contents}`
                   } else {
@@ -3778,12 +3807,10 @@ module Union = {
                 itemStart :=
                   itemStart.contents ++ if_ ++ `(!(${itemNoop.contents})){${fail(caught.contents)}}`
               } else {
-                typeValidationOutput.validation
-                ->Js.Array2.push({
+                typeValidationOutput->B.pushCheck({
                   cond: (~inputVar as _) => `(${itemNoop.contents})`,
                   fail: B.failInvalidType(~expected=typeValidationOutput.expected),
                 })
-                ->ignore
               }
             } else if withExhaustiveCheck.contents {
               let errorCode = fail(caught.contents)
@@ -3898,7 +3925,8 @@ module Union = {
               typeValidationInput->parse
             } catch {
             | _ => {
-                typeValidationInput.validation = []
+                // Invariant: `validation` is absent iff there are no checks.
+                typeValidationInput->B.clearChecks
                 typeValidationInput
               }
             }
@@ -3927,7 +3955,7 @@ module Union = {
               valRef := v.prev
               shouldDeopt :=
                 !(
-                  v.validation->Js.Array2.length > 0 && (
+                  v.validation->X.Option.unsafeToBool && (
                       v.hasTransform === Some(true)
                         ? (v.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                             v.codeFromPrev === ""
@@ -3990,17 +4018,21 @@ module Union = {
 
             let currentCode = ref("")
 
-            if val.validation->Js.Array2.length > 0 {
+            if val.validation->X.Option.unsafeToBool {
               if (
                 val.hasTransform === Some(true)
                   ? (val.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                       val.codeFromPrev === ""
                   : true
               ) {
-                // Cheap enough to hoist as a union dispatch discriminant
+                // Cheap enough to hoist as a union dispatch discriminant.
+                // Note: we intentionally bypass `noValidation` here — the
+                // condition is used to route between union cases, not to
+                // reject input, so suppressing it would break dispatch.
                 let input = current.contents->X.Option.getUnsafe
                 let inputVar = input.var()
-                let condCode = val.validation->B.mergeChecksCond(~inputVar)
+                let condCode =
+                  val.validation->X.Option.getUnsafe->B.mergeChecksCond(~inputVar)
                 if blockCond.contents->X.String.unsafeToBool {
                   blockCond := `${condCode}&&${blockCond.contents}`
                 } else {
@@ -5768,13 +5800,13 @@ let compactColumnsDecoder = (~input) => {
 
       if keys->Js.Array2.length === 0 {
         if isUnknownInput {
-          input.validation = [
+          input.validation = Some([
             {
               cond: (~inputVar) =>
                 `Array.isArray(${inputVar})&&${inputVar}.length===0`,
               fail: B.failInvalidType(~expected=input.expected),
             },
-          ]
+          ])
         }
         let outputSchema = base(arrayTag, ~selfReverse=false)
         let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
@@ -5783,7 +5815,7 @@ let compactColumnsDecoder = (~input) => {
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         if isUnknownInput {
-          input.validation = [
+          input.validation = Some([
             {
               cond: (~inputVar) =>
                 `Array.isArray(${inputVar})&&${inputVar}.length===${keys
@@ -5796,7 +5828,7 @@ let compactColumnsDecoder = (~input) => {
                   ->Js.Array2.joinWith("")}`,
               fail: B.failInvalidType(~expected=input.expected),
             },
-          ]
+          ])
         }
 
         let inputVar = input.var()

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -586,7 +586,8 @@ and val = {
   mutable varsAllocation: string,
   @as("a")
   mutable allocate: string => unit,
-  mutable validation: option<(~inputVar: string) => string>,
+  @as("vc")
+  mutable validation: array<validationCheck>,
   @as("u")
   mutable isUnion?: bool,
   // Whether the chain starting from the root prev has a transformation
@@ -609,6 +610,18 @@ and bGlobal = {
   embeded: array<unknown>,
   @as("d")
   mutable defs?: dict<internal>,
+}
+// A single validation check attached to a val.
+// Emitted as `${cond(inputVar)}||${embed(fail(input))}(${inputVar});` at merge time.
+// Two adjacent checks sharing a `fail` by reference equality are fused with `&&`.
+and validationCheck = {
+  // Positive "valid-when-true" JS expression
+  @as("c")
+  cond: (~inputVar: string) => string,
+  // Emit-time factory: takes the prev val and returns the runtime error-builder
+  // that will be embedded and called when the check fails.
+  @as("f")
+  fail: (~input: val) => (unknown => errorDetails),
 }
 and flag = int
 and error = private {
@@ -1169,7 +1182,7 @@ module Builder = {
         // Measure performance
         // TODO: Also try setting values to embed without allocation
         // (Is it memory leak?)
-        validation: None,
+        validation: [],
         path: Path.empty,
         global: {
           ?defs,
@@ -1271,20 +1284,74 @@ module Builder = {
       details
     }
 
-    let embedInvalidInput = (~input: val, ~expected=input.expected) => {
-      let received = input.schema->castToPublic
-
-      input->failWithArg(
+    // Default type-failure error builder.
+    // Outer call runs at emit time (fresh val); inner function is embedded and runs at throw time.
+    let failInvalidType = (~expected: internal) => {
+      (~input: val) => {
+        let received = input.schema->castToPublic
+        let path = input.path
         value =>
           makeInvalidInputDetails(
             ~expected,
             ~received,
-            ~path=input.path,
+            ~path,
             ~input=value,
             ~includeInput=true,
-          ),
-        input.var(),
-      )
+          )
+      }
+    }
+
+    // Back-compat wrapper. Some non-check code paths (union codegen, direct
+    // failures) still want "emit a throw expression right here". This now
+    // funnels through `failInvalidType` so the embed + call template lives
+    // in one place.
+    let embedInvalidInput = (~input: val, ~expected=input.expected) => {
+      let errorBuilder = failInvalidType(~expected)(~input)
+      input->failWithArg(errorBuilder, input.var())
+    }
+
+    // Emit the JS for a val's validation list (if any), respecting noValidation.
+    // Fuses adjacent checks whose `fail` references are `===` into one
+    // short-circuit statement, so hot-path primitives keep producing the same
+    // single `||`-throw line as before.
+    let emitValidation = (val: val, ~input: val, ~inputVar: string): string => {
+      if val.expected.noValidation === Some(true) || val.validation->Js.Array2.length === 0 {
+        ""
+      } else {
+        let out = ref("")
+        let pendingCond = ref("")
+        let pendingFail = ref(None)
+
+        let flush = () =>
+          switch pendingFail.contents {
+          | Some(fail) => {
+              let errorBuilder = fail(~input)
+              out :=
+                out.contents ++
+                `${pendingCond.contents}||${input->failWithArg(errorBuilder, inputVar)};`
+              pendingCond := ""
+              pendingFail := None
+            }
+          | None => ()
+          }
+
+        let checks = val.validation
+        for i in 0 to checks->Js.Array2.length - 1 {
+          let check = checks->Js.Array2.unsafe_get(i)
+          let condCode = check.cond(~inputVar)
+          switch pendingFail.contents {
+          | Some(f) if f === check.fail =>
+            pendingCond := `${pendingCond.contents}&&${condCode}`
+          | _ => {
+              flush()
+              pendingCond := condCode
+              pendingFail := Some(check.fail)
+            }
+          }
+        }
+        flush()
+        out.contents
+      }
     }
 
     let merge = (val: val): string => {
@@ -1297,16 +1364,10 @@ module Builder = {
 
         let currentCode = ref("")
 
-        switch val.validation {
-        | Some(validation) if val.expected.noValidation !== Some(true) => {
-            // Validation must be used only when there's a prev value
-            let input = current.contents->X.Option.getUnsafe
-            let inputVar = input.var()
-            let validationCode = validation(~inputVar)
-            currentCode :=
-              `${validationCode}||${embedInvalidInput(~input, ~expected=val.expected)};`
-          }
-        | _ => ()
+        if val.validation->Js.Array2.length > 0 {
+          // Validation must be used only when there's a prev value
+          let input = current.contents->X.Option.getUnsafe
+          currentCode := val->emitValidation(~input, ~inputVar=input.var())
         }
 
         if val.varsAllocation !== "" {
@@ -1326,18 +1387,22 @@ module Builder = {
       code.contents
     }
 
-    let appendValidation = (validation1, validation2) => {
-      Some(
-        (~inputVar) => {
-          {
-            switch validation1 {
-            | Some(prevValidation) => prevValidation(~inputVar) ++ "&&"
-            | None => ""
-            }
-          } ++
-          validation2(~inputVar)
-        },
-      )
+    // Fused positive-cond for all checks on a val, e.g. `cond1&&cond2&&cond3`.
+    // Empty string when there are no checks. Used by union codegen to hoist
+    // a val's validation into a dispatch discriminant.
+    let mergeChecksCond = (checks: array<validationCheck>, ~inputVar: string): string => {
+      let len = checks->Js.Array2.length
+      if len === 0 {
+        ""
+      } else {
+        let result = ref((checks->Js.Array2.unsafe_get(0)).cond(~inputVar))
+        for i in 1 to len - 1 {
+          result :=
+            result.contents ++
+            "&&" ++ (checks->Js.Array2.unsafe_get(i)).cond(~inputVar)
+        }
+        result.contents
+      }
     }
 
     let next = (prev: val, initial: string, ~schema, ~expected=prev.expected): val => {
@@ -1352,7 +1417,7 @@ module Builder = {
         codeFromPrev: "",
         varsAllocation: "",
         allocate: initialAllocate,
-        validation: None,
+        validation: [],
         path: prev.path,
         global: prev.global,
         hasTransform: true,
@@ -1360,7 +1425,7 @@ module Builder = {
       }
     }
 
-    let refine = (val: val, ~schema=val.schema, ~validation=?, ~expected=val.expected) => {
+    let refine = (val: val, ~schema=val.schema, ~checks=[], ~expected=val.expected) => {
       let shouldLink = val.var !== _var
       let nextVal = {
         prev: val,
@@ -1372,7 +1437,7 @@ module Builder = {
         codeFromPrev: "",
         varsAllocation: "",
         allocate: initialAllocate,
-        validation,
+        validation: checks,
         path: val.path,
         global: val.global,
         hasTransform: ?val.hasTransform,
@@ -1401,7 +1466,7 @@ module Builder = {
         varsAllocation: "",
         parent: from,
         allocate: initialAllocate,
-        validation: None,
+        validation: [],
         path: Path.empty,
         global: from.global,
       }
@@ -1473,7 +1538,7 @@ module Builder = {
           varsAllocation: "",
           hasTransform: false,
           allocate: initialAllocate,
-          validation: None,
+          validation: [],
           isInput: ?val.isInput,
           isOutput: ?val.isOutput,
           vals: ?val.vals, // TODO: Is this correct?
@@ -1535,7 +1600,7 @@ module Builder = {
               codeFromPrev: "",
               varsAllocation: "",
               allocate: initialAllocate,
-              validation: None,
+              validation: [],
               path: parent.path->Path.concat(pathAppend),
               global: parent.global,
               parent,
@@ -1712,21 +1777,32 @@ let int32FormatValidation = (~inputVar) => {
 let numberDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      `typeof ${inputVar}==="${(numberTag :> string)}"` ++
+    let fail = B.failInvalidType(~expected=input.expected)
+    let checks = [
       {
-        switch input.expected.format {
-        | Some(Int32) => `&&${int32FormatValidation(~inputVar)}`
-
-        | _ =>
-          if input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation) {
-            ""
-          } else {
-            `&&!Number.isNaN(${inputVar})`
-          }
-        }
+        cond: (~inputVar) => `typeof ${inputVar}==="${(numberTag :> string)}"`,
+        fail,
+      },
+    ]
+    switch input.expected.format {
+    | Some(Int32) =>
+      checks
+      ->Js.Array2.push({
+        cond: (~inputVar) => int32FormatValidation(~inputVar),
+        fail,
+      })
+      ->ignore
+    | _ =>
+      if !(input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation)) {
+        checks
+        ->Js.Array2.push({
+          cond: (~inputVar) => `!Number.isNaN(${inputVar})`,
+          fail,
+        })
+        ->ignore
       }
-    })
+    }
+    input->B.refine(~schema=input.expected, ~checks)
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.string) {
     let outputVar = input.global->B.varWithoutAllocation
     input.allocate(`${outputVar}=+${input.var()}`)
@@ -1734,21 +1810,29 @@ let numberDecoder = Builder.make((~input) => {
     let output = input->B.next(outputVar, ~schema=input.expected)
     output.var = B._var
 
-    output.validation = Some(
-      (~inputVar as _) => {
-        switch input.expected.format {
-        | Some(Int32) => int32FormatValidation(~inputVar=outputVar)
-        | _ => `!Number.isNaN(${outputVar})`
-        }
+    output.validation = [
+      {
+        cond: (~inputVar as _) =>
+          switch input.expected.format {
+          | Some(Int32) => int32FormatValidation(~inputVar=outputVar)
+          | _ => `!Number.isNaN(${outputVar})`
+          },
+        fail: B.failInvalidType(~expected=input.expected),
       },
-    )
+    ]
     output
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.number)) {
     input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
   } else if input.schema.format !== input.expected.format && input.expected.format === Some(Int32) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      int32FormatValidation(~inputVar)
-    })
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) => int32FormatValidation(~inputVar),
+          fail: B.failInvalidType(~expected=input.expected),
+        },
+      ],
+    )
   } else {
     input
   }
@@ -1760,9 +1844,15 @@ int.decoder = numberDecoder
 let stringDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      `typeof ${inputVar}==="${(stringTag :> string)}"`
-    })
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) => `typeof ${inputVar}==="${(stringTag :> string)}"`,
+          fail: B.failInvalidType(~expected=input.expected),
+        },
+      ],
+    )
   } else if (
     inputTagFlag->Flag.unsafeHas(
       TagFlag.boolean->Flag.with(
@@ -1796,9 +1886,15 @@ string.decoder = stringDecoder
 let booleanDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      `typeof ${inputVar}==="${(booleanTag :> string)}"`
-    })
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) => `typeof ${inputVar}==="${(booleanTag :> string)}"`,
+          fail: B.failInvalidType(~expected=input.expected),
+        },
+      ],
+    )
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.string) {
     let outputVar = input.global->B.varWithoutAllocation
     input.allocate(outputVar)
@@ -1824,9 +1920,15 @@ let bigintDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
 
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      `typeof ${inputVar}==="${(bigintTag :> string)}"`
-    })
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) => `typeof ${inputVar}==="${(bigintTag :> string)}"`,
+          fail: B.failInvalidType(~expected=input.expected),
+        },
+      ],
+    )
   } // TODO: Skip formats which 100% don't match
   else if inputTagFlag->Flag.unsafeHas(TagFlag.string) {
     let outputVar = input.global->B.varWithoutAllocation
@@ -1851,9 +1953,15 @@ bigint.decoder = bigintDecoder
 let symbolDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      `typeof ${inputVar}==="${(symbolTag :> string)}"`
-    })
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) => `typeof ${inputVar}==="${(symbolTag :> string)}"`,
+          fail: B.failInvalidType(~expected=input.expected),
+        },
+      ],
+    )
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.symbol)) {
     input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
   } else {
@@ -1921,22 +2029,35 @@ module Literal = {
         // FIXME: Test, that when from item has a refinement
         // and we need to keep existing validation
         // S.string->S.check->S.to(S.literal(false))
-        stringConstVal.validation = Some(
-          (~inputVar) => {
-            `${inputVar}==="${stringConstSchema.const->Obj.magic}"`
+        stringConstVal.validation = [
+          {
+            cond: (~inputVar) => `${inputVar}==="${stringConstSchema.const->Obj.magic}"`,
+            fail: B.failInvalidType(~expected=stringConstSchema),
           },
-        )
+        ]
 
         stringConstVal->B.nextConst(~schema=expectedSchema, ~expected=expectedSchema)
       } else if schemaTagFlag->Flag.unsafeHas(TagFlag.nan) {
-        input->B.refine(~schema=expectedSchema, ~validation=(~inputVar) => {
-          `Number.isNaN(${inputVar})`
-        })
+        input->B.refine(
+          ~schema=expectedSchema,
+          ~checks=[
+            {
+              cond: (~inputVar) => `Number.isNaN(${inputVar})`,
+              fail: B.failInvalidType(~expected=expectedSchema),
+            },
+          ],
+        )
       } else {
         // TODO: Determine impossible cases during compilation
-        input->B.refine(~schema=expectedSchema, ~validation=(~inputVar) => {
-          `${inputVar}===${input->B.inlineConst(expectedSchema)}`
-        })
+        input->B.refine(
+          ~schema=expectedSchema,
+          ~checks=[
+            {
+              cond: (~inputVar) => `${inputVar}===${input->B.inlineConst(expectedSchema)}`,
+              fail: B.failInvalidType(~expected=expectedSchema),
+            },
+          ],
+        )
       }
     }
   })
@@ -2377,7 +2498,7 @@ let rec makeObjectVal = (prev: val, ~schema): B.Val.Object.t => {
     codeFromPrev: "",
     varsAllocation: "",
     allocate: B.initialAllocate,
-    validation: None,
+    validation: [],
     path: prev.path,
     global: prev.global,
   }
@@ -2474,13 +2595,18 @@ and arrayDecoder: builder = (~input as unknownInput) => {
   let expectedLength = expectedItems->Js.Array2.length
 
   let input = if unknownInputTagFlag->Flag.unsafeHas(TagFlag.unknown->Flag.with(TagFlag.array)) {
-    let validation = ref(None)
     let isArrayInput = unknownInputTagFlag->Flag.unsafeHas(TagFlag.array)
     let schema = if !isArrayInput {
-      validation := Some((~inputVar) => `Array.isArray(${inputVar})`)
       array(unknown->castToPublic)->castToInternal
     } else {
       unknownInput.schema
+    }
+    let checks: array<validationCheck> = []
+    let fail = B.failInvalidType(~expected=expectedSchema)
+    if !isArrayInput {
+      checks
+      ->Js.Array2.push({cond: (~inputVar) => `Array.isArray(${inputVar})`, fail})
+      ->ignore
     }
 
     let isExactSize = switch schema.additionalItems->X.Option.getUnsafe {
@@ -2491,26 +2617,29 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     if !isExactSize {
       switch expectedSchema.additionalItems->X.Option.getUnsafe {
       | Strict =>
-        validation :=
-          validation.contents->B.appendValidation((~inputVar) =>
-            `${inputVar}.length===${expectedLength->X.Int.unsafeToString}`
-          )
+        checks
+        ->Js.Array2.push({
+          cond: (~inputVar) =>
+            `${inputVar}.length===${expectedLength->X.Int.unsafeToString}`,
+          fail,
+        })
+        ->ignore
       | Strip =>
-        validation :=
-          validation.contents->B.appendValidation((~inputVar) =>
-            `${inputVar}.length>=${expectedLength->X.Int.unsafeToString}`
-          )
+        checks
+        ->Js.Array2.push({
+          cond: (~inputVar) =>
+            `${inputVar}.length>=${expectedLength->X.Int.unsafeToString}`,
+          fail,
+        })
+        ->ignore
 
       | _ => ()
       }
     }
-    switch validation.contents {
-    | Some(validation) => unknownInput->B.refine(~schema, ~validation)
-    // Apply refine also here,
+    // Apply refine also when there are no checks,
     // so literals for union cases don't mutate input
     // FIXME: This should be removed and validation be attached to output
-    | None => unknownInput->B.refine
-    }
+    unknownInput->B.refine(~schema, ~checks)
   } else {
     unknownInput->B.unsupportedConversion(~from=unknownInput.schema, ~target=expectedSchema)
   }
@@ -2578,16 +2707,27 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
       let itemOutput = itemInput->parse
 
-      switch itemOutput.validation {
-      | Some(validation) if isUnion && schema->isLiteral =>
-        input.validation =
-          input.validation->B.appendValidation((~inputVar) => {
-            validation(
-              ~inputVar=inputVar ++ input.global->B.inlineLocation(key)->Path.fromInlinedLocation,
-            )
+      // Hoist the child's literal check into the parent as a union discriminant.
+      // We rewrite the check's `cond` to patch the inputVar with the element path,
+      // and we reuse the parent's existing fail reference so the hoisted check
+      // fuses with the parent's own type check in a single `||` emission.
+      if isUnion && schema->isLiteral && itemOutput.validation->Js.Array2.length > 0 {
+        let pathAppend =
+          input.global->B.inlineLocation(key)->Path.fromInlinedLocation
+        let parentFail = if input.validation->Js.Array2.length > 0 {
+          (input.validation->Js.Array2.unsafe_get(0)).fail
+        } else {
+          B.failInvalidType(~expected=input.expected)
+        }
+        itemOutput.validation->Js.Array2.forEach(check => {
+          input.validation
+          ->Js.Array2.push({
+            cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
+            fail: parentFail,
           })
-        itemOutput.validation = None
-      | _ => ()
+          ->ignore
+        })
+        itemOutput.validation = []
       }
 
       objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -2615,15 +2755,9 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
   let unknownInputTagFlag = unknownInput.schema.tag->TagFlag.get
 
   let input = if unknownInputTagFlag->Flag.unsafeHas(TagFlag.unknown->Flag.with(TagFlag.object)) {
-    let validation = ref(None)
     let isObjectInput = unknownInputTagFlag->Flag.unsafeHas(TagFlag.object)
     let schema = if !isObjectInput {
       // TODO: Use dictFactory here
-      validation :=
-        Some(
-          (~inputVar) =>
-            `typeof ${inputVar}==="${(objectTag :> string)}"&&${inputVar}`,
-        )
       let mut = base(objectTag, ~selfReverse=false)
       mut.properties = Some(X.Object.immutableEmpty)
       mut.additionalItems = Some(Schema(unknown->castToPublic))
@@ -2631,23 +2765,32 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     } else {
       unknownInput.schema
     }
-
-    if !isObjectInput && expectedSchema.additionalItems->X.Option.getUnsafe !== Strip {
-      // For strip case we recreate the value
-      // For other cases we might optimize it,
-      // this is why the check is a must have
-      validation :=
-        validation.contents->B.appendValidation((~inputVar) =>
-          `!Array.isArray(${inputVar})`
-        )
+    let checks: array<validationCheck> = []
+    let fail = B.failInvalidType(~expected=expectedSchema)
+    if !isObjectInput {
+      checks
+      ->Js.Array2.push({
+        cond: (~inputVar) =>
+          `typeof ${inputVar}==="${(objectTag :> string)}"&&${inputVar}`,
+        fail,
+      })
+      ->ignore
+      if expectedSchema.additionalItems->X.Option.getUnsafe !== Strip {
+        // For strip case we recreate the value
+        // For other cases we might optimize it,
+        // this is why the check is a must have
+        checks
+        ->Js.Array2.push({
+          cond: (~inputVar) => `!Array.isArray(${inputVar})`,
+          fail,
+        })
+        ->ignore
+      }
     }
 
-    switch validation.contents {
-    | Some(validation) => unknownInput->B.refine(~schema, ~validation)
-    // Apply refine also here,
+    // Apply refine also when there are no checks,
     // so literals for union cases don't mutate input
-    | None => unknownInput->B.refine
-    }
+    unknownInput->B.refine(~schema, ~checks)
   } else {
     unknownInput->B.unsupportedConversion(~from=unknownInput.schema, ~target=expectedSchema)
   }
@@ -2727,16 +2870,26 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
         let itemOutput = itemInput->parse
 
-        switch itemOutput.validation {
-        | Some(validation) if isUnion && schema->isLiteral =>
-          input.validation =
-            input.validation->B.appendValidation((~inputVar) => {
-              validation(
-                ~inputVar=inputVar ++ input.global->B.inlineLocation(key)->Path.fromInlinedLocation,
-              )
+        // Hoist the child's literal check into the parent as a union discriminant.
+        // Reuse the parent's existing fail so the hoisted check fuses with the
+        // parent's own type check in a single `||` emission.
+        if isUnion && schema->isLiteral && itemOutput.validation->Js.Array2.length > 0 {
+          let pathAppend =
+            input.global->B.inlineLocation(key)->Path.fromInlinedLocation
+          let parentFail = if input.validation->Js.Array2.length > 0 {
+            (input.validation->Js.Array2.unsafe_get(0)).fail
+          } else {
+            B.failInvalidType(~expected=input.expected)
+          }
+          itemOutput.validation->Js.Array2.forEach(check => {
+            input.validation
+            ->Js.Array2.push({
+              cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
+              fail: parentFail,
             })
-          itemOutput.validation = None
-        | _ => ()
+            ->ignore
+          })
+          itemOutput.validation = []
         }
 
         objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -2903,9 +3056,16 @@ let recursiveDecoder = Builder.make((~input) => {
 let instanceDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-      `${inputVar} instanceof ${input->B.embed(input.expected.class)}`
-    })
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) =>
+            `${inputVar} instanceof ${input->B.embed(input.expected.class)}`,
+          fail: B.failInvalidType(~expected=input.expected),
+        },
+      ],
+    )
   } else if (
     inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === input.expected.class
   ) {
@@ -3459,37 +3619,27 @@ module Union = {
 
               let currentCode = ref("")
 
-              switch val.validation {
-              | Some(validation) =>
+              if val.validation->Js.Array2.length > 0 {
                 if (
                   val.hasTransform === Some(true)
                     ? (val.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                         val.codeFromPrev === ""
                     : true
                 ) {
-                  // Validation must be used only when there's a prev value
+                  // Cheap enough to hoist as a union dispatch discriminant
                   let input = current.contents->X.Option.getUnsafe
                   let inputVar = input.var()
-                  let condCode = validation(~inputVar)
+                  let condCode = val.validation->B.mergeChecksCond(~inputVar)
                   if itemCond.contents->X.String.unsafeToBool {
                     itemCond := `${condCode}&&${itemCond.contents}`
                   } else {
                     itemCond := condCode
                   }
-                } else if val.expected.noValidation !== Some(true) {
-                  // Validation must be used only when there's a prev value
-                  let input = current.contents->X.Option.getUnsafe
-                  let inputVar = input.var()
-                  let validationCode = validation(~inputVar)
-                  currentCode :=
-                    `${validationCode}||${B.embedInvalidInput(
-                        ~input=val,
-                        ~expected=val.expected,
-                      )};`
                 } else {
-                  ()
+                  // Emit as standard validation block (respects noValidation)
+                  let input = current.contents->X.Option.getUnsafe
+                  currentCode := val->B.emitValidation(~input, ~inputVar=input.var())
                 }
-              | _ => ()
               }
 
               if val.varsAllocation !== "" {
@@ -3628,12 +3778,12 @@ module Union = {
                 itemStart :=
                   itemStart.contents ++ if_ ++ `(!(${itemNoop.contents})){${fail(caught.contents)}}`
               } else {
-                typeValidationOutput.validation =
-                  typeValidationOutput.validation->B.appendValidation((
-                    ~inputVar as _,
-                  ) => {
-                    `(${itemNoop.contents})`
-                  })
+                typeValidationOutput.validation
+                ->Js.Array2.push({
+                  cond: (~inputVar as _) => `(${itemNoop.contents})`,
+                  fail: B.failInvalidType(~expected=typeValidationOutput.expected),
+                })
+                ->ignore
               }
             } else if withExhaustiveCheck.contents {
               let errorCode = fail(caught.contents)
@@ -3748,7 +3898,7 @@ module Union = {
               typeValidationInput->parse
             } catch {
             | _ => {
-                typeValidationInput.validation = None
+                typeValidationInput.validation = []
                 typeValidationInput
               }
             }
@@ -3777,7 +3927,7 @@ module Union = {
               valRef := v.prev
               shouldDeopt :=
                 !(
-                  v.validation !== None && (
+                  v.validation->Js.Array2.length > 0 && (
                       v.hasTransform === Some(true)
                         ? (v.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                             v.codeFromPrev === ""
@@ -3840,37 +3990,27 @@ module Union = {
 
             let currentCode = ref("")
 
-            switch val.validation {
-            | Some(validation) =>
+            if val.validation->Js.Array2.length > 0 {
               if (
                 val.hasTransform === Some(true)
                   ? (val.prev->X.Option.getUnsafe).hasTransform !== Some(true) &&
                       val.codeFromPrev === ""
                   : true
               ) {
-                // Validation must be used only when there's a prev value
+                // Cheap enough to hoist as a union dispatch discriminant
                 let input = current.contents->X.Option.getUnsafe
                 let inputVar = input.var()
-                let condCode = validation(~inputVar)
+                let condCode = val.validation->B.mergeChecksCond(~inputVar)
                 if blockCond.contents->X.String.unsafeToBool {
                   blockCond := `${condCode}&&${blockCond.contents}`
                 } else {
                   blockCond := condCode
                 }
-              } else if val.expected.noValidation !== Some(true) {
-                // Validation must be used only when there's a prev value
-                let input = current.contents->X.Option.getUnsafe
-                let inputVar = input.var()
-                let validationCode = validation(~inputVar)
-                currentCode :=
-                  `${validationCode}||${B.embedInvalidInput(
-                      ~input=val,
-                      ~expected=val.expected,
-                    )};`
               } else {
-                ()
+                // Emit as standard validation block (respects noValidation)
+                let input = current.contents->X.Option.getUnsafe
+                currentCode := val->B.emitValidation(~input, ~inputVar=input.var())
               }
-            | _ => ()
             }
 
             if val.varsAllocation !== "" {
@@ -4693,9 +4833,15 @@ let enableUint8Array = () => {
 }
 
 let invalidDateRefine = (input: val) =>
-  input->B.refine(~schema=input.expected, ~validation=(~inputVar) => {
-    `!Number.isNaN(${inputVar}.getTime())`
-  })
+  input->B.refine(
+    ~schema=input.expected,
+    ~checks=[
+      {
+        cond: (~inputVar) => `!Number.isNaN(${inputVar}.getTime())`,
+        fail: B.failInvalidType(~expected=input.expected),
+      },
+    ],
+  )
 
 let date = {
   let mut = base(instanceTag, ~selfReverse=true)
@@ -5622,11 +5768,13 @@ let compactColumnsDecoder = (~input) => {
 
       if keys->Js.Array2.length === 0 {
         if isUnknownInput {
-          input.validation = Some(
-            (~inputVar) => {
-              `Array.isArray(${inputVar})&&${inputVar}.length===0`
+          input.validation = [
+            {
+              cond: (~inputVar) =>
+                `Array.isArray(${inputVar})&&${inputVar}.length===0`,
+              fail: B.failInvalidType(~expected=input.expected),
             },
-          )
+          ]
         }
         let outputSchema = base(arrayTag, ~selfReverse=false)
         let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
@@ -5635,18 +5783,20 @@ let compactColumnsDecoder = (~input) => {
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         if isUnknownInput {
-          input.validation = Some(
-            (~inputVar) => {
-              `Array.isArray(${inputVar})&&${inputVar}.length===${keys
-                ->Js.Array2.length
-                ->X.Int.unsafeToString}` ++
-              `${keys
-                ->Js.Array2.mapi((_, idx) => {
-                  `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
-                })
-                ->Js.Array2.joinWith("")}`
+          input.validation = [
+            {
+              cond: (~inputVar) =>
+                `Array.isArray(${inputVar})&&${inputVar}.length===${keys
+                  ->Js.Array2.length
+                  ->X.Int.unsafeToString}` ++
+                `${keys
+                  ->Js.Array2.mapi((_, idx) => {
+                    `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
+                  })
+                  ->Js.Array2.joinWith("")}`,
+              fail: B.failInvalidType(~expected=input.expected),
             },
-          )
+          ]
         }
 
         let inputVar = input.var()

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -586,9 +586,8 @@ and val = {
   mutable varsAllocation: string,
   @as("a")
   mutable allocate: string => unit,
-  // Absent when the val has no checks. We deliberately never store an empty
-  // array here: a missing field is a cheaper "no validation" than `Some([])`,
-  // and lets hot paths test `val.validation->unsafeToBool` instead of len.
+  // Invariant: absent iff no checks. Never stored as `Some([])` so callers
+  // can test presence with `->unsafeToBool` instead of length.
   @as("vc")
   mutable validation?: array<validationCheck>,
   @as("u")
@@ -614,15 +613,12 @@ and bGlobal = {
   @as("d")
   mutable defs?: dict<internal>,
 }
-// A single validation check attached to a val.
-// Emitted as `${cond(inputVar)}||${embed(fail(val))}(${inputVar});` at merge time.
-// Two adjacent checks sharing a `fail` by reference equality are fused with `&&`.
+// Adjacent checks sharing `fail` by reference equality are fused with `&&`
+// in `emitValidation`, so pass the same helper (e.g. `B.failInvalidType`) to
+// every check on a val if you want them to emit as one `||`-throw line.
 and validationCheck = {
-  // Positive "valid-when-true" JS expression
   @as("c")
   cond: (~inputVar: string) => string,
-  // Emit-time factory: receives the val that owns the check and returns the
-  // runtime error-builder that gets embedded and called when the check fails.
   @as("f")
   fail: (~input: val) => (unknown => errorDetails),
 }
@@ -1286,26 +1282,14 @@ module Builder = {
       details
     }
 
-    // Default `fail` used by `validationCheck` records. A plain top-level
-    // function reference (no partial application, no per-refine closure) so
-    // that every check carrying it shares the same `fail` identity and fuses
-    // with its neighbors in `emitValidation`.
-    //
-    // `input` here is the val that OWNS the check — `emitValidation` passes
-    // `val` as `~input`. All three error fields come from that one val:
-    // `input.expected` (target schema), `input.schema` (source schema),
-    // and `input.path` (error location).
+    // Pass this as `fail` on every check that wants "expected X, received Y"
+    // error semantics. Stable reference → adjacent checks fuse.
     let failInvalidType = (~input: val) => {
-      // FIXME: `received` is wrong for refine-chain vals. `B.refine` sets
-      // `~schema=prev.expected` so `input.schema` ends up equal to
-      // `input.expected` (the target), not the source type. The user-visible
-      // reason string is unaffected because it uses `input->stringify`
-      // (the stringified runtime value), but programmatic consumers reading
-      // `err.received` on a primitive type failure get the target schema.
-      // Fix would be to either reach through `input.prev.schema` (unsafe
-      // optional navigation) or stop mutating `val.schema` to the target in
-      // refine. Direct-assign sites like `compactColumns` are unaffected —
-      // they set `input.schema` to the genuine source type.
+      // FIXME: `input.schema` is the target schema for refine-chain vals
+      // (refine sets `~schema=prev.expected`), so `err.received` ends up
+      // equal to `err.expected` on a primitive type failure. Reason text is
+      // unaffected (it uses `input->stringify`) but programmatic consumers
+      // of `err.received` get the wrong schema.
       let received = input.schema->castToPublic
       let path = input.path
       let expected = input.expected
@@ -1319,10 +1303,9 @@ module Builder = {
         )
     }
 
-    // Emit a throw expression for a direct invalid-input failure (not
-    // attached to a val's validation list). Used inside decoders that build
-    // their own inline JS, e.g. booleanDecoder's `||…||${embedInvalidInput}`
-    // or bigintDecoder's `catch(_){${embedInvalidInput}}`.
+    // Inline variant: emits the throw expression directly. Used by decoders
+    // that splice errors into custom JS (e.g. `catch(_){${embedInvalidInput}}`),
+    // not via the `validationCheck` pipeline.
     let embedInvalidInput = (~input: val, ~expected=input.expected) => {
       let received = input.schema->castToPublic
       let path = input.path
@@ -1339,14 +1322,8 @@ module Builder = {
       )
     }
 
-    // Emit the JS for a val's validation list, respecting `noValidation`.
-    // Adjacent checks that share a `fail` function reference are fused into
-    // one `cond1&&cond2||…;` emission so primitive decoders keep producing a
-    // single throw line. The single-check fast path skips the ref+loop setup.
-    //
-    // Caller must verify `val.validation->unsafeToBool` before dispatching
-    // (so we can unwrap with `getUnsafe`) and pass `inputVar` — the JS
-    // variable holding the runtime value, typically `val.prev.var()`.
+    // Caller must verify `val.validation->unsafeToBool` first — the unwrap
+    // below is unchecked. `inputVar` is usually `val.prev.var()`.
     let emitValidation = (val: val, ~inputVar: string): string => {
       if val.expected.noValidation === Some(true) {
         ""
@@ -1393,7 +1370,6 @@ module Builder = {
         let currentCode = ref("")
 
         if val.validation->X.Option.unsafeToBool {
-          // Validation must be used only when there's a prev value
           let prev = current.contents->X.Option.getUnsafe
           currentCode := val->emitValidation(~inputVar=prev.var())
         }
@@ -1415,10 +1391,8 @@ module Builder = {
       code.contents
     }
 
-    // Fused positive-cond for all checks on a val, e.g. `cond1&&cond2&&cond3`.
-    // Caller guarantees the array is non-empty (union hoist sites check
-    // `val.validation->unsafeToBool` first). Used by union codegen to hoist
-    // a val's validation into a dispatch discriminant.
+    // AND-joins every check's cond — caller guarantees `checks` is non-empty.
+    // Used by union codegen to hoist a val's validation into a dispatch discriminant.
     let mergeChecksCond = (checks: array<validationCheck>, ~inputVar: string): string => {
       let result = ref((checks->Js.Array2.unsafe_get(0)).cond(~inputVar))
       for i in 1 to checks->Js.Array2.length - 1 {
@@ -1447,9 +1421,8 @@ module Builder = {
       }
     }
 
-    // `~checks` is optional so callers can omit it entirely (which keeps
-    // `validation` absent on the resulting val) or pass a non-empty array.
-    // An empty array would break the "absent iff no checks" invariant.
+    // Pass a non-empty `~checks` or omit it. Never pass `~checks=[]` —
+    // that would break the val.validation "absent iff no checks" invariant.
     let refine = (val: val, ~schema=val.schema, ~checks=?, ~expected=val.expected) => {
       let shouldLink = val.var !== _var
       let nextVal = {
@@ -1480,10 +1453,8 @@ module Builder = {
       nextVal
     }
 
-    // Append a check to a val's validation list, allocating the list lazily.
-    // Used by discriminant hoisting and the union synthetic-check emitter —
-    // i.e. places that mutate an existing val rather than building a local
-    // array to pass through `refine`.
+    // Lazy-allocate helper for mutating an existing val (as opposed to
+    // building a local array and passing it through `refine`).
     let pushCheck = (val: val, check: validationCheck) => {
       switch val.validation {
       | Some(arr) => arr->Js.Array2.push(check)->ignore
@@ -2744,10 +2715,10 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
       let itemOutput = itemInput->parse
 
-      // Hoist the child's literal check into the parent as a union discriminant.
-      // Rewrite the check's `cond` to patch the inputVar with the element path;
-      // the `fail` is the shared `B.failInvalidType` so the hoisted check fuses
-      // with the parent's own type check in a single `||` emission.
+      // Hoist a child literal's check onto the parent so union dispatch can
+      // use it as a discriminant. The rewritten cond patches `inputVar` to
+      // `parent[key]`; `fail` stays as the shared `B.failInvalidType` so the
+      // lifted check fuses with the parent's own type guard.
       if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
         let pathAppend =
           input.global->B.inlineLocation(key)->Path.fromInlinedLocation
@@ -2759,7 +2730,6 @@ and arrayDecoder: builder = (~input as unknownInput) => {
             fail: check.fail,
           })
         })
-        // Invariant: `validation` is absent iff there are no checks.
         itemOutput.validation = None
       }
 
@@ -2906,9 +2876,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
         let itemOutput = itemInput->parse
 
-        // Hoist the child's literal check into the parent as a union discriminant.
-        // Rewrite the check's `cond` to patch the inputVar with the field path;
-        // the shared `B.failInvalidType` fuses with the parent's own type check.
+        // Same literal-check hoist as arrayDecoder above — see comment there.
         if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
           let pathAppend =
             input.global->B.inlineLocation(key)->Path.fromInlinedLocation
@@ -2920,7 +2888,6 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
               fail: check.fail,
             })
           })
-          // Invariant: `validation` is absent iff there are no checks.
           itemOutput.validation = None
         }
 
@@ -3658,10 +3625,9 @@ module Union = {
                         val.codeFromPrev === ""
                     : true
                 ) {
-                  // Cheap enough to hoist as a union dispatch discriminant.
-                  // Note: we intentionally bypass `noValidation` here — the
-                  // condition is used to route between union cases, not to
-                  // reject input, so suppressing it would break dispatch.
+                  // Hoist as a dispatch discriminant. `noValidation` is
+                  // intentionally bypassed here — the cond routes between
+                  // cases, it doesn't reject, so suppressing breaks dispatch.
                   let input = current.contents->X.Option.getUnsafe
                   let inputVar = input.var()
                   let condCode =
@@ -3672,7 +3638,6 @@ module Union = {
                     itemCond := condCode
                   }
                 } else {
-                  // Emit as standard validation block (respects noValidation)
                   let prev = current.contents->X.Option.getUnsafe
                   currentCode := val->B.emitValidation(~inputVar=prev.var())
                 }
@@ -4031,10 +3996,7 @@ module Union = {
                       val.codeFromPrev === ""
                   : true
               ) {
-                // Cheap enough to hoist as a union dispatch discriminant.
-                // Note: we intentionally bypass `noValidation` here — the
-                // condition is used to route between union cases, not to
-                // reject input, so suppressing it would break dispatch.
+                // Same `noValidation` bypass as the other union-merge copy above.
                 let input = current.contents->X.Option.getUnsafe
                 let inputVar = input.var()
                 let condCode =
@@ -4045,7 +4007,6 @@ module Union = {
                   blockCond := condCode
                 }
               } else {
-                // Emit as standard validation block (respects noValidation)
                 let prev = current.contents->X.Option.getUnsafe
                 currentCode := val->B.emitValidation(~inputVar=prev.var())
               }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1293,17 +1293,19 @@ module Builder = {
     //
     // `input` here is the val that OWNS the check — `emitValidation` passes
     // `val` as `~input`. All three error fields come from that one val:
-    // `input.expected` (target schema), `input.schema` (received schema —
-    // see note below), `input.path` (error location).
-    //
-    // Note on `received`: for refine-chain vals `input.schema` equals the
-    // target schema (refine calls set `~schema=prev.expected`), so the
-    // structural `err.received` field ends up equal to `err.expected`. The
-    // user-visible reason string is unaffected because it uses the
-    // stringified runtime value (`input->stringify`), not the schema name.
-    // For direct-assign vals like `compactColumns` where `input.schema` is
-    // the genuine source type, `received` is accurate.
+    // `input.expected` (target schema), `input.schema` (source schema),
+    // and `input.path` (error location).
     let failInvalidType = (~input: val) => {
+      // FIXME: `received` is wrong for refine-chain vals. `B.refine` sets
+      // `~schema=prev.expected` so `input.schema` ends up equal to
+      // `input.expected` (the target), not the source type. The user-visible
+      // reason string is unaffected because it uses `input->stringify`
+      // (the stringified runtime value), but programmatic consumers reading
+      // `err.received` on a primitive type failure get the target schema.
+      // Fix would be to either reach through `input.prev.schema` (unsafe
+      // optional navigation) or stop mutating `val.schema` to the target in
+      // refine. Direct-assign sites like `compactColumns` are unaffected —
+      // they set `input.schema` to the genuine source type.
       let received = input.schema->castToPublic
       let path = input.path
       let expected = input.expected

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5704,37 +5704,45 @@ let compactColumnsDecoder = (~input) => {
       }
 
       if keysLen === 0 {
-        if isUnknownInput {
-          input.checks = Some([
-            {
-              cond: (~inputVar) =>
-                `Array.isArray(${inputVar})&&${inputVar}.length===0`,
-              fail: B.failInvalidType,
-            },
-          ])
+        let input = if isUnknownInput {
+          input->B.refine(
+            ~checks=[
+              {
+                cond: (~inputVar) =>
+                  `Array.isArray(${inputVar})&&${inputVar}.length===0`,
+                fail: B.failInvalidType,
+              },
+            ],
+          )
+        } else {
+          input
         }
         let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
         output.isOutput = Some(true)
         output
       } else if isForwardDirection {
         // Forward direction: columnar → rows
-        if isUnknownInput {
-          input.checks = Some([
-            {
-              cond: (~inputVar) => {
-                let check = ref(
-                  `Array.isArray(${inputVar})&&${inputVar}.length===${keysLen->X.Int.unsafeToString}`,
-                )
-                for idx in 0 to keysLen - 1 {
-                  check :=
-                    check.contents ++
-                    `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
-                }
-                check.contents
+        let input = if isUnknownInput {
+          input->B.refine(
+            ~checks=[
+              {
+                cond: (~inputVar) => {
+                  let check = ref(
+                    `Array.isArray(${inputVar})&&${inputVar}.length===${keysLen->X.Int.unsafeToString}`,
+                  )
+                  for idx in 0 to keysLen - 1 {
+                    check :=
+                      check.contents ++
+                      `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
+                  }
+                  check.contents
+                },
+                fail: B.failInvalidType,
               },
-              fail: B.failInvalidType,
-            },
-          ])
+            ],
+          )
+        } else {
+          input
         }
 
         let inputVar = input.var()

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -615,19 +615,16 @@ and bGlobal = {
   mutable defs?: dict<internal>,
 }
 // A single validation check attached to a val.
-// Emitted as `${cond(inputVar)}||${fail(val, inputVar)};` at merge time.
+// Emitted as `${cond(inputVar)}||${embed(fail(val))}(${inputVar});` at merge time.
 // Two adjacent checks sharing a `fail` by reference equality are fused with `&&`.
 and validationCheck = {
   // Positive "valid-when-true" JS expression
   @as("c")
   cond: (~inputVar: string) => string,
-  // Emits the throw expression for the owning val when this check fails.
-  // Receives the val (source of expected/received/path) and the inputVar
-  // (the JS variable holding the runtime value). Returns e.g. `e[N](v0)`.
-  // Kept as a stable function reference so adjacent checks with the same
-  // `fail` fuse by `===` identity in `emitValidation`.
+  // Emit-time factory: receives the val that owns the check and returns the
+  // runtime error-builder that gets embedded and called when the check fails.
   @as("f")
-  fail: (val, ~inputVar: string) => string,
+  fail: (~input: val) => (unknown => errorDetails),
 }
 and flag = int
 and error = private {
@@ -1289,36 +1286,35 @@ module Builder = {
       details
     }
 
-    // Default `fail` used by `validationCheck` records. A plain function
-    // reference (no partial application, no per-refine closure) so that
-    // every check carrying it shares the same `fail` identity and fuses
+    // Default `fail` used by `validationCheck` records. A plain top-level
+    // function reference (no partial application, no per-refine closure) so
+    // that every check carrying it shares the same `fail` identity and fuses
     // with its neighbors in `emitValidation`.
     //
-    // Reads everything from the val that owns the check: `val.expected`
-    // (target schema), `val.schema` (received schema — see note below),
-    // `val.path` (error location). `inputVar` is the JS variable holding
-    // the runtime value at the call site.
+    // `input` here is the val that OWNS the check — `emitValidation` passes
+    // `val` as `~input`. All three error fields come from that one val:
+    // `input.expected` (target schema), `input.schema` (received schema —
+    // see note below), `input.path` (error location).
     //
-    // Note on `received`: for refine-chain vals `val.schema` equals the
-    // target schema (refine calls set `~schema=input.expected`), so the
+    // Note on `received`: for refine-chain vals `input.schema` equals the
+    // target schema (refine calls set `~schema=prev.expected`), so the
     // structural `err.received` field ends up equal to `err.expected`. The
     // user-visible reason string is unaffected because it uses the
     // stringified runtime value (`input->stringify`), not the schema name.
-    let failInvalidType = (val: val, ~inputVar: string): string => {
-      let received = val.schema->castToPublic
-      let path = val.path
-      let expected = val.expected
-      val->failWithArg(
-        value =>
-          makeInvalidInputDetails(
-            ~expected,
-            ~received,
-            ~path,
-            ~input=value,
-            ~includeInput=true,
-          ),
-        inputVar,
-      )
+    // For direct-assign vals like `compactColumns` where `input.schema` is
+    // the genuine source type, `received` is accurate.
+    let failInvalidType = (~input: val) => {
+      let received = input.schema->castToPublic
+      let path = input.path
+      let expected = input.expected
+      value =>
+        makeInvalidInputDetails(
+          ~expected,
+          ~received,
+          ~path,
+          ~input=value,
+          ~includeInput=true,
+        )
     }
 
     // Emit a throw expression for a direct invalid-input failure (not
@@ -1357,7 +1353,7 @@ module Builder = {
         let len = checks->Js.Array2.length
         if len === 1 {
           let check = checks->Js.Array2.unsafe_get(0)
-          `${check.cond(~inputVar)}||${check.fail(val, ~inputVar)};`
+          `${check.cond(~inputVar)}||${val->failWithArg(check.fail(~input=val), inputVar)};`
         } else {
           let out = ref("")
           let i = ref(0)
@@ -1375,7 +1371,9 @@ module Builder = {
                 "&&" ++ (checks->Js.Array2.unsafe_get(i.contents)).cond(~inputVar)
               i := i.contents + 1
             }
-            out := out.contents ++ `${cond.contents}||${fail(val, ~inputVar)};`
+            out :=
+              out.contents ++
+              `${cond.contents}||${val->failWithArg(fail(~input=val), inputVar)};`
           }
           out.contents
         }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1286,8 +1286,11 @@ module Builder = {
       details
     }
 
-    // Default type-failure error builder.
-    // Outer call runs at emit time (fresh val); inner function is embedded and runs at throw time.
+    // Factory used by declarative check records (see `validationCheck`).
+    // Outer call runs at emit time against the fresh prev val, so `input.path`
+    // and `input.schema` are read at the right moment. The returned inner
+    // function is embedded via `failWithArg` and only constructs the error
+    // details when the check actually fails at runtime.
     let failInvalidType = (~expected: internal) => {
       (~input: val) => {
         let received = input.schema->castToPublic
@@ -1303,57 +1306,63 @@ module Builder = {
       }
     }
 
-    // Back-compat wrapper. Some non-check code paths (union codegen, direct
-    // failures) still want "emit a throw expression right here". This now
-    // funnels through `failInvalidType` so the embed + call template lives
-    // in one place.
+    // Emit a throw expression for a direct invalid-input failure (not
+    // attached to a val's validation list). Used inside decoders that build
+    // their own inline JS, e.g. booleanDecoder's `||…||${embedInvalidInput}`
+    // or bigintDecoder's `catch(_){${embedInvalidInput}}`.
     let embedInvalidInput = (~input: val, ~expected=input.expected) => {
-      let errorBuilder = failInvalidType(~expected)(~input)
-      input->failWithArg(errorBuilder, input.var())
+      let received = input.schema->castToPublic
+      let path = input.path
+      input->failWithArg(
+        value =>
+          makeInvalidInputDetails(
+            ~expected,
+            ~received,
+            ~path,
+            ~input=value,
+            ~includeInput=true,
+          ),
+        input.var(),
+      )
     }
 
-    // Emit the JS for a val's validation list (if any), respecting noValidation.
-    // Fuses adjacent checks whose `fail` references are `===` into one
-    // short-circuit statement, so hot-path primitives keep producing the same
-    // single `||`-throw line as before.
+    // Emit the JS for a val's validation list, respecting `noValidation`.
+    // Adjacent checks that share a `fail` closure by reference are fused into
+    // one `cond1&&cond2||…;` emission so primitive decoders keep producing a
+    // single throw line. The single-check fast path skips the ref+loop setup.
     let emitValidation = (val: val, ~input: val, ~inputVar: string): string => {
-      // Optional field invariant: if `validation` is present, it's non-empty.
+      // Invariant: if `validation` is present it is non-empty.
       if val.expected.noValidation === Some(true) || !(val.validation->X.Option.unsafeToBool) {
         ""
       } else {
         let checks = val.validation->X.Option.getUnsafe
-        let out = ref("")
-        let pendingCond = ref("")
-        let pendingFail = ref(None)
-
-        let flush = () =>
-          switch pendingFail.contents {
-          | Some(fail) => {
-              let errorBuilder = fail(~input)
-              out :=
-                out.contents ++
-                `${pendingCond.contents}||${input->failWithArg(errorBuilder, inputVar)};`
-              pendingCond := ""
-              pendingFail := None
+        let len = checks->Js.Array2.length
+        if len === 1 {
+          let check = checks->Js.Array2.unsafe_get(0)
+          `${check.cond(~inputVar)}||${input->failWithArg(check.fail(~input), inputVar)};`
+        } else {
+          let out = ref("")
+          let i = ref(0)
+          while i.contents < len {
+            let head = checks->Js.Array2.unsafe_get(i.contents)
+            let fail = head.fail
+            let cond = ref(head.cond(~inputVar))
+            i := i.contents + 1
+            // Extend the fused cond while the next check shares this `fail`.
+            while (
+              i.contents < len && (checks->Js.Array2.unsafe_get(i.contents)).fail === fail
+            ) {
+              cond :=
+                cond.contents ++
+                "&&" ++ (checks->Js.Array2.unsafe_get(i.contents)).cond(~inputVar)
+              i := i.contents + 1
             }
-          | None => ()
+            out :=
+              out.contents ++
+              `${cond.contents}||${input->failWithArg(fail(~input), inputVar)};`
           }
-
-        for i in 0 to checks->Js.Array2.length - 1 {
-          let check = checks->Js.Array2.unsafe_get(i)
-          let condCode = check.cond(~inputVar)
-          switch pendingFail.contents {
-          | Some(f) if f === check.fail =>
-            pendingCond := `${pendingCond.contents}&&${condCode}`
-          | _ => {
-              flush()
-              pendingCond := condCode
-              pendingFail := Some(check.fail)
-            }
-          }
+          out.contents
         }
-        flush()
-        out.contents
       }
     }
 
@@ -1391,21 +1400,16 @@ module Builder = {
     }
 
     // Fused positive-cond for all checks on a val, e.g. `cond1&&cond2&&cond3`.
-    // Empty string when there are no checks. Used by union codegen to hoist
+    // Caller guarantees the array is non-empty (union hoist sites check
+    // `val.validation->unsafeToBool` first). Used by union codegen to hoist
     // a val's validation into a dispatch discriminant.
     let mergeChecksCond = (checks: array<validationCheck>, ~inputVar: string): string => {
-      let len = checks->Js.Array2.length
-      if len === 0 {
-        ""
-      } else {
-        let result = ref((checks->Js.Array2.unsafe_get(0)).cond(~inputVar))
-        for i in 1 to len - 1 {
-          result :=
-            result.contents ++
-            "&&" ++ (checks->Js.Array2.unsafe_get(i)).cond(~inputVar)
-        }
-        result.contents
+      let result = ref((checks->Js.Array2.unsafe_get(0)).cond(~inputVar))
+      for i in 1 to checks->Js.Array2.length - 1 {
+        result :=
+          result.contents ++ "&&" ++ (checks->Js.Array2.unsafe_get(i)).cond(~inputVar)
       }
+      result.contents
     }
 
     let next = (prev: val, initial: string, ~schema, ~expected=prev.expected): val => {
@@ -1470,12 +1474,6 @@ module Builder = {
       | None => val.validation = Some([check])
       }
     }
-
-    // Clear a val's validation list. Sets the optional field to None,
-    // which compiles to `val.vc = undefined` — same truthy-check semantics
-    // as an absent field (undefined is falsy), without the engine-level
-    // shape churn of a full `delete`.
-    let clearChecks = (val: val) => val.validation = None
 
     let dynamicScope = (from: val, ~locationVar): val => {
       {
@@ -2749,7 +2747,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
           })
         })
         // Invariant: `validation` is absent iff there are no checks.
-        itemOutput->B.clearChecks
+        itemOutput.validation = None
       }
 
       objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -2915,7 +2913,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
             })
           })
           // Invariant: `validation` is absent iff there are no checks.
-          itemOutput->B.clearChecks
+          itemOutput.validation = None
         }
 
         objectVal->B.Val.Object.add(~location=key, itemOutput)
@@ -3926,8 +3924,7 @@ module Union = {
               typeValidationInput->parse
             } catch {
             | _ => {
-                // Invariant: `validation` is absent iff there are no checks.
-                typeValidationInput->B.clearChecks
+                typeValidationInput.validation = None
                 typeValidationInput
               }
             }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -615,16 +615,19 @@ and bGlobal = {
   mutable defs?: dict<internal>,
 }
 // A single validation check attached to a val.
-// Emitted as `${cond(inputVar)}||${embed(fail(input))}(${inputVar});` at merge time.
+// Emitted as `${cond(inputVar)}||${fail(val, inputVar)};` at merge time.
 // Two adjacent checks sharing a `fail` by reference equality are fused with `&&`.
 and validationCheck = {
   // Positive "valid-when-true" JS expression
   @as("c")
   cond: (~inputVar: string) => string,
-  // Emit-time factory: takes the prev val and returns the runtime error-builder
-  // that will be embedded and called when the check fails.
+  // Emits the throw expression for the owning val when this check fails.
+  // Receives the val (source of expected/received/path) and the inputVar
+  // (the JS variable holding the runtime value). Returns e.g. `e[N](v0)`.
+  // Kept as a stable function reference so adjacent checks with the same
+  // `fail` fuse by `===` identity in `emitValidation`.
   @as("f")
-  fail: (~input: val) => (unknown => errorDetails),
+  fail: (val, ~inputVar: string) => string,
 }
 and flag = int
 and error = private {
@@ -1286,15 +1289,26 @@ module Builder = {
       details
     }
 
-    // Factory used by declarative check records (see `validationCheck`).
-    // Outer call runs at emit time against the fresh prev val, so `input.path`
-    // and `input.schema` are read at the right moment. The returned inner
-    // function is embedded via `failWithArg` and only constructs the error
-    // details when the check actually fails at runtime.
-    let failInvalidType = (~expected: internal) => {
-      (~input: val) => {
-        let received = input.schema->castToPublic
-        let path = input.path
+    // Default `fail` used by `validationCheck` records. A plain function
+    // reference (no partial application, no per-refine closure) so that
+    // every check carrying it shares the same `fail` identity and fuses
+    // with its neighbors in `emitValidation`.
+    //
+    // Reads everything from the val that owns the check: `val.expected`
+    // (target schema), `val.schema` (received schema — see note below),
+    // `val.path` (error location). `inputVar` is the JS variable holding
+    // the runtime value at the call site.
+    //
+    // Note on `received`: for refine-chain vals `val.schema` equals the
+    // target schema (refine calls set `~schema=input.expected`), so the
+    // structural `err.received` field ends up equal to `err.expected`. The
+    // user-visible reason string is unaffected because it uses the
+    // stringified runtime value (`input->stringify`), not the schema name.
+    let failInvalidType = (val: val, ~inputVar: string): string => {
+      let received = val.schema->castToPublic
+      let path = val.path
+      let expected = val.expected
+      val->failWithArg(
         value =>
           makeInvalidInputDetails(
             ~expected,
@@ -1302,8 +1316,9 @@ module Builder = {
             ~path,
             ~input=value,
             ~includeInput=true,
-          )
-      }
+          ),
+        inputVar,
+      )
     }
 
     // Emit a throw expression for a direct invalid-input failure (not
@@ -1327,19 +1342,22 @@ module Builder = {
     }
 
     // Emit the JS for a val's validation list, respecting `noValidation`.
-    // Adjacent checks that share a `fail` closure by reference are fused into
+    // Adjacent checks that share a `fail` function reference are fused into
     // one `cond1&&cond2||…;` emission so primitive decoders keep producing a
     // single throw line. The single-check fast path skips the ref+loop setup.
-    let emitValidation = (val: val, ~input: val, ~inputVar: string): string => {
-      // Invariant: if `validation` is present it is non-empty.
-      if val.expected.noValidation === Some(true) || !(val.validation->X.Option.unsafeToBool) {
+    //
+    // Caller must verify `val.validation->unsafeToBool` before dispatching
+    // (so we can unwrap with `getUnsafe`) and pass `inputVar` — the JS
+    // variable holding the runtime value, typically `val.prev.var()`.
+    let emitValidation = (val: val, ~inputVar: string): string => {
+      if val.expected.noValidation === Some(true) {
         ""
       } else {
         let checks = val.validation->X.Option.getUnsafe
         let len = checks->Js.Array2.length
         if len === 1 {
           let check = checks->Js.Array2.unsafe_get(0)
-          `${check.cond(~inputVar)}||${input->failWithArg(check.fail(~input), inputVar)};`
+          `${check.cond(~inputVar)}||${check.fail(val, ~inputVar)};`
         } else {
           let out = ref("")
           let i = ref(0)
@@ -1357,9 +1375,7 @@ module Builder = {
                 "&&" ++ (checks->Js.Array2.unsafe_get(i.contents)).cond(~inputVar)
               i := i.contents + 1
             }
-            out :=
-              out.contents ++
-              `${cond.contents}||${input->failWithArg(fail(~input), inputVar)};`
+            out := out.contents ++ `${cond.contents}||${fail(val, ~inputVar)};`
           }
           out.contents
         }
@@ -1378,8 +1394,8 @@ module Builder = {
 
         if val.validation->X.Option.unsafeToBool {
           // Validation must be used only when there's a prev value
-          let input = current.contents->X.Option.getUnsafe
-          currentCode := val->emitValidation(~input, ~inputVar=input.var())
+          let prev = current.contents->X.Option.getUnsafe
+          currentCode := val->emitValidation(~inputVar=prev.var())
         }
 
         if val.varsAllocation !== "" {
@@ -1794,11 +1810,10 @@ let int32FormatValidation = (~inputVar) => {
 let numberDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    let fail = B.failInvalidType(~expected=input.expected)
     let checks = [
       {
         cond: (~inputVar) => `typeof ${inputVar}==="${(numberTag :> string)}"`,
-        fail,
+        fail: B.failInvalidType,
       },
     ]
     switch input.expected.format {
@@ -1806,7 +1821,7 @@ let numberDecoder = Builder.make((~input) => {
       checks
       ->Js.Array2.push({
         cond: (~inputVar) => int32FormatValidation(~inputVar),
-        fail,
+        fail: B.failInvalidType,
       })
       ->ignore
     | _ =>
@@ -1814,7 +1829,7 @@ let numberDecoder = Builder.make((~input) => {
         checks
         ->Js.Array2.push({
           cond: (~inputVar) => `!Number.isNaN(${inputVar})`,
-          fail,
+          fail: B.failInvalidType,
         })
         ->ignore
       }
@@ -1834,7 +1849,7 @@ let numberDecoder = Builder.make((~input) => {
           | Some(Int32) => int32FormatValidation(~inputVar=outputVar)
           | _ => `!Number.isNaN(${outputVar})`
           },
-        fail: B.failInvalidType(~expected=input.expected),
+        fail: B.failInvalidType,
       },
     ])
     output
@@ -1846,7 +1861,7 @@ let numberDecoder = Builder.make((~input) => {
       ~checks=[
         {
           cond: (~inputVar) => int32FormatValidation(~inputVar),
-          fail: B.failInvalidType(~expected=input.expected),
+          fail: B.failInvalidType,
         },
       ],
     )
@@ -1866,7 +1881,7 @@ let stringDecoder = Builder.make((~input) => {
       ~checks=[
         {
           cond: (~inputVar) => `typeof ${inputVar}==="${(stringTag :> string)}"`,
-          fail: B.failInvalidType(~expected=input.expected),
+          fail: B.failInvalidType,
         },
       ],
     )
@@ -1908,7 +1923,7 @@ let booleanDecoder = Builder.make((~input) => {
       ~checks=[
         {
           cond: (~inputVar) => `typeof ${inputVar}==="${(booleanTag :> string)}"`,
-          fail: B.failInvalidType(~expected=input.expected),
+          fail: B.failInvalidType,
         },
       ],
     )
@@ -1942,7 +1957,7 @@ let bigintDecoder = Builder.make((~input) => {
       ~checks=[
         {
           cond: (~inputVar) => `typeof ${inputVar}==="${(bigintTag :> string)}"`,
-          fail: B.failInvalidType(~expected=input.expected),
+          fail: B.failInvalidType,
         },
       ],
     )
@@ -1975,7 +1990,7 @@ let symbolDecoder = Builder.make((~input) => {
       ~checks=[
         {
           cond: (~inputVar) => `typeof ${inputVar}==="${(symbolTag :> string)}"`,
-          fail: B.failInvalidType(~expected=input.expected),
+          fail: B.failInvalidType,
         },
       ],
     )
@@ -2049,7 +2064,7 @@ module Literal = {
         stringConstVal.validation = Some([
           {
             cond: (~inputVar) => `${inputVar}==="${stringConstSchema.const->Obj.magic}"`,
-            fail: B.failInvalidType(~expected=stringConstSchema),
+            fail: B.failInvalidType,
           },
         ])
 
@@ -2060,7 +2075,7 @@ module Literal = {
           ~checks=[
             {
               cond: (~inputVar) => `Number.isNaN(${inputVar})`,
-              fail: B.failInvalidType(~expected=expectedSchema),
+              fail: B.failInvalidType,
             },
           ],
         )
@@ -2071,7 +2086,7 @@ module Literal = {
           ~checks=[
             {
               cond: (~inputVar) => `${inputVar}===${input->B.inlineConst(expectedSchema)}`,
-              fail: B.failInvalidType(~expected=expectedSchema),
+              fail: B.failInvalidType,
             },
           ],
         )
@@ -2618,10 +2633,12 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       unknownInput.schema
     }
     let checks: array<validationCheck> = []
-    let fail = B.failInvalidType(~expected=expectedSchema)
     if !isArrayInput {
       checks
-      ->Js.Array2.push({cond: (~inputVar) => `Array.isArray(${inputVar})`, fail})
+      ->Js.Array2.push({
+        cond: (~inputVar) => `Array.isArray(${inputVar})`,
+        fail: B.failInvalidType,
+      })
       ->ignore
     }
 
@@ -2637,7 +2654,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
         ->Js.Array2.push({
           cond: (~inputVar) =>
             `${inputVar}.length===${expectedLength->X.Int.unsafeToString}`,
-          fail,
+          fail: B.failInvalidType,
         })
         ->ignore
       | Strip =>
@@ -2645,7 +2662,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
         ->Js.Array2.push({
           cond: (~inputVar) =>
             `${inputVar}.length>=${expectedLength->X.Int.unsafeToString}`,
-          fail,
+          fail: B.failInvalidType,
         })
         ->ignore
 
@@ -2728,22 +2745,18 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       let itemOutput = itemInput->parse
 
       // Hoist the child's literal check into the parent as a union discriminant.
-      // We rewrite the check's `cond` to patch the inputVar with the element path,
-      // and we reuse the parent's existing fail reference so the hoisted check
-      // fuses with the parent's own type check in a single `||` emission.
+      // Rewrite the check's `cond` to patch the inputVar with the element path;
+      // the `fail` is the shared `B.failInvalidType` so the hoisted check fuses
+      // with the parent's own type check in a single `||` emission.
       if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
         let pathAppend =
           input.global->B.inlineLocation(key)->Path.fromInlinedLocation
-        let parentFail = switch input.validation {
-        | Some(arr) => (arr->Js.Array2.unsafe_get(0)).fail
-        | None => B.failInvalidType(~expected=input.expected)
-        }
         itemOutput.validation
         ->X.Option.getUnsafe
         ->Js.Array2.forEach(check => {
           input->B.pushCheck({
             cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
-            fail: parentFail,
+            fail: check.fail,
           })
         })
         // Invariant: `validation` is absent iff there are no checks.
@@ -2786,13 +2799,12 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
       unknownInput.schema
     }
     let checks: array<validationCheck> = []
-    let fail = B.failInvalidType(~expected=expectedSchema)
     if !isObjectInput {
       checks
       ->Js.Array2.push({
         cond: (~inputVar) =>
           `typeof ${inputVar}==="${(objectTag :> string)}"&&${inputVar}`,
-        fail,
+        fail: B.failInvalidType,
       })
       ->ignore
       if expectedSchema.additionalItems->X.Option.getUnsafe !== Strip {
@@ -2802,7 +2814,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         checks
         ->Js.Array2.push({
           cond: (~inputVar) => `!Array.isArray(${inputVar})`,
-          fail,
+          fail: B.failInvalidType,
         })
         ->ignore
       }
@@ -2895,21 +2907,17 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         let itemOutput = itemInput->parse
 
         // Hoist the child's literal check into the parent as a union discriminant.
-        // Reuse the parent's existing fail so the hoisted check fuses with the
-        // parent's own type check in a single `||` emission.
+        // Rewrite the check's `cond` to patch the inputVar with the field path;
+        // the shared `B.failInvalidType` fuses with the parent's own type check.
         if isUnion && schema->isLiteral && itemOutput.validation->X.Option.unsafeToBool {
           let pathAppend =
             input.global->B.inlineLocation(key)->Path.fromInlinedLocation
-          let parentFail = switch input.validation {
-          | Some(arr) => (arr->Js.Array2.unsafe_get(0)).fail
-          | None => B.failInvalidType(~expected=input.expected)
-          }
           itemOutput.validation
           ->X.Option.getUnsafe
           ->Js.Array2.forEach(check => {
             input->B.pushCheck({
               cond: (~inputVar) => check.cond(~inputVar=inputVar ++ pathAppend),
-              fail: parentFail,
+              fail: check.fail,
             })
           })
           // Invariant: `validation` is absent iff there are no checks.
@@ -3086,7 +3094,7 @@ let instanceDecoder = Builder.make((~input) => {
         {
           cond: (~inputVar) =>
             `${inputVar} instanceof ${input->B.embed(input.expected.class)}`,
-          fail: B.failInvalidType(~expected=input.expected),
+          fail: B.failInvalidType,
         },
       ],
     )
@@ -3665,8 +3673,8 @@ module Union = {
                   }
                 } else {
                   // Emit as standard validation block (respects noValidation)
-                  let input = current.contents->X.Option.getUnsafe
-                  currentCode := val->B.emitValidation(~input, ~inputVar=input.var())
+                  let prev = current.contents->X.Option.getUnsafe
+                  currentCode := val->B.emitValidation(~inputVar=prev.var())
                 }
               }
 
@@ -3808,7 +3816,7 @@ module Union = {
               } else {
                 typeValidationOutput->B.pushCheck({
                   cond: (~inputVar as _) => `(${itemNoop.contents})`,
-                  fail: B.failInvalidType(~expected=typeValidationOutput.expected),
+                  fail: B.failInvalidType,
                 })
               }
             } else if withExhaustiveCheck.contents {
@@ -4038,8 +4046,8 @@ module Union = {
                 }
               } else {
                 // Emit as standard validation block (respects noValidation)
-                let input = current.contents->X.Option.getUnsafe
-                currentCode := val->B.emitValidation(~input, ~inputVar=input.var())
+                let prev = current.contents->X.Option.getUnsafe
+                currentCode := val->B.emitValidation(~inputVar=prev.var())
               }
             }
 
@@ -4868,7 +4876,7 @@ let invalidDateRefine = (input: val) =>
     ~checks=[
       {
         cond: (~inputVar) => `!Number.isNaN(${inputVar}.getTime())`,
-        fail: B.failInvalidType(~expected=input.expected),
+        fail: B.failInvalidType,
       },
     ],
   )
@@ -5802,7 +5810,7 @@ let compactColumnsDecoder = (~input) => {
             {
               cond: (~inputVar) =>
                 `Array.isArray(${inputVar})&&${inputVar}.length===0`,
-              fail: B.failInvalidType(~expected=input.expected),
+              fail: B.failInvalidType,
             },
           ])
         }
@@ -5824,7 +5832,7 @@ let compactColumnsDecoder = (~input) => {
                     `&&Array.isArray(${inputVar}[${idx->X.Int.unsafeToString}])`
                   })
                   ->Js.Array2.joinWith("")}`,
-              fail: B.failInvalidType(~expected=input.expected),
+              fail: B.failInvalidType,
             },
           ])
         }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -535,7 +535,6 @@ function operationArg(schema, expected, flag, defs) {
     cp: "",
     l: "",
     a: initialAllocate,
-    vc: [],
     path: "",
     g: {
       v: -1,
@@ -625,9 +624,10 @@ function embedInvalidInput(input, expectedOpt) {
 }
 
 function emitValidation(val, input, inputVar) {
-  if (val.e.noValidation === true || val.vc.length === 0) {
+  if (val.e.noValidation === true || !val.vc) {
     return "";
   }
+  let checks = val.vc;
   let out = {
     contents: ""
   };
@@ -647,7 +647,6 @@ function emitValidation(val, input, inputVar) {
     pendingCond.contents = "";
     pendingFail.contents = undefined;
   };
-  let checks = val.vc;
   for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
     let check = checks[i];
     let condCode = check.c(inputVar);
@@ -676,7 +675,7 @@ function merge(val) {
     let val$1 = current;
     current = val$1.prev;
     let currentCode = "";
-    if (val$1.vc.length > 0) {
+    if (val$1.vc) {
       let input = current;
       currentCode = emitValidation(val$1, input, input.v());
     }
@@ -715,16 +714,14 @@ function next(prev, initial, schema, expectedOpt) {
     cp: "",
     l: "",
     a: initialAllocate,
-    vc: [],
     t: true,
     path: prev.path,
     g: prev.g
   };
 }
 
-function refine(val, schemaOpt, checksOpt, expectedOpt) {
+function refine(val, schemaOpt, checks, expectedOpt) {
   let schema = schemaOpt !== undefined ? schemaOpt : val.s;
-  let checks = checksOpt !== undefined ? checksOpt : [];
   let expected = expectedOpt !== undefined ? expectedOpt : val.e;
   let shouldLink = val.v !== _var;
   let nextVal = {
@@ -755,6 +752,17 @@ function refine(val, schemaOpt, checksOpt, expectedOpt) {
   return nextVal;
 }
 
+function pushCheck(val, check) {
+  let arr = val.vc;
+  if (arr !== undefined) {
+    arr.push(check);
+  } else {
+    val.vc = [check];
+  }
+}
+
+let clearChecks = (function(v){delete v.vc});
+
 function dynamicScope(from, locationVar) {
   return {
     p: from,
@@ -766,7 +774,6 @@ function dynamicScope(from, locationVar) {
     cp: "",
     l: "",
     a: initialAllocate,
-    vc: [],
     path: "",
     g: from.g
   };
@@ -814,7 +821,6 @@ function scope(val) {
     cp: "",
     l: "",
     a: initialAllocate,
-    vc: [],
     u: false,
     t: false,
     path: val.path,
@@ -873,7 +879,6 @@ function get(parent, location) {
     cp: "",
     l: "",
     a: initialAllocate,
-    vc: [],
     path: parent.path + pathAppend,
     g: parent.g
   };
@@ -1521,7 +1526,6 @@ function makeObjectVal(prev, schema) {
     cp: "",
     l: "",
     a: initialAllocate,
-    vc: [],
     t: true,
     path: prev.path,
     g: prev.g
@@ -1624,7 +1628,7 @@ function arrayDecoder(unknownInput) {
       }
       
     }
-    input = refine(unknownInput, schema, checks, undefined);
+    input = checks.length > 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
   } else {
     input = unsupportedConversion(unknownInput, unknownInput.s, expectedSchema);
   }
@@ -1673,17 +1677,16 @@ function arrayDecoder(unknownInput) {
     itemInput$1.io = false;
     itemInput$1.u = isUnion;
     let itemOutput$1 = parse$1(itemInput$1);
-    if (isUnion && constField in schema$1 && itemOutput$1.vc.length > 0) {
+    if (isUnion && constField in schema$1 && itemOutput$1.vc) {
       let inlinedLocation = inlineLocation(input.g, key);
       let pathAppend = "[" + inlinedLocation + "]";
-      let parentFail = input.vc.length > 0 ? input.vc[0].f : failInvalidType(input.e);
-      itemOutput$1.vc.forEach(check => {
-        input.vc.push({
-          c: inputVar => check.c(inputVar + pathAppend),
-          f: parentFail
-        });
-      });
-      itemOutput$1.vc = [];
+      let arr = input.vc;
+      let parentFail = arr !== undefined ? arr[0].f : failInvalidType(input.e);
+      itemOutput$1.vc.forEach(check => pushCheck(input, {
+        c: inputVar => check.c(inputVar + pathAppend),
+        f: parentFail
+      }));
+      clearChecks(itemOutput$1);
     }
     add(objectVal, key, itemOutput$1);
     if (!shouldRecreateInput) {
@@ -1731,7 +1734,7 @@ function objectDecoder(unknownInput) {
       }
       
     }
-    input = refine(unknownInput, schema, checks, undefined);
+    input = checks.length > 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
   } else {
     input = unsupportedConversion(unknownInput, unknownInput.s, expectedSchema);
   }
@@ -1798,17 +1801,16 @@ function objectDecoder(unknownInput) {
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
       let itemOutput$1 = parse$1(itemInput$1);
-      if (isUnion && constField in schema$1 && itemOutput$1.vc.length > 0) {
+      if (isUnion && constField in schema$1 && itemOutput$1.vc) {
         let inlinedLocation = inlineLocation(input.g, key);
         let pathAppend = "[" + inlinedLocation + "]";
-        let parentFail = input.vc.length > 0 ? input.vc[0].f : failInvalidType(input.e);
-        itemOutput$1.vc.forEach(check => {
-          input.vc.push({
-            c: inputVar => check.c(inputVar + pathAppend),
-            f: parentFail
-          });
-        });
-        itemOutput$1.vc = [];
+        let arr = input.vc;
+        let parentFail = arr !== undefined ? arr[0].f : failInvalidType(input.e);
+        itemOutput$1.vc.forEach(check => pushCheck(input, {
+          c: inputVar => check.c(inputVar + pathAppend),
+          f: parentFail
+        }));
+        clearChecks(itemOutput$1);
       }
       add(objectVal, key, itemOutput$1);
       if (!shouldRecreateInput) {
@@ -2335,7 +2337,7 @@ function unionDecoder(input) {
           let val = current;
           current = val.prev;
           let currentCode = "";
-          if (val.vc.length > 0) {
+          if (val.vc) {
             if (val.t === true ? val.prev.t !== true && val.cp === "" : true) {
               let input$1 = current;
               let inputVar = input$1.v();
@@ -2458,7 +2460,7 @@ function unionDecoder(input) {
             let if_$2 = itemNextElse ? "else if" : "if";
             itemStart = itemStart + if_$2 + ("(!(" + itemNoop.contents + ")){" + fail(caught) + "}");
           } else {
-            typeValidationOutput.vc.push({
+            pushCheck(typeValidationOutput, {
               c: param => "(" + itemNoop.contents + ")",
               f: failInvalidType(typeValidationOutput.e)
             });
@@ -2527,7 +2529,7 @@ function unionDecoder(input) {
         try {
           typeValidationOutput = parse$1(typeValidationInput);
         } catch (exn) {
-          typeValidationInput.vc = [];
+          clearChecks(typeValidationInput);
           typeValidationOutput = typeValidationInput;
         }
         if (isPriority(tagFlag, byKey)) {
@@ -2545,7 +2547,7 @@ function unionDecoder(input) {
         while (valRef !== undefined && shouldDeopt) {
           let v = valRef;
           valRef = v.prev;
-          shouldDeopt = !(v.vc.length > 0 && (
+          shouldDeopt = !(v.vc && (
             v.t === true ? v.prev.t !== true && v.cp === "" : true
           ));
         };
@@ -2593,7 +2595,7 @@ function unionDecoder(input) {
         let val = current;
         current = val.prev;
         let currentCode = "";
-        if (val.vc.length > 0) {
+        if (val.vc) {
           if (val.t === true ? val.prev.t !== true && val.cp === "" : true) {
             let input$1 = current;
             let inputVar = input$1.v();
@@ -3382,6 +3384,232 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3482,104 +3710,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
 function shapedSerializer(input) {
   let acc = {};
   prepareShapedSerializerAcc(acc, input);
@@ -3588,134 +3718,6 @@ function shapedSerializer(input) {
   output.t = true;
   output.prev = input;
   return output;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -619,8 +619,9 @@ function failInvalidType(expected) {
 
 function embedInvalidInput(input, expectedOpt) {
   let expected = expectedOpt !== undefined ? expectedOpt : input.e;
-  let errorBuilder = failInvalidType(expected)(input);
-  return failWithArg(input, errorBuilder, input.v());
+  let received = input.s;
+  let path = input.path;
+  return failWithArg(input, value => makeInvalidInputDetails(expected, received, path, value, true, undefined), input.v());
 }
 
 function emitValidation(val, input, inputVar) {
@@ -628,44 +629,25 @@ function emitValidation(val, input, inputVar) {
     return "";
   }
   let checks = val.vc;
-  let out = {
-    contents: ""
-  };
-  let pendingCond = {
-    contents: ""
-  };
-  let pendingFail = {
-    contents: undefined
-  };
-  let flush = () => {
-    let fail = pendingFail.contents;
-    if (fail === undefined) {
-      return;
-    }
-    let errorBuilder = fail(input);
-    out.contents = out.contents + (pendingCond.contents + "||" + failWithArg(input, errorBuilder, inputVar) + ";");
-    pendingCond.contents = "";
-    pendingFail.contents = undefined;
-  };
-  for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
-    let check = checks[i];
-    let condCode = check.c(inputVar);
-    let f = pendingFail.contents;
-    let exit = 0;
-    if (f !== undefined && f === check.f) {
-      pendingCond.contents = pendingCond.contents + "&&" + condCode;
-    } else {
-      exit = 1;
-    }
-    if (exit === 1) {
-      flush();
-      pendingCond.contents = condCode;
-      pendingFail.contents = check.f;
-    }
-    
+  let len = checks.length;
+  if (len === 1) {
+    let check = checks[0];
+    return check.c(inputVar) + "||" + failWithArg(input, check.f(input), inputVar) + ";";
   }
-  flush();
-  return out.contents;
+  let out = "";
+  let i = 0;
+  while (i < len) {
+    let head = checks[i];
+    let fail = head.f;
+    let cond = head.c(inputVar);
+    i = i + 1 | 0;
+    while (i < len && checks[i].f === fail) {
+      cond = cond + "&&" + checks[i].c(inputVar);
+      i = i + 1 | 0;
+    };
+    out = out + (cond + "||" + failWithArg(input, fail(input), inputVar) + ";");
+  };
+  return out;
 }
 
 function merge(val) {
@@ -690,12 +672,8 @@ function merge(val) {
 }
 
 function mergeChecksCond(checks, inputVar) {
-  let len = checks.length;
-  if (len === 0) {
-    return "";
-  }
   let result = checks[0].c(inputVar);
-  for (let i = 1; i < len; ++i) {
+  for (let i = 1, i_finish = checks.length; i < i_finish; ++i) {
     result = result + "&&" + checks[i].c(inputVar);
   }
   return result;
@@ -1299,6 +1277,18 @@ function parse$1(input) {
   return valRef;
 }
 
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
+}
+
 function reverse(schema) {
   if (reversedKey in schema) {
     return schema[reversedKey];
@@ -1402,18 +1392,6 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function parseDynamic(input) {
@@ -3382,121 +3360,43 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
         throw new Error("[Sury] " + message);
       }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
     }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
+    v = completeObjectVal(output);
   }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
 }
 
 function prepareShapedSerializerAcc(acc, input) {
@@ -3655,43 +3555,46 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
   }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
 }
 
 function getValByFrom(_input, from, _idx) {
@@ -3716,6 +3619,81 @@ function shapedSerializer(input) {
   output.t = true;
   output.prev = input;
   return output;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -609,12 +609,11 @@ function makeInvalidInputDetails(expected, received, path, input, includeInput, 
   return details;
 }
 
-function failInvalidType(expected) {
-  return input => {
-    let received = input.s;
-    let path = input.path;
-    return value => makeInvalidInputDetails(expected, received, path, value, true, undefined);
-  };
+function failInvalidType(val, inputVar) {
+  let received = val.s;
+  let path = val.path;
+  let expected = val.e;
+  return failWithArg(val, value => makeInvalidInputDetails(expected, received, path, value, true, undefined), inputVar);
 }
 
 function embedInvalidInput(input, expectedOpt) {
@@ -624,15 +623,15 @@ function embedInvalidInput(input, expectedOpt) {
   return failWithArg(input, value => makeInvalidInputDetails(expected, received, path, value, true, undefined), input.v());
 }
 
-function emitValidation(val, input, inputVar) {
-  if (val.e.noValidation === true || !val.vc) {
+function emitValidation(val, inputVar) {
+  if (val.e.noValidation === true) {
     return "";
   }
   let checks = val.vc;
   let len = checks.length;
   if (len === 1) {
     let check = checks[0];
-    return check.c(inputVar) + "||" + failWithArg(input, check.f(input), inputVar) + ";";
+    return check.c(inputVar) + "||" + check.f(val, inputVar) + ";";
   }
   let out = "";
   let i = 0;
@@ -645,7 +644,7 @@ function emitValidation(val, input, inputVar) {
       cond = cond + "&&" + checks[i].c(inputVar);
       i = i + 1 | 0;
     };
-    out = out + (cond + "||" + failWithArg(input, fail(input), inputVar) + ";");
+    out = out + (cond + "||" + fail(val, inputVar) + ";");
   };
   return out;
 }
@@ -658,8 +657,8 @@ function merge(val) {
     current = val$1.prev;
     let currentCode = "";
     if (val$1.vc) {
-      let input = current;
-      currentCode = emitValidation(val$1, input, input.v());
+      let prev = current;
+      currentCode = emitValidation(val$1, prev.v());
     }
     if (val$1.l !== "") {
       currentCode = currentCode + ("let " + val$1.l + ";");
@@ -976,17 +975,16 @@ function int32FormatValidation(inputVar) {
 function numberDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    let fail = failInvalidType(input.e);
     let checks = [{
         c: inputVar => "typeof " + inputVar + "===\"" + numberTag + "\"",
-        f: fail
+        f: failInvalidType
       }];
     let match = input.e.format;
     let exit = 0;
     if (match === "int32") {
       checks.push({
         c: int32FormatValidation,
-        f: fail
+        f: failInvalidType
       });
     } else {
       exit = 1;
@@ -995,7 +993,7 @@ function numberDecoder(input) {
       if (!(input.g.o & 2)) {
         checks.push({
           c: inputVar => "!Number.isNaN(" + inputVar + ")",
-          f: fail
+          f: failInvalidType
         });
       }
       
@@ -1007,7 +1005,7 @@ function numberDecoder(input) {
       if (input.s.format !== input.e.format && input.e.format === "int32") {
         return refine(input, input.e, [{
             c: int32FormatValidation,
-            f: failInvalidType(input.e)
+            f: failInvalidType
           }], undefined);
       } else {
         return input;
@@ -1033,7 +1031,7 @@ function numberDecoder(input) {
           return "!Number.isNaN(" + outputVar + ")";
         }
       },
-      f: failInvalidType(input.e)
+      f: failInvalidType
     }];
   return output;
 }
@@ -1047,7 +1045,7 @@ function stringDecoder(input) {
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
         c: inputVar => "typeof " + inputVar + "===\"" + stringTag + "\"",
-        f: failInvalidType(input.e)
+        f: failInvalidType
       }], undefined);
   }
   if (!(inputTagFlag & 3132 && constField in input.s)) {
@@ -1072,7 +1070,7 @@ function booleanDecoder(input) {
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
         c: inputVar => "typeof " + inputVar + "===\"" + booleanTag + "\"",
-        f: failInvalidType(input.e)
+        f: failInvalidType
       }], undefined);
   }
   if (!(inputTagFlag & 2)) {
@@ -1098,7 +1096,7 @@ function bigintDecoder(input) {
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
         c: inputVar => "typeof " + inputVar + "===\"" + bigintTag + "\"",
-        f: failInvalidType(input.e)
+        f: failInvalidType
       }], undefined);
   }
   if (!(inputTagFlag & 2)) {
@@ -1125,7 +1123,7 @@ function symbolDecoder(input) {
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
         c: inputVar => "typeof " + inputVar + "===\"" + symbolTag + "\"",
-        f: failInvalidType(input.e)
+        f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 32768) {
     return input;
@@ -1169,12 +1167,12 @@ function literalDecoder(input) {
     if (schemaTagFlag & 2048) {
       return refine(input, expectedSchema, [{
           c: inputVar => "Number.isNaN(" + inputVar + ")",
-          f: failInvalidType(expectedSchema)
+          f: failInvalidType
         }], undefined);
     } else {
       return refine(input, expectedSchema, [{
           c: inputVar => inputVar + "===" + inlineConst(input, expectedSchema),
-          f: failInvalidType(expectedSchema)
+          f: failInvalidType
         }], undefined);
     }
   }
@@ -1183,7 +1181,7 @@ function literalDecoder(input) {
   let stringConstVal = nextConst(input, stringConstSchema, stringConstSchema);
   stringConstVal.vc = [{
       c: inputVar => inputVar + "===\"" + stringConstSchema.const + "\"",
-      f: failInvalidType(stringConstSchema)
+      f: failInvalidType
     }];
   return nextConst(stringConstVal, expectedSchema, expectedSchema);
 }
@@ -1275,18 +1273,6 @@ function parse$1(input) {
     }
   };
   return valRef;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function reverse(schema) {
@@ -1392,6 +1378,18 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
+}
+
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
 }
 
 function parseDynamic(input) {
@@ -1577,11 +1575,10 @@ function arrayDecoder(unknownInput) {
     let isArrayInput = unknownInputTagFlag & 128;
     let schema = isArrayInput ? unknownInput.s : array(unknown);
     let checks = [];
-    let fail = failInvalidType(expectedSchema);
     if (!isArrayInput) {
       checks.push({
         c: inputVar => "Array.isArray(" + inputVar + ")",
-        f: fail
+        f: failInvalidType
       });
     }
     let match = schema.additionalItems;
@@ -1593,12 +1590,12 @@ function arrayDecoder(unknownInput) {
         if (match$1 === "strip") {
           checks.push({
             c: inputVar => inputVar + ".length>=" + expectedLength,
-            f: fail
+            f: failInvalidType
           });
         } else {
           checks.push({
             c: inputVar => inputVar + ".length===" + expectedLength,
-            f: fail
+            f: failInvalidType
           });
         }
       }
@@ -1656,11 +1653,9 @@ function arrayDecoder(unknownInput) {
     if (isUnion && constField in schema$1 && itemOutput$1.vc) {
       let inlinedLocation = inlineLocation(input.g, key);
       let pathAppend = "[" + inlinedLocation + "]";
-      let arr = input.vc;
-      let parentFail = arr !== undefined ? arr[0].f : failInvalidType(input.e);
       itemOutput$1.vc.forEach(check => pushCheck(input, {
         c: inputVar => check.c(inputVar + pathAppend),
-        f: parentFail
+        f: check.f
       }));
       itemOutput$1.vc = undefined;
     }
@@ -1696,16 +1691,15 @@ function objectDecoder(unknownInput) {
       schema = mut;
     }
     let checks = [];
-    let fail = failInvalidType(expectedSchema);
     if (!isObjectInput) {
       checks.push({
         c: inputVar => "typeof " + inputVar + "===\"" + objectTag + "\"&&" + inputVar,
-        f: fail
+        f: failInvalidType
       });
       if (expectedSchema.additionalItems !== "strip") {
         checks.push({
           c: inputVar => "!Array.isArray(" + inputVar + ")",
-          f: fail
+          f: failInvalidType
         });
       }
       
@@ -1780,11 +1774,9 @@ function objectDecoder(unknownInput) {
       if (isUnion && constField in schema$1 && itemOutput$1.vc) {
         let inlinedLocation = inlineLocation(input.g, key);
         let pathAppend = "[" + inlinedLocation + "]";
-        let arr = input.vc;
-        let parentFail = arr !== undefined ? arr[0].f : failInvalidType(input.e);
         itemOutput$1.vc.forEach(check => pushCheck(input, {
           c: inputVar => check.c(inputVar + pathAppend),
-          f: parentFail
+          f: check.f
         }));
         itemOutput$1.vc = undefined;
       }
@@ -1908,7 +1900,7 @@ function instanceDecoder(input) {
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
         c: inputVar => inputVar + " instanceof " + embed(input, input.e.class),
-        f: failInvalidType(input.e)
+        f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
     return input;
@@ -2320,8 +2312,8 @@ function unionDecoder(input) {
               let condCode = mergeChecksCond(val.vc, inputVar);
               itemCond = itemCond ? condCode + "&&" + itemCond : condCode;
             } else {
-              let input$2 = current;
-              currentCode = emitValidation(val, input$2, input$2.v());
+              let prev = current;
+              currentCode = emitValidation(val, prev.v());
             }
           }
           if (val.l !== "") {
@@ -2438,7 +2430,7 @@ function unionDecoder(input) {
           } else {
             pushCheck(typeValidationOutput, {
               c: param => "(" + itemNoop.contents + ")",
-              f: failInvalidType(typeValidationOutput.e)
+              f: failInvalidType
             });
           }
         } else if (withExhaustiveCheck) {
@@ -2578,8 +2570,8 @@ function unionDecoder(input) {
             let condCode = mergeChecksCond(val.vc, inputVar);
             blockCond = blockCond ? condCode + "&&" + blockCond : condCode;
           } else {
-            let input$2 = current;
-            currentCode = emitValidation(val, input$2, input$2.v());
+            let prev = current;
+            currentCode = emitValidation(val, prev.v());
           }
         }
         if (val.l !== "") {
@@ -3215,7 +3207,7 @@ function enableUint8Array() {
 function invalidDateRefine(input) {
   return refine(input, input.e, [{
       c: inputVar => "!Number.isNaN(" + inputVar + ".getTime())",
-      f: failInvalidType(input.e)
+      f: failInvalidType
     }], undefined);
 }
 
@@ -3360,101 +3352,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3555,46 +3452,60 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
     }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
   }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
   }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
   }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
 }
 
 function getValByFrom(_input, from, _idx) {
@@ -3611,23 +3522,43 @@ function getValByFrom(_input, from, _idx) {
   };
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
     }
-    
-  });
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
 }
 
 function nested(fieldName) {
@@ -3694,6 +3625,67 @@ function nested(fieldName) {
   };
   parentCtx[cacheId] = ctx$1;
   return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input) {
@@ -3963,7 +3955,7 @@ function compactColumnsDecoder(input) {
       if (isUnknownInput) {
         input.vc = [{
             c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0",
-            f: failInvalidType(input.e)
+            f: failInvalidType
           }];
       }
       let outputSchema = base(arrayTag, false);
@@ -3975,7 +3967,7 @@ function compactColumnsDecoder(input) {
       if (isUnknownInput) {
         input.vc = [{
             c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===" + keys.length + keys.map((param, idx) => "&&Array.isArray(" + inputVar + "[" + idx + "])").join(""),
-            f: failInvalidType(input.e)
+            f: failInvalidType
           }];
       }
       let inputVar = input.v();

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -609,11 +609,11 @@ function makeInvalidInputDetails(expected, received, path, input, includeInput, 
   return details;
 }
 
-function failInvalidType(val, inputVar) {
-  let received = val.s;
-  let path = val.path;
-  let expected = val.e;
-  return failWithArg(val, value => makeInvalidInputDetails(expected, received, path, value, true, undefined), inputVar);
+function failInvalidType(input) {
+  let received = input.s;
+  let path = input.path;
+  let expected = input.e;
+  return value => makeInvalidInputDetails(expected, received, path, value, true, undefined);
 }
 
 function embedInvalidInput(input, expectedOpt) {
@@ -631,7 +631,7 @@ function emitValidation(val, inputVar) {
   let len = checks.length;
   if (len === 1) {
     let check = checks[0];
-    return check.c(inputVar) + "||" + check.f(val, inputVar) + ";";
+    return check.c(inputVar) + "||" + failWithArg(val, check.f(val), inputVar) + ";";
   }
   let out = "";
   let i = 0;
@@ -644,7 +644,7 @@ function emitValidation(val, inputVar) {
       cond = cond + "&&" + checks[i].c(inputVar);
       i = i + 1 | 0;
     };
-    out = out + (cond + "||" + fail(val, inputVar) + ";");
+    out = out + (cond + "||" + failWithArg(val, fail(val), inputVar) + ";");
   };
   return out;
 }
@@ -3352,162 +3352,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getShapedSerializerOutput(input, acc, targetSchema, path) {
-  let exit = 0;
-  if (acc !== undefined) {
-    let val = acc.val;
-    if (val !== undefined) {
-      let v = scope(val);
-      v.t = true;
-      v.s = targetSchema;
-      v.e = targetSchema;
-      return parse$1(v);
-    }
-    exit = 1;
-  } else {
-    exit = 1;
-  }
-  if (exit === 1) {
-    if (constField in targetSchema) {
-      let v$1 = nextConst(input, targetSchema, targetSchema);
-      v$1.prev = undefined;
-      v$1.p = input;
-      v$1.v = _notVarAtParent;
-      v$1.io = true;
-      return parse$1(v$1);
-    }
-    let resolvedTargetSchema = acc === undefined ? getOutputSchema(targetSchema) : targetSchema;
-    let v$2 = makeObjectVal(input, resolvedTargetSchema);
-    v$2.e = resolvedTargetSchema;
-    v$2.io = true;
-    v$2.prev = undefined;
-    v$2.p = input;
-    v$2.v = _notVarAtParent;
-    let flattened = resolvedTargetSchema.flattened;
-    let items = resolvedTargetSchema.items;
-    let exit$1 = 0;
-    let exit$2 = 0;
-    if (items !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        let tmp;
-        if (acc !== undefined) {
-          let properties = acc.properties;
-          tmp = properties !== undefined ? properties[location] : undefined;
-        } else {
-          tmp = undefined;
-        }
-        let inlinedLocation = inlineLocation(input.g, location);
-        add(v$2, location, getShapedSerializerOutput(input, tmp, items[idx], path + ("[" + inlinedLocation + "]")));
-      }
-    } else {
-      exit$2 = 3;
-    }
-    if (exit$2 === 3) {
-      let properties$1 = resolvedTargetSchema.properties;
-      if (properties$1 !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
-        if (flattened !== undefined && acc !== undefined) {
-          let flattenedAcc = acc.flattened;
-          if (flattenedAcc !== undefined) {
-            flattenedAcc.forEach((acc, idx) => {
-              let flattenedOutput = getShapedSerializerOutput(input, acc, reverse(flattened[idx]), path);
-              let vals = flattenedOutput.d;
-              let locations = Object.keys(vals);
-              for (let idx$1 = 0, idx_finish = locations.length; idx$1 < idx_finish; ++idx$1) {
-                let location = locations[idx$1];
-                add(v$2, location, vals[location]);
-              }
-            });
-          }
-          
-        }
-        let keys = Object.keys(properties$1);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          if (!(location$1 in v$2.d)) {
-            let tmp$1;
-            if (acc !== undefined) {
-              let properties$2 = acc.properties;
-              tmp$1 = properties$2 !== undefined ? properties$2[location$1] : undefined;
-            } else {
-              tmp$1 = undefined;
-            }
-            let inlinedLocation$1 = inlineLocation(input.g, location$1);
-            add(v$2, location$1, getShapedSerializerOutput(input, tmp$1, properties$1[location$1], path + ("[" + inlinedLocation$1 + "]")));
-          }
-          
-        }
-      } else {
-        exit$1 = 2;
-      }
-    }
-    if (exit$1 === 2) {
-      let from = targetSchema.from;
-      let path$1 = from !== undefined ? path + from.map(item => "[\"" + item + "\"]").join("") : path;
-      let tmp$2 = path$1 === "" ? "" : " at " + path$1;
-      invalidOperation(input, "Missing input for " + toExpression(reverse(targetSchema)) + tmp$2);
-    }
-    return completeObjectVal(v$2);
-  }
-  
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function getValByFrom(_input, from, _idx) {
   while (true) {
     let idx = _idx;
@@ -3520,45 +3364,6 @@ function getValByFrom(_input, from, _idx) {
     _input = input.d[key];
     continue;
   };
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
 }
 
 function nested(fieldName) {
@@ -3686,6 +3491,201 @@ function shapedSerializer(input) {
   output.t = true;
   output.prev = input;
   return output;
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function getShapedSerializerOutput(input, acc, targetSchema, path) {
+  let exit = 0;
+  if (acc !== undefined) {
+    let val = acc.val;
+    if (val !== undefined) {
+      let v = scope(val);
+      v.t = true;
+      v.s = targetSchema;
+      v.e = targetSchema;
+      return parse$1(v);
+    }
+    exit = 1;
+  } else {
+    exit = 1;
+  }
+  if (exit === 1) {
+    if (constField in targetSchema) {
+      let v$1 = nextConst(input, targetSchema, targetSchema);
+      v$1.prev = undefined;
+      v$1.p = input;
+      v$1.v = _notVarAtParent;
+      v$1.io = true;
+      return parse$1(v$1);
+    }
+    let resolvedTargetSchema = acc === undefined ? getOutputSchema(targetSchema) : targetSchema;
+    let v$2 = makeObjectVal(input, resolvedTargetSchema);
+    v$2.e = resolvedTargetSchema;
+    v$2.io = true;
+    v$2.prev = undefined;
+    v$2.p = input;
+    v$2.v = _notVarAtParent;
+    let flattened = resolvedTargetSchema.flattened;
+    let items = resolvedTargetSchema.items;
+    let exit$1 = 0;
+    let exit$2 = 0;
+    if (items !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        let tmp;
+        if (acc !== undefined) {
+          let properties = acc.properties;
+          tmp = properties !== undefined ? properties[location] : undefined;
+        } else {
+          tmp = undefined;
+        }
+        let inlinedLocation = inlineLocation(input.g, location);
+        add(v$2, location, getShapedSerializerOutput(input, tmp, items[idx], path + ("[" + inlinedLocation + "]")));
+      }
+    } else {
+      exit$2 = 3;
+    }
+    if (exit$2 === 3) {
+      let properties$1 = resolvedTargetSchema.properties;
+      if (properties$1 !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
+        if (flattened !== undefined && acc !== undefined) {
+          let flattenedAcc = acc.flattened;
+          if (flattenedAcc !== undefined) {
+            flattenedAcc.forEach((acc, idx) => {
+              let flattenedOutput = getShapedSerializerOutput(input, acc, reverse(flattened[idx]), path);
+              let vals = flattenedOutput.d;
+              let locations = Object.keys(vals);
+              for (let idx$1 = 0, idx_finish = locations.length; idx$1 < idx_finish; ++idx$1) {
+                let location = locations[idx$1];
+                add(v$2, location, vals[location]);
+              }
+            });
+          }
+          
+        }
+        let keys = Object.keys(properties$1);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          if (!(location$1 in v$2.d)) {
+            let tmp$1;
+            if (acc !== undefined) {
+              let properties$2 = acc.properties;
+              tmp$1 = properties$2 !== undefined ? properties$2[location$1] : undefined;
+            } else {
+              tmp$1 = undefined;
+            }
+            let inlinedLocation$1 = inlineLocation(input.g, location$1);
+            add(v$2, location$1, getShapedSerializerOutput(input, tmp$1, properties$1[location$1], path + ("[" + inlinedLocation$1 + "]")));
+          }
+          
+        }
+      } else {
+        exit$1 = 2;
+      }
+    }
+    if (exit$1 === 2) {
+      let from = targetSchema.from;
+      let path$1 = from !== undefined ? path + from.map(item => "[\"" + item + "\"]").join("") : path;
+      let tmp$2 = path$1 === "" ? "" : " at " + path$1;
+      invalidOperation(input, "Missing input for " + toExpression(reverse(targetSchema)) + tmp$2);
+    }
+    return completeObjectVal(v$2);
+  }
+  
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -761,8 +761,6 @@ function pushCheck(val, check) {
   }
 }
 
-let clearChecks = (function(v){delete v.vc});
-
 function dynamicScope(from, locationVar) {
   return {
     p: from,
@@ -1686,7 +1684,7 @@ function arrayDecoder(unknownInput) {
         c: inputVar => check.c(inputVar + pathAppend),
         f: parentFail
       }));
-      clearChecks(itemOutput$1);
+      itemOutput$1.vc = undefined;
     }
     add(objectVal, key, itemOutput$1);
     if (!shouldRecreateInput) {
@@ -1810,7 +1808,7 @@ function objectDecoder(unknownInput) {
           c: inputVar => check.c(inputVar + pathAppend),
           f: parentFail
         }));
-        clearChecks(itemOutput$1);
+        itemOutput$1.vc = undefined;
       }
       add(objectVal, key, itemOutput$1);
       if (!shouldRecreateInput) {
@@ -2529,7 +2527,7 @@ function unionDecoder(input) {
         try {
           typeValidationOutput = parse$1(typeValidationInput);
         } catch (exn) {
-          clearChecks(typeValidationInput);
+          typeValidationInput.vc = undefined;
           typeValidationOutput = typeValidationInput;
         }
         if (isPriority(tagFlag, byKey)) {
@@ -3384,48 +3382,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = "~" + fieldName;
@@ -3501,57 +3457,46 @@ function definitionToSchema(definition) {
   });
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
   }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
     }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
 }
 
 function prepareShapedSerializerAcc(acc, input) {
@@ -3708,6 +3653,59 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
     return completeObjectVal(v$2);
   }
   
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function shapedSerializer(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -535,7 +535,7 @@ function operationArg(schema, expected, flag, defs) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: undefined,
+    vc: [],
     path: "",
     g: {
       v: -1,
@@ -610,10 +610,63 @@ function makeInvalidInputDetails(expected, received, path, input, includeInput, 
   return details;
 }
 
+function failInvalidType(expected) {
+  return input => {
+    let received = input.s;
+    let path = input.path;
+    return value => makeInvalidInputDetails(expected, received, path, value, true, undefined);
+  };
+}
+
 function embedInvalidInput(input, expectedOpt) {
   let expected = expectedOpt !== undefined ? expectedOpt : input.e;
-  let received = input.s;
-  return failWithArg(input, value => makeInvalidInputDetails(expected, received, input.path, value, true, undefined), input.v());
+  let errorBuilder = failInvalidType(expected)(input);
+  return failWithArg(input, errorBuilder, input.v());
+}
+
+function emitValidation(val, input, inputVar) {
+  if (val.e.noValidation === true || val.vc.length === 0) {
+    return "";
+  }
+  let out = {
+    contents: ""
+  };
+  let pendingCond = {
+    contents: ""
+  };
+  let pendingFail = {
+    contents: undefined
+  };
+  let flush = () => {
+    let fail = pendingFail.contents;
+    if (fail === undefined) {
+      return;
+    }
+    let errorBuilder = fail(input);
+    out.contents = out.contents + (pendingCond.contents + "||" + failWithArg(input, errorBuilder, inputVar) + ";");
+    pendingCond.contents = "";
+    pendingFail.contents = undefined;
+  };
+  let checks = val.vc;
+  for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
+    let check = checks[i];
+    let condCode = check.c(inputVar);
+    let f = pendingFail.contents;
+    let exit = 0;
+    if (f !== undefined && f === check.f) {
+      pendingCond.contents = pendingCond.contents + "&&" + condCode;
+    } else {
+      exit = 1;
+    }
+    if (exit === 1) {
+      flush();
+      pendingCond.contents = condCode;
+      pendingFail.contents = check.f;
+    }
+    
+  }
+  flush();
+  return out.contents;
 }
 
 function merge(val) {
@@ -623,12 +676,9 @@ function merge(val) {
     let val$1 = current;
     current = val$1.prev;
     let currentCode = "";
-    let validation = val$1.validation;
-    if (validation !== undefined && val$1.e.noValidation !== true) {
+    if (val$1.vc.length > 0) {
       let input = current;
-      let inputVar = input.v();
-      let validationCode = validation(inputVar);
-      currentCode = validationCode + "||" + embedInvalidInput(input, val$1.e) + ";";
+      currentCode = emitValidation(val$1, input, input.v());
     }
     if (val$1.l !== "") {
       currentCode = currentCode + ("let " + val$1.l + ";");
@@ -640,10 +690,16 @@ function merge(val) {
   return code;
 }
 
-function appendValidation(validation1, validation2) {
-  return inputVar => (
-    validation1 !== undefined ? validation1(inputVar) + "&&" : ""
-  ) + validation2(inputVar);
+function mergeChecksCond(checks, inputVar) {
+  let len = checks.length;
+  if (len === 0) {
+    return "";
+  }
+  let result = checks[0].c(inputVar);
+  for (let i = 1; i < len; ++i) {
+    result = result + "&&" + checks[i].c(inputVar);
+  }
+  return result;
 }
 
 function next(prev, initial, schema, expectedOpt) {
@@ -659,15 +715,16 @@ function next(prev, initial, schema, expectedOpt) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: undefined,
+    vc: [],
     t: true,
     path: prev.path,
     g: prev.g
   };
 }
 
-function refine(val, schemaOpt, validation, expectedOpt) {
+function refine(val, schemaOpt, checksOpt, expectedOpt) {
   let schema = schemaOpt !== undefined ? schemaOpt : val.s;
+  let checks = checksOpt !== undefined ? checksOpt : [];
   let expected = expectedOpt !== undefined ? expectedOpt : val.e;
   let shouldLink = val.v !== _var;
   let nextVal = {
@@ -681,7 +738,7 @@ function refine(val, schemaOpt, validation, expectedOpt) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: validation,
+    vc: checks,
     t: val.t,
     path: val.path,
     g: val.g
@@ -709,7 +766,7 @@ function dynamicScope(from, locationVar) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: undefined,
+    vc: [],
     path: "",
     g: from.g
   };
@@ -757,7 +814,7 @@ function scope(val) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: undefined,
+    vc: [],
     u: false,
     t: false,
     path: val.path,
@@ -816,7 +873,7 @@ function get(parent, location) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: undefined,
+    vc: [],
     path: parent.path + pathAppend,
     g: parent.g
   };
@@ -938,25 +995,39 @@ function int32FormatValidation(inputVar) {
 function numberDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    return refine(input, input.e, inputVar => {
-      let match = input.e.format;
-      let tmp;
-      let exit = 0;
-      if (match === "int32") {
-        tmp = "&&" + int32FormatValidation(inputVar);
-      } else {
-        exit = 1;
+    let fail = failInvalidType(input.e);
+    let checks = [{
+        c: inputVar => "typeof " + inputVar + "===\"" + numberTag + "\"",
+        f: fail
+      }];
+    let match = input.e.format;
+    let exit = 0;
+    if (match === "int32") {
+      checks.push({
+        c: int32FormatValidation,
+        f: fail
+      });
+    } else {
+      exit = 1;
+    }
+    if (exit === 1) {
+      if (!(input.g.o & 2)) {
+        checks.push({
+          c: inputVar => "!Number.isNaN(" + inputVar + ")",
+          f: fail
+        });
       }
-      if (exit === 1) {
-        tmp = input.g.o & 2 ? "" : "&&!Number.isNaN(" + inputVar + ")";
-      }
-      return "typeof " + inputVar + "===\"" + numberTag + "\"" + tmp;
-    }, undefined);
+      
+    }
+    return refine(input, input.e, checks, undefined);
   }
   if (!(inputTagFlag & 2)) {
     if (inputTagFlag & 4) {
       if (input.s.format !== input.e.format && input.e.format === "int32") {
-        return refine(input, input.e, int32FormatValidation, undefined);
+        return refine(input, input.e, [{
+            c: int32FormatValidation,
+            f: failInvalidType(input.e)
+          }], undefined);
       } else {
         return input;
       }
@@ -968,18 +1039,21 @@ function numberDecoder(input) {
   input.a(outputVar + "=+" + input.v());
   let output = next(input, outputVar, input.e, undefined);
   output.v = _var;
-  output.validation = param => {
-    let match = input.e.format;
-    if (match !== undefined) {
-      if (match === "int32") {
-        return int32FormatValidation(outputVar);
-      } else {
-        return "!Number.isNaN(" + outputVar + ")";
-      }
-    } else {
-      return "!Number.isNaN(" + outputVar + ")";
-    }
-  };
+  output.vc = [{
+      c: param => {
+        let match = input.e.format;
+        if (match !== undefined) {
+          if (match === "int32") {
+            return int32FormatValidation(outputVar);
+          } else {
+            return "!Number.isNaN(" + outputVar + ")";
+          }
+        } else {
+          return "!Number.isNaN(" + outputVar + ")";
+        }
+      },
+      f: failInvalidType(input.e)
+    }];
   return output;
 }
 
@@ -990,7 +1064,10 @@ int.decoder = numberDecoder;
 function stringDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    return refine(input, input.e, inputVar => "typeof " + inputVar + "===\"" + stringTag + "\"", undefined);
+    return refine(input, input.e, [{
+        c: inputVar => "typeof " + inputVar + "===\"" + stringTag + "\"",
+        f: failInvalidType(input.e)
+      }], undefined);
   }
   if (!(inputTagFlag & 3132 && constField in input.s)) {
     if (inputTagFlag & 1036) {
@@ -1012,7 +1089,10 @@ string.decoder = stringDecoder;
 function booleanDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    return refine(input, input.e, inputVar => "typeof " + inputVar + "===\"" + booleanTag + "\"", undefined);
+    return refine(input, input.e, [{
+        c: inputVar => "typeof " + inputVar + "===\"" + booleanTag + "\"",
+        f: failInvalidType(input.e)
+      }], undefined);
   }
   if (!(inputTagFlag & 2)) {
     if (inputTagFlag & 8) {
@@ -1035,7 +1115,10 @@ bool.decoder = booleanDecoder;
 function bigintDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    return refine(input, input.e, inputVar => "typeof " + inputVar + "===\"" + bigintTag + "\"", undefined);
+    return refine(input, input.e, [{
+        c: inputVar => "typeof " + inputVar + "===\"" + bigintTag + "\"",
+        f: failInvalidType(input.e)
+      }], undefined);
   }
   if (!(inputTagFlag & 2)) {
     if (inputTagFlag & 4) {
@@ -1059,7 +1142,10 @@ bigint.decoder = bigintDecoder;
 function symbolDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    return refine(input, input.e, inputVar => "typeof " + inputVar + "===\"" + symbolTag + "\"", undefined);
+    return refine(input, input.e, [{
+        c: inputVar => "typeof " + inputVar + "===\"" + symbolTag + "\"",
+        f: failInvalidType(input.e)
+      }], undefined);
   } else if (inputTagFlag & 32768) {
     return input;
   } else {
@@ -1100,15 +1186,24 @@ function literalDecoder(input) {
   let schemaTagFlag = flags[expectedSchema.type];
   if (!(flags[input.s.type] & 2 && schemaTagFlag & 3132)) {
     if (schemaTagFlag & 2048) {
-      return refine(input, expectedSchema, inputVar => "Number.isNaN(" + inputVar + ")", undefined);
+      return refine(input, expectedSchema, [{
+          c: inputVar => "Number.isNaN(" + inputVar + ")",
+          f: failInvalidType(expectedSchema)
+        }], undefined);
     } else {
-      return refine(input, expectedSchema, inputVar => inputVar + "===" + inlineConst(input, expectedSchema), undefined);
+      return refine(input, expectedSchema, [{
+          c: inputVar => inputVar + "===" + inlineConst(input, expectedSchema),
+          f: failInvalidType(expectedSchema)
+        }], undefined);
     }
   }
   let stringConstSchema = base(stringTag, false);
   stringConstSchema.const = ("" + expectedSchema.const);
   let stringConstVal = nextConst(input, stringConstSchema, stringConstSchema);
-  stringConstVal.validation = inputVar => inputVar + "===\"" + stringConstSchema.const + "\"";
+  stringConstVal.vc = [{
+      c: inputVar => inputVar + "===\"" + stringConstSchema.const + "\"",
+      f: failInvalidType(stringConstSchema)
+    }];
   return nextConst(stringConstVal, expectedSchema, expectedSchema);
 }
 
@@ -1199,18 +1294,6 @@ function parse$1(input) {
     }
   };
   return valRef;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function reverse(schema) {
@@ -1316,6 +1399,18 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
+}
+
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
 }
 
 function parseDynamic(input) {
@@ -1426,7 +1521,7 @@ function makeObjectVal(prev, schema) {
     cp: "",
     l: "",
     a: initialAllocate,
-    validation: undefined,
+    vc: [],
     t: true,
     path: prev.path,
     g: prev.g
@@ -1499,14 +1594,15 @@ function arrayDecoder(unknownInput) {
   let expectedLength = expectedItems.length;
   let input;
   if (unknownInputTagFlag & 129) {
-    let validation;
     let isArrayInput = unknownInputTagFlag & 128;
-    let schema;
-    if (isArrayInput) {
-      schema = unknownInput.s;
-    } else {
-      validation = inputVar => "Array.isArray(" + inputVar + ")";
-      schema = array(unknown);
+    let schema = isArrayInput ? unknownInput.s : array(unknown);
+    let checks = [];
+    let fail = failInvalidType(expectedSchema);
+    if (!isArrayInput) {
+      checks.push({
+        c: inputVar => "Array.isArray(" + inputVar + ")",
+        f: fail
+      });
     }
     let match = schema.additionalItems;
     let isExactSize;
@@ -1514,12 +1610,21 @@ function arrayDecoder(unknownInput) {
     if (!isExactSize) {
       let match$1 = expectedSchema.additionalItems;
       if (match$1 === "strip" || match$1 === "strict") {
-        validation = match$1 === "strip" ? appendValidation(validation, inputVar => inputVar + ".length>=" + expectedLength) : appendValidation(validation, inputVar => inputVar + ".length===" + expectedLength);
+        if (match$1 === "strip") {
+          checks.push({
+            c: inputVar => inputVar + ".length>=" + expectedLength,
+            f: fail
+          });
+        } else {
+          checks.push({
+            c: inputVar => inputVar + ".length===" + expectedLength,
+            f: fail
+          });
+        }
       }
       
     }
-    let validation$1 = validation;
-    input = validation$1 !== undefined ? refine(unknownInput, schema, validation$1, undefined) : refine(unknownInput, undefined, undefined, undefined);
+    input = refine(unknownInput, schema, checks, undefined);
   } else {
     input = unsupportedConversion(unknownInput, unknownInput.s, expectedSchema);
   }
@@ -1568,13 +1673,17 @@ function arrayDecoder(unknownInput) {
     itemInput$1.io = false;
     itemInput$1.u = isUnion;
     let itemOutput$1 = parse$1(itemInput$1);
-    let validation$2 = itemOutput$1.validation;
-    if (validation$2 !== undefined && isUnion && constField in schema$1) {
-      input.validation = appendValidation(input.validation, inputVar => {
-        let inlinedLocation = inlineLocation(input.g, key);
-        return validation$2(inputVar + ("[" + inlinedLocation + "]"));
+    if (isUnion && constField in schema$1 && itemOutput$1.vc.length > 0) {
+      let inlinedLocation = inlineLocation(input.g, key);
+      let pathAppend = "[" + inlinedLocation + "]";
+      let parentFail = input.vc.length > 0 ? input.vc[0].f : failInvalidType(input.e);
+      itemOutput$1.vc.forEach(check => {
+        input.vc.push({
+          c: inputVar => check.c(inputVar + pathAppend),
+          f: parentFail
+        });
       });
-      itemOutput$1.validation = undefined;
+      itemOutput$1.vc = [];
     }
     add(objectVal, key, itemOutput$1);
     if (!shouldRecreateInput) {
@@ -1597,23 +1706,32 @@ function objectDecoder(unknownInput) {
   let unknownInputTagFlag = flags[unknownInput.s.type];
   let input;
   if (unknownInputTagFlag & 65) {
-    let validation;
     let isObjectInput = unknownInputTagFlag & 64;
     let schema;
     if (isObjectInput) {
       schema = unknownInput.s;
     } else {
-      validation = inputVar => "typeof " + inputVar + "===\"" + objectTag + "\"&&" + inputVar;
       let mut = base(objectTag, false);
       mut.properties = immutableEmpty;
       mut.additionalItems = unknown;
       schema = mut;
     }
-    if (!isObjectInput && expectedSchema.additionalItems !== "strip") {
-      validation = appendValidation(validation, inputVar => "!Array.isArray(" + inputVar + ")");
+    let checks = [];
+    let fail = failInvalidType(expectedSchema);
+    if (!isObjectInput) {
+      checks.push({
+        c: inputVar => "typeof " + inputVar + "===\"" + objectTag + "\"&&" + inputVar,
+        f: fail
+      });
+      if (expectedSchema.additionalItems !== "strip") {
+        checks.push({
+          c: inputVar => "!Array.isArray(" + inputVar + ")",
+          f: fail
+        });
+      }
+      
     }
-    let validation$1 = validation;
-    input = validation$1 !== undefined ? refine(unknownInput, schema, validation$1, undefined) : refine(unknownInput, undefined, undefined, undefined);
+    input = refine(unknownInput, schema, checks, undefined);
   } else {
     input = unsupportedConversion(unknownInput, unknownInput.s, expectedSchema);
   }
@@ -1680,13 +1798,17 @@ function objectDecoder(unknownInput) {
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
       let itemOutput$1 = parse$1(itemInput$1);
-      let validation$2 = itemOutput$1.validation;
-      if (validation$2 !== undefined && isUnion && constField in schema$1) {
-        input.validation = appendValidation(input.validation, inputVar => {
-          let inlinedLocation = inlineLocation(input.g, key);
-          return validation$2(inputVar + ("[" + inlinedLocation + "]"));
+      if (isUnion && constField in schema$1 && itemOutput$1.vc.length > 0) {
+        let inlinedLocation = inlineLocation(input.g, key);
+        let pathAppend = "[" + inlinedLocation + "]";
+        let parentFail = input.vc.length > 0 ? input.vc[0].f : failInvalidType(input.e);
+        itemOutput$1.vc.forEach(check => {
+          input.vc.push({
+            c: inputVar => check.c(inputVar + pathAppend),
+            f: parentFail
+          });
         });
-        itemOutput$1.validation = undefined;
+        itemOutput$1.vc = [];
       }
       add(objectVal, key, itemOutput$1);
       if (!shouldRecreateInput) {
@@ -1806,7 +1928,10 @@ function recursiveDecoder(input) {
 function instanceDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
-    return refine(input, input.e, inputVar => inputVar + " instanceof " + embed(input, input.e.class), undefined);
+    return refine(input, input.e, [{
+        c: inputVar => inputVar + " instanceof " + embed(input, input.e.class),
+        f: failInvalidType(input.e)
+      }], undefined);
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
     return input;
   } else {
@@ -2210,20 +2335,16 @@ function unionDecoder(input) {
           let val = current;
           current = val.prev;
           let currentCode = "";
-          let validation = val.validation;
-          if (validation !== undefined) {
+          if (val.vc.length > 0) {
             if (val.t === true ? val.prev.t !== true && val.cp === "" : true) {
               let input$1 = current;
               let inputVar = input$1.v();
-              let condCode = validation(inputVar);
+              let condCode = mergeChecksCond(val.vc, inputVar);
               itemCond = itemCond ? condCode + "&&" + itemCond : condCode;
-            } else if (val.e.noValidation !== true) {
+            } else {
               let input$2 = current;
-              let inputVar$1 = input$2.v();
-              let validationCode = validation(inputVar$1);
-              currentCode = validationCode + "||" + embedInvalidInput(val, val.e) + ";";
+              currentCode = emitValidation(val, input$2, input$2.v());
             }
-            
           }
           if (val.l !== "") {
             currentCode = currentCode + ("let " + val.l + ";");
@@ -2337,7 +2458,10 @@ function unionDecoder(input) {
             let if_$2 = itemNextElse ? "else if" : "if";
             itemStart = itemStart + if_$2 + ("(!(" + itemNoop.contents + ")){" + fail(caught) + "}");
           } else {
-            typeValidationOutput.validation = appendValidation(typeValidationOutput.validation, param => "(" + itemNoop.contents + ")");
+            typeValidationOutput.vc.push({
+              c: param => "(" + itemNoop.contents + ")",
+              f: failInvalidType(typeValidationOutput.e)
+            });
           }
         } else if (withExhaustiveCheck) {
           let errorCode = fail(caught);
@@ -2403,7 +2527,7 @@ function unionDecoder(input) {
         try {
           typeValidationOutput = parse$1(typeValidationInput);
         } catch (exn) {
-          typeValidationInput.validation = undefined;
+          typeValidationInput.vc = [];
           typeValidationOutput = typeValidationInput;
         }
         if (isPriority(tagFlag, byKey)) {
@@ -2421,7 +2545,7 @@ function unionDecoder(input) {
         while (valRef !== undefined && shouldDeopt) {
           let v = valRef;
           valRef = v.prev;
-          shouldDeopt = !(v.validation !== undefined && (
+          shouldDeopt = !(v.vc.length > 0 && (
             v.t === true ? v.prev.t !== true && v.cp === "" : true
           ));
         };
@@ -2469,20 +2593,16 @@ function unionDecoder(input) {
         let val = current;
         current = val.prev;
         let currentCode = "";
-        let validation = val.validation;
-        if (validation !== undefined) {
+        if (val.vc.length > 0) {
           if (val.t === true ? val.prev.t !== true && val.cp === "" : true) {
             let input$1 = current;
             let inputVar = input$1.v();
-            let condCode = validation(inputVar);
+            let condCode = mergeChecksCond(val.vc, inputVar);
             blockCond = blockCond ? condCode + "&&" + blockCond : condCode;
-          } else if (val.e.noValidation !== true) {
+          } else {
             let input$2 = current;
-            let inputVar$1 = input$2.v();
-            let validationCode = validation(inputVar$1);
-            currentCode = validationCode + "||" + embedInvalidInput(val, val.e) + ";";
+            currentCode = emitValidation(val, input$2, input$2.v());
           }
-          
         }
         if (val.l !== "") {
           currentCode = currentCode + ("let " + val.l + ";");
@@ -3115,7 +3235,10 @@ function enableUint8Array() {
 }
 
 function invalidDateRefine(input) {
-  return refine(input, input.e, inputVar => "!Number.isNaN(" + inputVar + ".getTime())", undefined);
+  return refine(input, input.e, [{
+      c: inputVar => "!Number.isNaN(" + inputVar + ".getTime())",
+      f: failInvalidType(input.e)
+    }], undefined);
 }
 
 let mut = base(instanceTag, true);
@@ -3257,48 +3380,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
       return proxifyShapedSchema(maybeField, target.from.concat(prop), target.fromFlattened);
     }
   });
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3457,6 +3538,111 @@ function prepareShapedSerializerAcc(acc, input) {
   }
 }
 
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = "~" + fieldName;
@@ -3530,69 +3716,6 @@ function definitionToSchema(definition) {
     }
     
   });
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
 }
 
 function shapedParser(input) {
@@ -3860,7 +3983,10 @@ function compactColumnsDecoder(input) {
     let keys = Object.keys(maybeProperties$1);
     if (keys.length === 0) {
       if (isUnknownInput) {
-        input.validation = inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0";
+        input.vc = [{
+            c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0",
+            f: failInvalidType(input.e)
+          }];
       }
       let outputSchema = base(arrayTag, false);
       let output = next(input, "[]", outputSchema, outputSchema);
@@ -3869,7 +3995,10 @@ function compactColumnsDecoder(input) {
     }
     if (match$3[1]) {
       if (isUnknownInput) {
-        input.validation = inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===" + keys.length + keys.map((param, idx) => "&&Array.isArray(" + inputVar + "[" + idx + "])").join("");
+        input.vc = [{
+            c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===" + keys.length + keys.map((param, idx) => "&&Array.isArray(" + inputVar + "[" + idx + "])").join(""),
+            f: failInvalidType(input.e)
+          }];
       }
       let inputVar = input.v();
       let iteratorVar = varWithoutAllocation(input.g);

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -670,7 +670,7 @@ function merge(val) {
   return code;
 }
 
-function mergeChecksCond(checks, inputVar) {
+function andJoinChecks(checks, inputVar) {
   let result = checks[0].c(inputVar);
   for (let i = 1, i_finish = checks.length; i < i_finish; ++i) {
     result = result + "&&" + checks[i].c(inputVar);
@@ -736,6 +736,19 @@ function pushCheck(val, check) {
   } else {
     val.vc = [check];
   }
+}
+
+function hoistChildChecks(parent, child, key) {
+  if (!child.vc) {
+    return;
+  }
+  let inlinedLocation = inlineLocation(parent.g, key);
+  let pathAppend = "[" + inlinedLocation + "]";
+  child.vc.forEach(check => pushCheck(parent, {
+    c: inputVar => check.c(inputVar + pathAppend),
+    f: check.f
+  }));
+  child.vc = undefined;
 }
 
 function dynamicScope(from, locationVar) {
@@ -1650,14 +1663,8 @@ function arrayDecoder(unknownInput) {
     itemInput$1.io = false;
     itemInput$1.u = isUnion;
     let itemOutput$1 = parse$1(itemInput$1);
-    if (isUnion && constField in schema$1 && itemOutput$1.vc) {
-      let inlinedLocation = inlineLocation(input.g, key);
-      let pathAppend = "[" + inlinedLocation + "]";
-      itemOutput$1.vc.forEach(check => pushCheck(input, {
-        c: inputVar => check.c(inputVar + pathAppend),
-        f: check.f
-      }));
-      itemOutput$1.vc = undefined;
+    if (isUnion && constField in schema$1) {
+      hoistChildChecks(input, itemOutput$1, key);
     }
     add(objectVal, key, itemOutput$1);
     if (!shouldRecreateInput) {
@@ -1771,14 +1778,8 @@ function objectDecoder(unknownInput) {
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
       let itemOutput$1 = parse$1(itemInput$1);
-      if (isUnion && constField in schema$1 && itemOutput$1.vc) {
-        let inlinedLocation = inlineLocation(input.g, key);
-        let pathAppend = "[" + inlinedLocation + "]";
-        itemOutput$1.vc.forEach(check => pushCheck(input, {
-          c: inputVar => check.c(inputVar + pathAppend),
-          f: check.f
-        }));
-        itemOutput$1.vc = undefined;
+      if (isUnion && constField in schema$1) {
+        hoistChildChecks(input, itemOutput$1, key);
       }
       add(objectVal, key, itemOutput$1);
       if (!shouldRecreateInput) {
@@ -2309,7 +2310,7 @@ function unionDecoder(input) {
             if (val.t === true ? val.prev.t !== true && val.cp === "" : true) {
               let input$1 = current;
               let inputVar = input$1.v();
-              let condCode = mergeChecksCond(val.vc, inputVar);
+              let condCode = andJoinChecks(val.vc, inputVar);
               itemCond = itemCond ? condCode + "&&" + itemCond : condCode;
             } else {
               let prev = current;
@@ -2567,7 +2568,7 @@ function unionDecoder(input) {
           if (val.t === true ? val.prev.t !== true && val.cp === "" : true) {
             let input$1 = current;
             let inputVar = input$1.v();
-            let condCode = mergeChecksCond(val.vc, inputVar);
+            let condCode = andJoinChecks(val.vc, inputVar);
             blockCond = blockCond ? condCode + "&&" + blockCond : condCode;
           } else {
             let prev = current;
@@ -3352,95 +3353,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== "object" || definition === null) {
     return parse(definition);
@@ -3481,111 +3393,6 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3686,6 +3493,200 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
     return completeObjectVal(v$2);
   }
   
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -623,10 +623,7 @@ function embedInvalidInput(input, expectedOpt) {
   return failWithArg(input, value => makeInvalidInputDetails(expected, received, path, value, true, undefined), input.v());
 }
 
-function emitValidation(val, inputVar) {
-  if (val.e.noValidation === true) {
-    return "";
-  }
+function emitChecks(val, inputVar) {
   let checks = val.vc;
   let len = checks.length;
   if (len === 1) {
@@ -656,9 +653,9 @@ function merge(val) {
     let val$1 = current;
     current = val$1.prev;
     let currentCode = "";
-    if (val$1.vc) {
+    if (val$1.vc && val$1.e.noValidation !== true) {
       let prev = current;
-      currentCode = emitValidation(val$1, prev.v());
+      currentCode = emitChecks(val$1, prev.v());
     }
     if (val$1.l !== "") {
       currentCode = currentCode + ("let " + val$1.l + ";");
@@ -2312,10 +2309,11 @@ function unionDecoder(input) {
               let inputVar = input$1.v();
               let condCode = andJoinChecks(val.vc, inputVar);
               itemCond = itemCond ? condCode + "&&" + itemCond : condCode;
-            } else {
+            } else if (val.e.noValidation !== true) {
               let prev = current;
-              currentCode = emitValidation(val, prev.v());
+              currentCode = emitChecks(val, prev.v());
             }
+            
           }
           if (val.l !== "") {
             currentCode = currentCode + ("let " + val.l + ";");
@@ -2570,10 +2568,11 @@ function unionDecoder(input) {
             let inputVar = input$1.v();
             let condCode = andJoinChecks(val.vc, inputVar);
             blockCond = blockCond ? condCode + "&&" + blockCond : condCode;
-          } else {
+          } else if (val.e.noValidation !== true) {
             let prev = current;
-            currentCode = emitValidation(val, prev.v());
+            currentCode = emitChecks(val, prev.v());
           }
+          
         }
         if (val.l !== "") {
           currentCode = currentCode + ("let " + val.l + ";");

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3878,19 +3878,16 @@ function compactColumnsDecoder(input) {
       outputSchema = s;
     }
     if (keysLen === 0) {
-      if (isUnknownInput) {
-        input.vc = [{
+      let input$1 = isUnknownInput ? refine(input, undefined, [{
             c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0",
             f: failInvalidType
-          }];
-      }
-      let output = next(input, "[]", outputSchema, outputSchema);
+          }], undefined) : input;
+      let output = next(input$1, "[]", outputSchema, outputSchema);
       output.io = true;
       return output;
     }
     if (forwardProps) {
-      if (isUnknownInput) {
-        input.vc = [{
+      let input$2 = isUnknownInput ? refine(input, undefined, [{
             c: inputVar => {
               let check = "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===" + keysLen;
               for (let idx = 0; idx < keysLen; ++idx) {
@@ -3899,12 +3896,11 @@ function compactColumnsDecoder(input) {
               return check;
             },
             f: failInvalidType
-          }];
-      }
-      let inputVar = input.v();
-      let iteratorVar = varWithoutAllocation(input.g);
-      let outputVar = varWithoutAllocation(input.g);
-      let itemSchema = isUnknownInput ? unknown : input.s.additionalItems.additionalItems;
+          }], undefined) : input;
+      let inputVar = input$2.v();
+      let iteratorVar = varWithoutAllocation(input$2.g);
+      let outputVar = varWithoutAllocation(input$2.g);
+      let itemSchema = isUnknownInput ? unknown : input$2.s.additionalItems.additionalItems;
       let lengthCode = "";
       let itemBuildCode = "";
       let itemParseCode = "";
@@ -3912,14 +3908,14 @@ function compactColumnsDecoder(input) {
       let hasAsync = false;
       for (let idx = 0; idx < keysLen; ++idx) {
         let key = keys[idx];
-        let itemInput = scope(input);
+        let itemInput = scope(input$2);
         itemInput.i = inputVar + "[" + idx + "][" + iteratorVar + "]";
         itemInput.s = itemSchema;
         itemInput.e = maybeProperties[key];
         itemInput.v = _notVarBeforeValidation;
         itemInput.ii = false;
         itemInput.io = false;
-        let inlinedLocation = inlineLocation(input.g, key);
+        let inlinedLocation = inlineLocation(input$2.g, key);
         itemInput.path = "[" + inlinedLocation + "]";
         let itemOutput = parse$1(itemInput);
         if (itemOutput.f & 1) {
@@ -3930,13 +3926,13 @@ function compactColumnsDecoder(input) {
         asyncInlines = asyncInlines + (itemOutput.i + ",");
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
-      input.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
-      let output$1 = next(input, outputVar, outputSchema, outputSchema);
+      input$2.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
+      let output$1 = next(input$2, outputVar, outputSchema, outputSchema);
       output$1.v = _var;
       output$1.io = true;
       let rowAssign;
       if (hasAsync) {
-        let rowResultVar = varWithoutAllocation(input.g);
+        let rowResultVar = varWithoutAllocation(input$2.g);
         let asyncBuildCode = "";
         for (let idx$1 = 0; idx$1 < keysLen; ++idx$1) {
           let key$1 = keys[idx$1];
@@ -3951,7 +3947,7 @@ function compactColumnsDecoder(input) {
       if (itemParseCode === "") {
         wrappedBody = rowBody;
       } else {
-        let errorVar = varWithoutAllocation(input.g);
+        let errorVar = varWithoutAllocation(input$2.g);
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
       output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");

--- a/packages/sury/tests/S_noValidation_test.res
+++ b/packages/sury/tests/S_noValidation_test.res
@@ -16,3 +16,31 @@ test("Works for literals", t => {
   t->Assert.deepEqual(1->S.parseOrThrow(schemaWithoutTypeValidation), "foo")
   t->U.assertCompiledCode(~schema=schemaWithoutTypeValidation, ~op=#Parse, `i=>{return "foo"}`)
 })
+
+// KNOWN BUG: `noValidation` on a union case silently breaks dispatch.
+//
+// `literalDecoder` short-circuits when `expectedSchema.noValidation` is set
+// (Sury.res:2001) and emits no check at all — so there's nothing for the
+// union discriminant hoister to lift, and that case becomes a catch-all
+// that swallows every input ahead of subsequent cases.
+//
+// The `noValidation`-bypass comment on `emitValidation` is at the wrong
+// layer to fix this (by the time union codegen runs, the literal's val has
+// no checks to preserve). Proper fix would be for `literalDecoder` to emit
+// its equality check regardless of `noValidation` when the val ends up in
+// a union, or for `S.noValidation` on a literal inside a union to be
+// rejected at schema construction time.
+test("Union dispatch still works when a case has noValidation", t => {
+  let schema = S.union([
+    S.literal("a")->S.noValidation(true),
+    S.literal("b"),
+  ])
+
+  t->Assert.deepEqual("a"->S.parseOrThrow(schema), "a")
+  // BUG: returns "a" instead of "b" — first case becomes catch-all.
+  t->Assert.deepEqual("b"->S.parseOrThrow(schema), "b")
+  t->U.assertThrowsMessage(
+    () => "c"->S.parseOrThrow(schema),
+    `Expected "a" | "b", received "c"`,
+  )
+})

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -67,6 +67,49 @@ test("Coerce from string to bool literal", t => {
   t->U.assertCompiledCode(~schema, ~op=#ReverseConvert, `i=>{i===false||e[0](i);return "false"}`)
 })
 
+// Refinements on a source schema are currently appended to `val.codeFromPrev`
+// in `parse` (Sury.res:2209), and `merge` emits `codeFromPrev ++ validation_code`
+// — which places the refiner BEFORE the type guard. That ordering is observable
+// here: a numeric input fails with the refinement message ("non-empty") instead
+// of "Expected string, received 123", because `(123).length > 0` is false.
+//
+// The FIXME on Sury.res:2048 ("Test, that when from item has a refinement /
+// and we need to keep existing validation / S.string->S.check->S.to(S.literal(false))")
+// was pointing at this exact interaction. All three checks do survive the `.to`
+// coercion — the refiner, the typeof guard, and the stringConstVal equality —
+// but their order is wrong.
+//
+// Once refinements move off `codeFromPrev` and onto `val.validation` as
+// `{kind: Refinement}` checks, type guards will naturally emit first and the
+// error for a numeric input will say "Expected string" as expected. Until
+// then this is marked failing so a future fix surfaces as a passing `.failing`
+// case (which ava reports as a reverse-regression).
+Failing.test(
+  "S.string->S.refine->S.to(S.literal) reports type error before refinement error",
+  t => {
+    let schema =
+      S.string
+      ->S.refine(v => v->String.length > 0, ~error="non-empty")
+      ->S.to(S.literal(false))
+
+    // Golden path: happy case still works.
+    t->Assert.deepEqual("false"->S.parseOrThrow(schema), false)
+
+    // Refinement fires for empty string — currently correct.
+    t->U.assertThrowsMessage(() => ""->S.parseOrThrow(schema), "non-empty")
+
+    // Const check fires for non-matching string — currently correct.
+    t->U.assertThrowsMessage(
+      () => "true"->S.parseOrThrow(schema),
+      `Expected "false", received "true"`,
+    )
+
+    // For a non-string input, the type guard should fire first with "Expected string".
+    // Currently the refiner runs first and fails with its own message — BUG.
+    t->U.assertThrowsMessage(() => 123->S.parseOrThrow(schema), `Expected string, received 123`)
+  },
+)
+
 test("Coerce from string to null literal", t => {
   let schema = S.string->S.to(S.literal(%raw(`null`)))
 

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -67,39 +67,23 @@ test("Coerce from string to bool literal", t => {
   t->U.assertCompiledCode(~schema, ~op=#ReverseConvert, `i=>{i===false||e[0](i);return "false"}`)
 })
 
-// KNOWN BUG: refiner runs before type guard when coercing via `.to`.
-//
-// Refinements on a source schema are appended to `val.codeFromPrev` in
-// `parse` (Sury.res:2209), and `merge` emits `codeFromPrev ++ validation_code`
-// — which places the refiner BEFORE the type guard. A numeric input fails
-// with the refinement message ("non-empty") instead of "Expected string,
-// received 123", because `(123).length > 0` is false and the type guard
-// never gets a chance to run.
-//
-// The FIXME at Sury.res:2048 points at this interaction. All three checks do
-// survive the `.to` coercion (refiner, typeof guard, stringConstVal equality)
-// but their order is wrong. Fix lands when refinements migrate off
-// `codeFromPrev` onto `val.validation` as `{kind: Refinement}` checks.
+// KNOWN BUG: refiner runs before the type guard when coercing via `.to`.
+// `parse` appends refiner code to `codeFromPrev`, and `merge` emits
+// `codeFromPrev ++ validation_code`, so the refiner sees untyped input.
+// Fix lands when refinements migrate off `codeFromPrev` onto `val.validation`.
 test("S.string->S.refine->S.to(S.literal) reports type error before refinement error", t => {
   let schema =
     S.string
     ->S.refine(v => v->String.length > 0, ~error="non-empty")
     ->S.to(S.literal(false))
 
-  // Golden path: happy case still works.
   t->Assert.deepEqual("false"->S.parseOrThrow(schema), false)
-
-  // Refinement fires for empty string — currently correct.
   t->U.assertThrowsMessage(() => ""->S.parseOrThrow(schema), "non-empty")
-
-  // Const check fires for non-matching string — currently correct.
   t->U.assertThrowsMessage(
     () => "true"->S.parseOrThrow(schema),
     `Expected "false", received "true"`,
   )
-
-  // For a non-string input, the type guard should fire first with "Expected string".
-  // Currently the refiner runs first and fails with its own message — BUG.
+  // BUG: currently fails with the refiner's "non-empty" because `(123).length > 0` is false.
   t->U.assertThrowsMessage(() => 123->S.parseOrThrow(schema), `Expected string, received 123`)
 })
 

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -67,48 +67,41 @@ test("Coerce from string to bool literal", t => {
   t->U.assertCompiledCode(~schema, ~op=#ReverseConvert, `i=>{i===false||e[0](i);return "false"}`)
 })
 
-// Refinements on a source schema are currently appended to `val.codeFromPrev`
-// in `parse` (Sury.res:2209), and `merge` emits `codeFromPrev ++ validation_code`
-// — which places the refiner BEFORE the type guard. That ordering is observable
-// here: a numeric input fails with the refinement message ("non-empty") instead
-// of "Expected string, received 123", because `(123).length > 0` is false.
+// KNOWN BUG: refiner runs before type guard when coercing via `.to`.
 //
-// The FIXME on Sury.res:2048 ("Test, that when from item has a refinement /
-// and we need to keep existing validation / S.string->S.check->S.to(S.literal(false))")
-// was pointing at this exact interaction. All three checks do survive the `.to`
-// coercion — the refiner, the typeof guard, and the stringConstVal equality —
-// but their order is wrong.
+// Refinements on a source schema are appended to `val.codeFromPrev` in
+// `parse` (Sury.res:2209), and `merge` emits `codeFromPrev ++ validation_code`
+// — which places the refiner BEFORE the type guard. A numeric input fails
+// with the refinement message ("non-empty") instead of "Expected string,
+// received 123", because `(123).length > 0` is false and the type guard
+// never gets a chance to run.
 //
-// Once refinements move off `codeFromPrev` and onto `val.validation` as
-// `{kind: Refinement}` checks, type guards will naturally emit first and the
-// error for a numeric input will say "Expected string" as expected. Until
-// then this is marked failing so a future fix surfaces as a passing `.failing`
-// case (which ava reports as a reverse-regression).
-Failing.test(
-  "S.string->S.refine->S.to(S.literal) reports type error before refinement error",
-  t => {
-    let schema =
-      S.string
-      ->S.refine(v => v->String.length > 0, ~error="non-empty")
-      ->S.to(S.literal(false))
+// The FIXME at Sury.res:2048 points at this interaction. All three checks do
+// survive the `.to` coercion (refiner, typeof guard, stringConstVal equality)
+// but their order is wrong. Fix lands when refinements migrate off
+// `codeFromPrev` onto `val.validation` as `{kind: Refinement}` checks.
+test("S.string->S.refine->S.to(S.literal) reports type error before refinement error", t => {
+  let schema =
+    S.string
+    ->S.refine(v => v->String.length > 0, ~error="non-empty")
+    ->S.to(S.literal(false))
 
-    // Golden path: happy case still works.
-    t->Assert.deepEqual("false"->S.parseOrThrow(schema), false)
+  // Golden path: happy case still works.
+  t->Assert.deepEqual("false"->S.parseOrThrow(schema), false)
 
-    // Refinement fires for empty string — currently correct.
-    t->U.assertThrowsMessage(() => ""->S.parseOrThrow(schema), "non-empty")
+  // Refinement fires for empty string — currently correct.
+  t->U.assertThrowsMessage(() => ""->S.parseOrThrow(schema), "non-empty")
 
-    // Const check fires for non-matching string — currently correct.
-    t->U.assertThrowsMessage(
-      () => "true"->S.parseOrThrow(schema),
-      `Expected "false", received "true"`,
-    )
+  // Const check fires for non-matching string — currently correct.
+  t->U.assertThrowsMessage(
+    () => "true"->S.parseOrThrow(schema),
+    `Expected "false", received "true"`,
+  )
 
-    // For a non-string input, the type guard should fire first with "Expected string".
-    // Currently the refiner runs first and fails with its own message — BUG.
-    t->U.assertThrowsMessage(() => 123->S.parseOrThrow(schema), `Expected string, received 123`)
-  },
-)
+  // For a non-string input, the type guard should fire first with "Expected string".
+  // Currently the refiner runs first and fails with its own message — BUG.
+  t->U.assertThrowsMessage(() => 123->S.parseOrThrow(schema), `Expected string, received 123`)
+})
 
 test("Coerce from string to null literal", t => {
   let schema = S.string->S.to(S.literal(%raw(`null`)))

--- a/packages/sury/tests/S_union_test.res
+++ b/packages/sury/tests/S_union_test.res
@@ -953,3 +953,16 @@ test("Optional of int32 should keep a format validation", t => {
     `i=>{if(!(typeof i==="number"&&!Number.isNaN(i)&&(i<=2147483647&&i>=-2147483648&&i%1===0)||i===void 0)){e[0](i)}return i}`,
   )
 })
+
+// Tagged tuple union — dispatches on i["0"] === "a" / "b", which is what the
+// `B.hoistChildChecks` helper lifts from each tuple's literal first field
+// into the parent's validation list as union discriminants.
+test("Tagged tuple union dispatches via literal first-field discriminant", t => {
+  let schema = S.union([
+    S.tuple(s => (s.item(0, S.literal("a")), s.item(1, S.string))),
+    S.tuple(s => (s.item(0, S.literal("b")), s.item(1, S.string))),
+  ])
+
+  t->Assert.deepEqual(("a", "hello")->S.parseOrThrow(schema), ("a", "hello"))
+  t->Assert.deepEqual(("b", "world")->S.parseOrThrow(schema), ("b", "world"))
+})


### PR DESCRIPTION
## Summary

This PR refactors the validation system in Sury from storing single validation functions (`val.validation: option<(~inputVar: string) => string>`) to storing arrays of structured checks (`val.checks?: array<check>`). This enables better code generation through check fusion and hoisting for union discriminants.

## Key Changes

- **New `check` type**: Replaces single validation functions with a structured record containing:
  - `cond`: A function that generates the condition code
  - `fail`: A function that generates the error details
  
- **Check fusion optimization**: Adjacent checks sharing the same `fail` function are fused with `&&` operators in a single throw statement, reducing generated code size

- **Union discriminant hoisting**: The new `hoistChildChecks` helper lifts checks from union case literals into the parent's check array, enabling proper dispatch on discriminant conditions

- **Helper functions**:
  - `failInvalidType`: Reusable error handler for type validation failures (stable reference enables check fusion)
  - `emitChecks`: Generates optimized validation code with check fusion
  - `andJoinChecks`: Joins multiple checks with `&&` for union dispatch
  - `pushCheck`: Lazy-allocates and mutates check arrays
  - `hoistChildChecks`: Splices child checks into parent for union dispatch

- **Invariant**: `val.checks` is absent (undefined) iff there are no checks. Never stored as empty array, allowing callers to test presence with `->unsafeToBool` instead of length checks

- **Updated decoders**: All primitive type decoders (number, string, boolean, bigint, symbol, literal, instance) and container decoders (array, object) now use the new check-based validation system

## Notable Implementation Details

- The refactoring preserves the "expected X, received Y" error semantics through the `failInvalidType` helper
- Check conditions capture their input variable at generation time, enabling path rewriting during hoisting
- The compiled output uses minified field names (`vc` for checks, `c` for cond, `f` for fail)
- Known bugs documented in IDEAS.md regarding refinement ordering and `noValidation` on union cases

https://claude.ai/code/session_015beGc8tvCMzpxPbsotAbiv