### PR TITLE
Improve assertNumber validation with NaN checks and better error messages

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -6215,12 +6215,12 @@ let union = Union.factory
 // =============
 
 let assertNumber: 'a => unit = n =>
-  if Js.typeof(n->Obj.magic) !== "number" {
+  if Js.typeof(n->Obj.magic) !== "number" || %raw(`Number.isNaN(n)`) {
     X.Exn.throwAny(
       InternalError.make(
         InvalidOperation({
           path: Path.empty,
-          reason: `Expected number, received ${(Stdlib.Type.typeof(n->Obj.magic) :> string)}`,
+          reason: `Expected number, received ${n->Obj.magic->stringify}`,
         }),
       ),
     )

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -6214,20 +6214,20 @@ let union = Union.factory
 // Built-in refinements
 // =============
 
-let assertNumber: 'a => unit = n =>
+let assertNumber: (string, 'a) => unit = (fnName, n) =>
   if Js.typeof(n->Obj.magic) !== "number" || %raw(`Number.isNaN(n)`) {
     X.Exn.throwAny(
       InternalError.make(
         InvalidOperation({
           path: Path.empty,
-          reason: `Expected number, received ${n->Obj.magic->stringify}`,
+          reason: `[S.${fnName}] Expected number, received ${n->Obj.magic->stringify}`,
         }),
       ),
     )
   }
 
 let intMin = (schema, minValue, ~message as maybeMessage=?) => {
-  assertNumber(minValue)
+  assertNumber("min", minValue)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Number must be greater than or equal to ${minValue->X.Int.unsafeToString}`
@@ -6245,7 +6245,7 @@ let intMin = (schema, minValue, ~message as maybeMessage=?) => {
 }
 
 let intMax = (schema, maxValue, ~message as maybeMessage=?) => {
-  assertNumber(maxValue)
+  assertNumber("max", maxValue)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Number must be lower than or equal to ${maxValue->X.Int.unsafeToString}`
@@ -6280,7 +6280,7 @@ let port = (schema, ~message=?) => {
 }
 
 let floatMin = (schema, minValue, ~message as maybeMessage=?) => {
-  assertNumber(minValue)
+  assertNumber("min", minValue)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Number must be greater than or equal to ${minValue->X.Float.unsafeToString}`
@@ -6298,7 +6298,7 @@ let floatMin = (schema, minValue, ~message as maybeMessage=?) => {
 }
 
 let floatMax = (schema, maxValue, ~message as maybeMessage=?) => {
-  assertNumber(maxValue)
+  assertNumber("max", maxValue)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Number must be lower than or equal to ${maxValue->X.Float.unsafeToString}`
@@ -6316,7 +6316,7 @@ let floatMax = (schema, maxValue, ~message as maybeMessage=?) => {
 }
 
 let arrayMinLength = (schema, length, ~message as maybeMessage=?) => {
-  assertNumber(length)
+  assertNumber("min", length)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Array must be ${length->X.Int.unsafeToString} or more items long`
@@ -6334,7 +6334,7 @@ let arrayMinLength = (schema, length, ~message as maybeMessage=?) => {
 }
 
 let arrayMaxLength = (schema, length, ~message as maybeMessage=?) => {
-  assertNumber(length)
+  assertNumber("max", length)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Array must be ${length->X.Int.unsafeToString} or fewer items long`
@@ -6352,7 +6352,7 @@ let arrayMaxLength = (schema, length, ~message as maybeMessage=?) => {
 }
 
 let arrayLength = (schema, length, ~message as maybeMessage=?) => {
-  assertNumber(length)
+  assertNumber("length", length)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `Array must be exactly ${length->X.Int.unsafeToString} items long`
@@ -6370,7 +6370,7 @@ let arrayLength = (schema, length, ~message as maybeMessage=?) => {
 }
 
 let stringMinLength = (schema, length, ~message as maybeMessage=?) => {
-  assertNumber(length)
+  assertNumber("min", length)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `String must be ${length->X.Int.unsafeToString} or more characters long`
@@ -6388,7 +6388,7 @@ let stringMinLength = (schema, length, ~message as maybeMessage=?) => {
 }
 
 let stringMaxLength = (schema, length, ~message as maybeMessage=?) => {
-  assertNumber(length)
+  assertNumber("max", length)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `String must be ${length->X.Int.unsafeToString} or fewer characters long`
@@ -6406,7 +6406,7 @@ let stringMaxLength = (schema, length, ~message as maybeMessage=?) => {
 }
 
 let stringLength = (schema, length, ~message as maybeMessage=?) => {
-  assertNumber(length)
+  assertNumber("length", length)
   let message = switch maybeMessage {
   | Some(m) => m
   | None => `String must be exactly ${length->X.Int.unsafeToString} characters long`

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -4101,13 +4101,13 @@ function tuple3(v0, v1, v2) {
 }
 
 function assertNumber(n) {
-  if (typeof n === "number") {
+  if (!(typeof n !== "number" || (Number.isNaN(n)))) {
     return;
   }
   throw new SuryError({
     code: "invalid_operation",
     path: "",
-    reason: "Expected number, received " + typeof n
+    reason: "Expected number, received " + stringify(n)
   });
 }
 

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -4100,19 +4100,19 @@ function tuple3(v0, v1, v2) {
   ]);
 }
 
-function assertNumber(n) {
+function assertNumber(fnName, n) {
   if (!(typeof n !== "number" || (Number.isNaN(n)))) {
     return;
   }
   throw new SuryError({
     code: "invalid_operation",
     path: "",
-    reason: "Expected number, received " + stringify(n)
+    reason: "[S." + fnName + "] Expected number, received " + stringify(n)
   });
 }
 
 function intMin(schema, minValue, maybeMessage) {
-  assertNumber(minValue);
+  assertNumber("min", minValue);
   let message = maybeMessage !== undefined ? maybeMessage : "Number must be greater than or equal to " + minValue;
   return addRefinement(schema, metadataId$2, {
     kind: {
@@ -4127,7 +4127,7 @@ function intMin(schema, minValue, maybeMessage) {
 }
 
 function intMax(schema, maxValue, maybeMessage) {
-  assertNumber(maxValue);
+  assertNumber("max", maxValue);
   let message = maybeMessage !== undefined ? maybeMessage : "Number must be lower than or equal to " + maxValue;
   return addRefinement(schema, metadataId$2, {
     kind: {
@@ -4159,7 +4159,7 @@ function port(schema, message) {
 }
 
 function floatMin(schema, minValue, maybeMessage) {
-  assertNumber(minValue);
+  assertNumber("min", minValue);
   let message = maybeMessage !== undefined ? maybeMessage : "Number must be greater than or equal to " + minValue;
   return addRefinement(schema, metadataId$3, {
     kind: {
@@ -4174,7 +4174,7 @@ function floatMin(schema, minValue, maybeMessage) {
 }
 
 function floatMax(schema, maxValue, maybeMessage) {
-  assertNumber(maxValue);
+  assertNumber("max", maxValue);
   let message = maybeMessage !== undefined ? maybeMessage : "Number must be lower than or equal to " + maxValue;
   return addRefinement(schema, metadataId$3, {
     kind: {
@@ -4189,7 +4189,7 @@ function floatMax(schema, maxValue, maybeMessage) {
 }
 
 function arrayMinLength(schema, length, maybeMessage) {
-  assertNumber(length);
+  assertNumber("min", length);
   let message = maybeMessage !== undefined ? maybeMessage : "Array must be " + length + " or more items long";
   return addRefinement(schema, metadataId, {
     kind: {
@@ -4204,7 +4204,7 @@ function arrayMinLength(schema, length, maybeMessage) {
 }
 
 function arrayMaxLength(schema, length, maybeMessage) {
-  assertNumber(length);
+  assertNumber("max", length);
   let message = maybeMessage !== undefined ? maybeMessage : "Array must be " + length + " or fewer items long";
   return addRefinement(schema, metadataId, {
     kind: {
@@ -4219,7 +4219,7 @@ function arrayMaxLength(schema, length, maybeMessage) {
 }
 
 function stringMinLength(schema, length, maybeMessage) {
-  assertNumber(length);
+  assertNumber("min", length);
   let message = maybeMessage !== undefined ? maybeMessage : "String must be " + length + " or more characters long";
   return addRefinement(schema, metadataId$1, {
     kind: {
@@ -4234,7 +4234,7 @@ function stringMinLength(schema, length, maybeMessage) {
 }
 
 function stringMaxLength(schema, length, maybeMessage) {
-  assertNumber(length);
+  assertNumber("max", length);
   let message = maybeMessage !== undefined ? maybeMessage : "String must be " + length + " or fewer characters long";
   return addRefinement(schema, metadataId$1, {
     kind: {
@@ -5143,7 +5143,7 @@ function max(schema, maxValue, maybeMessage) {
 function length(schema, length$1, maybeMessage) {
   switch (schema.type) {
     case "string" :
-      assertNumber(length$1);
+      assertNumber("length", length$1);
       let message = maybeMessage !== undefined ? maybeMessage : "String must be exactly " + length$1 + " characters long";
       return addRefinement(schema, metadataId$1, {
         kind: {
@@ -5156,7 +5156,7 @@ function length(schema, length$1, maybeMessage) {
           f: failCustom(message)
         }]);
     case "array" :
-      assertNumber(length$1);
+      assertNumber("length", length$1);
       let message$1 = maybeMessage !== undefined ? maybeMessage : "Array must be exactly " + length$1 + " items long";
       return addRefinement(schema, metadataId, {
         kind: {

--- a/packages/sury/tests/S_Int_min_test.res
+++ b/packages/sury/tests/S_Int_min_test.res
@@ -41,7 +41,7 @@ test("Returns custom error message", t => {
 test("Throws when called with a non-number value", t => {
   t->U.assertThrowsMessage(
     () => S.int->S.min(%raw(`"abc"`)),
-    `Expected number, received string`,
+    `Expected number, received "abc"`,
   )
 })
 

--- a/packages/sury/tests/S_Int_min_test.res
+++ b/packages/sury/tests/S_Int_min_test.res
@@ -41,7 +41,7 @@ test("Returns custom error message", t => {
 test("Throws when called with a non-number value", t => {
   t->U.assertThrowsMessage(
     () => S.int->S.min(%raw(`"abc"`)),
-    `Expected number, received "abc"`,
+    `[S.min] Expected number, received "abc"`,
   )
 })
 


### PR DESCRIPTION
## Summary
Enhanced the `assertNumber` validation function to detect NaN values and provide more informative error messages that include the function name and actual received value.

## Key Changes
- **Updated `assertNumber` signature**: Now accepts a function name parameter `(string, 'a) => unit` instead of just `'a => unit` to provide context in error messages
- **Added NaN detection**: The validation now checks for `Number.isNaN(n)` in addition to type checking, preventing NaN from being accepted as a valid number
- **Improved error messages**: Error messages now include:
  - The function name that triggered the validation (e.g., `[S.min]`, `[S.max]`, `[S.length]`)
  - The actual received value using `stringify` instead of just the type name
- **Updated all call sites**: All functions that call `assertNumber` now pass the appropriate function name:
  - `intMin`, `intMax` → `"min"`, `"max"`
  - `floatMin`, `floatMax` → `"min"`, `"max"`
  - `arrayMinLength`, `arrayMaxLength`, `arrayLength` → `"min"`, `"max"`, `"length"`
  - `stringMinLength`, `stringMaxLength`, `stringLength` → `"min"`, `"max"`, `"length"`

## Implementation Details
- The NaN check uses `%raw` to access JavaScript's `Number.isNaN()` function
- Error messages now follow the pattern `[S.{fnName}] Expected number, received {value}` for better debugging
- Both ReScript source and compiled JavaScript output have been updated consistently

https://claude.ai/code/session_01GJSLrSZwrGrFuNmncENGde