### PR TITLE
Rename unsupported_conversion to unsupported_decode with improved messaging

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -27,6 +27,9 @@
 - ReScript: `S.null` -> `S.nullAsOption`
 - Updated union conversion logic - it now always performs exhaustive validation
 - Encoding to JSON now strips undefined fields
+- JSON decoder now automatically decodes non-JSON types (e.g. `S.date`, `S.bigint`) to string via their encoder, instead of special-casing each type. Schemas with a string encoder (like `S.date` → `toISOString()`) work with `S.json`/`S.jsonString` out of the box.
+- Renamed error code `unsupported_conversion` → `unsupported_decode` and variant `UnsupportedConversion` → `UnsupportedDecode`
+- Error message for unsupported decode now reads: `"Can't decode X to Y. Use S.to to define a custom decoder"`
 
 ### TS
 

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -266,7 +266,7 @@ export type Error =
       readonly reason: string;
     }
   | {
-      readonly code: "unsupported_conversion";
+      readonly code: "unsupported_decode";
       readonly path: Path;
       readonly message: string;
       readonly reason: string;

--- a/packages/sury/src/S.resi
+++ b/packages/sury/src/S.resi
@@ -263,7 +263,7 @@ and errorDetails =
     })
   // When an operation fails, because it's impossible or called incorrectly
   | @as("invalid_operation") InvalidOperation({path: Path.t, reason: string})
-  // When the value decode between two schemas is not supported
+  // When the value decoding between two schemas is not supported
   | @as("unsupported_decode")
   UnsupportedDecode({
       path: Path.t,

--- a/packages/sury/src/S.resi
+++ b/packages/sury/src/S.resi
@@ -263,9 +263,9 @@ and errorDetails =
     })
   // When an operation fails, because it's impossible or called incorrectly
   | @as("invalid_operation") InvalidOperation({path: Path.t, reason: string})
-  // When the value conversion between two schemas is not supported
-  | @as("unsupported_conversion")
-  UnsupportedConversion({
+  // When the value decode between two schemas is not supported
+  | @as("unsupported_decode")
+  UnsupportedDecode({
       path: Path.t,
       reason: string,
       from: schema<unknown>,

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1786,7 +1786,7 @@ module Builder = {
           to: target->castToPublic,
           reason: `Can't decode ${from->castToPublic->toExpression} to ${target
             ->castToPublic
-            ->toExpression}`,
+            ->toExpression}. Use S.to to transform it to a compatible type`,
           path: b.path,
         }),
       )
@@ -4621,15 +4621,7 @@ let jsonDecoder = (~input) => {
       input.expected = expected
       input->parse
     } catch {
-    | _ =>
-      input->B.throw(
-        UnsupportedDecode({
-          from: input.schema->castToPublic,
-          to: json->castToPublic,
-          reason: `Can't decode ${input.schema->castToPublic->toExpression} to JSON`,
-          path: input.path,
-        }),
-      )
+    | _ => input->B.unsupportedDecode(~from=input.schema, ~target=json)
     }
   }
 }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -4616,9 +4616,8 @@ let jsonDecoder = (~input) => {
     }
   } else {
     try {
-      let attempt = input->B.Val.scope
-      attempt.expected = string
-      attempt->parse
+      input.expected = string
+      input->parse
     } catch {
     | _ =>
       input->B.throw(

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1784,7 +1784,7 @@ module Builder = {
         UnsupportedConversion({
           from: from->castToPublic,
           to: target->castToPublic,
-          reason: `Unsupported conversion from ${from->castToPublic->toExpression} to ${target
+          reason: `Unsupported decode from ${from->castToPublic->toExpression} to ${target
             ->castToPublic
             ->toExpression}`,
           path: b.path,
@@ -4542,9 +4542,6 @@ let jsonDecoder = (~input) => {
     input
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.undefined->Flag.with(TagFlag.nan)) {
     input->B.nextConst(~schema=nullLiteral)
-  } else if inputTagFlag->Flag.unsafeHas(TagFlag.bigint) {
-    // FIXME: Support number here
-    input->inputToString
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.array) {
     let expected = base(arrayTag, ~selfReverse=false)
     expected.items = Some(
@@ -4618,7 +4615,21 @@ let jsonDecoder = (~input) => {
       recursiveDecoder(~input)
     }
   } else {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    try {
+      let attempt = input->B.Val.scope
+      attempt.expected = string
+      attempt->parse
+    } catch {
+    | _ =>
+      input->B.throw(
+        UnsupportedConversion({
+          from: input.schema->castToPublic,
+          to: json->castToPublic,
+          reason: `Can't decode ${input.schema->castToPublic->toExpression} to JSON`,
+          path: input.path,
+        }),
+      )
+    }
   }
 }
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1786,7 +1786,7 @@ module Builder = {
           to: target->castToPublic,
           reason: `Can't decode ${from->castToPublic->toExpression} to ${target
             ->castToPublic
-            ->toExpression}. Use S.to to transform it to a compatible type`,
+            ->toExpression}. Use S.to to define a custom decoder`,
           path: b.path,
         }),
       )

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -4616,7 +4616,9 @@ let jsonDecoder = (~input) => {
     }
   } else {
     try {
-      input.expected = string
+      let expected = string->copySchema
+      expected.to = Some(input.expected)
+      input.expected = expected
       input->parse
     } catch {
     | _ =>

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -642,9 +642,9 @@ and errorDetails =
     })
   // When an operation fails, because it's impossible or called incorrectly
   | @as("invalid_operation") InvalidOperation({path: Path.t, reason: string})
-  // When the value conversion between two schemas is not supported
-  | @as("unsupported_conversion")
-  UnsupportedConversion({
+  // When the value decode between two schemas is not supported
+  | @as("unsupported_decode")
+  UnsupportedDecode({
       path: Path.t,
       reason: string,
       from: schema<unknown>,
@@ -1779,12 +1779,12 @@ module Builder = {
       }
     }
 
-    let unsupportedConversion = (b, ~from: internal, ~target: internal) => {
+    let unsupportedDecode = (b, ~from: internal, ~target: internal) => {
       b->throw(
-        UnsupportedConversion({
+        UnsupportedDecode({
           from: from->castToPublic,
           to: target->castToPublic,
-          reason: `Unsupported decode from ${from->castToPublic->toExpression} to ${target
+          reason: `Can't decode ${from->castToPublic->toExpression} to ${target
             ->castToPublic
             ->toExpression}`,
           path: b.path,
@@ -1854,7 +1854,7 @@ let numberDecoder = Builder.make((~input) => {
     ])
     output
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.number)) {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   } else if input.schema.format !== input.expected.format && input.expected.format === Some(Int32) {
     input->B.refine(
       ~schema=input.expected,
@@ -1907,7 +1907,7 @@ let stringDecoder = Builder.make((~input) => {
   ) {
     input->inputToString
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.string)) {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   } else {
     input
   }
@@ -1940,7 +1940,7 @@ let booleanDecoder = Builder.make((~input) => {
       )};`
     output
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.boolean)) {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   } else {
     input
   }
@@ -1974,7 +1974,7 @@ let bigintDecoder = Builder.make((~input) => {
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.number) {
     input->B.next(`BigInt(${input.inline})`, ~schema=input.expected)
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.bigint)) {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   } else {
     input
   }
@@ -1995,7 +1995,7 @@ let symbolDecoder = Builder.make((~input) => {
       ],
     )
   } else if !(inputTagFlag->Flag.unsafeHas(TagFlag.symbol)) {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   } else {
     input
   }
@@ -2690,7 +2690,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       unknownInput->B.refine(~schema)
     }
   } else {
-    unknownInput->B.unsupportedConversion(~from=unknownInput.schema, ~target=expectedSchema)
+    unknownInput->B.unsupportedDecode(~from=unknownInput.schema, ~target=expectedSchema)
   }
 
   switch expectedSchema.additionalItems->X.Option.getUnsafe {
@@ -2825,7 +2825,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
       unknownInput->B.refine(~schema)
     }
   } else {
-    unknownInput->B.unsupportedConversion(~from=unknownInput.schema, ~target=expectedSchema)
+    unknownInput->B.unsupportedDecode(~from=unknownInput.schema, ~target=expectedSchema)
   }
 
   switch expectedSchema.additionalItems->X.Option.getUnsafe {
@@ -3086,7 +3086,7 @@ let instanceDecoder = Builder.make((~input) => {
   ) {
     input
   } else {
-    input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   }
 })
 
@@ -4623,7 +4623,7 @@ let jsonDecoder = (~input) => {
     } catch {
     | _ =>
       input->B.throw(
-        UnsupportedConversion({
+        UnsupportedDecode({
           from: input.schema->castToPublic,
           to: json->castToPublic,
           reason: `Can't decode ${input.schema->castToPublic->toExpression} to JSON`,
@@ -4689,7 +4689,7 @@ let enableJsonString = {
     } else if tagFlag->Flag.unsafeHas(TagFlag.number->Flag.with(TagFlag.boolean)) {
       `"${const->Obj.magic}"`
     } else {
-      input->B.unsupportedConversion(~from=schema, ~target=input.expected)
+      input->B.unsupportedDecode(~from=schema, ~target=input.expected)
     }
   }
 
@@ -4705,7 +4705,7 @@ let enableJsonString = {
     } else if tagFlag->Flag.unsafeHas(TagFlag.number->Flag.with(TagFlag.boolean)) {
       %raw(`""+$$const`)
     } else {
-      input->B.unsupportedConversion(~from=input.schema, ~target)
+      input->B.unsupportedDecode(~from=input.schema, ~target)
     }
   }
 
@@ -4793,7 +4793,7 @@ let enableJsonString = {
         ~expected=expectedSchema,
       )
     } else {
-      input->B.unsupportedConversion(~from=input.schema, ~target=expectedSchema)
+      input->B.unsupportedDecode(~from=input.schema, ~target=expectedSchema)
     }
   })
 
@@ -4903,7 +4903,7 @@ let date = {
     } else if inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === mut.class {
       input
     } else {
-      input->B.unsupportedConversion(~from=input.schema, ~target=input.expected)
+      input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
     }
   })
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -642,7 +642,7 @@ and errorDetails =
     })
   // When an operation fails, because it's impossible or called incorrectly
   | @as("invalid_operation") InvalidOperation({path: Path.t, reason: string})
-  // When the value decode between two schemas is not supported
+  // When the value decoding between two schemas is not supported
   | @as("unsupported_decode")
   UnsupportedDecode({
       path: Path.t,

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -958,7 +958,7 @@ function mergeWithPathPrepend(val, parent, locationVar, appendSafe) {
 
 function unsupportedDecode(b, from, target) {
   let errorDetails_0 = b.path;
-  let errorDetails_1 = "Can't decode " + toExpression(from) + " to " + toExpression(target);
+  let errorDetails_1 = "Can't decode " + toExpression(from) + " to " + toExpression(target) + ". Use S.to to transform it to a compatible type";
   let errorDetails = {
     code: "unsupported_decode",
     path: errorDetails_0,
@@ -3032,17 +3032,7 @@ function jsonDecoder(input) {
     input.e = expected$2;
     return parse$1(input);
   } catch (exn) {
-    let errorDetails_0 = input.path;
-    let errorDetails_1 = "Can't decode " + toExpression(input.s) + " to JSON";
-    let errorDetails_2 = input.s;
-    let errorDetails = {
-      code: "unsupported_decode",
-      path: errorDetails_0,
-      reason: errorDetails_1,
-      from: errorDetails_2,
-      to: json
-    };
-    throw new SuryError(errorDetails);
+    return unsupportedDecode(input, input.s, json);
   }
 }
 

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3027,9 +3027,8 @@ function jsonDecoder(input) {
     }
   }
   try {
-    let attempt = scope(input);
-    attempt.e = string;
-    return parse$1(attempt);
+    input.e = string;
+    return parse$1(input);
   } catch (exn) {
     let errorDetails_0 = input.path;
     let errorDetails_1 = "Can't decode " + toExpression(input.s) + " to JSON";
@@ -3405,242 +3404,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3739,6 +3502,242 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
     return completeObjectVal(v$2);
   }
   
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -958,7 +958,7 @@ function mergeWithPathPrepend(val, parent, locationVar, appendSafe) {
 
 function unsupportedConversion(b, from, target) {
   let errorDetails_0 = b.path;
-  let errorDetails_1 = "Unsupported conversion from " + toExpression(from) + " to " + toExpression(target);
+  let errorDetails_1 = "Unsupported decode from " + toExpression(from) + " to " + toExpression(target);
   let errorDetails = {
     code: "unsupported_conversion",
     path: errorDetails_0,
@@ -2963,9 +2963,6 @@ function jsonDecoder(input) {
   if (inputTagFlag & 2064) {
     return nextConst(input, nullLiteral, undefined);
   }
-  if (inputTagFlag & 1024) {
-    return inputToString(input);
-  }
   if (inputTagFlag & 128) {
     let expected = base(arrayTag, false);
     expected.items = input.s.items.map(param => json);
@@ -3016,19 +3013,35 @@ function jsonDecoder(input) {
   if (inputTagFlag & 512) {
     return recursiveDecoder(input);
   }
-  if (!(inputTagFlag & 1)) {
-    return unsupportedConversion(input, input.s, input.e);
+  if (inputTagFlag & 1) {
+    let to = input.e.to;
+    let preEncode = to && !input.e.parser;
+    if (preEncode) {
+      input.s = json;
+      return jsonEncoder(input, input.e);
+    } else if (input.e.noValidation) {
+      input.s = json;
+      return input;
+    } else {
+      return recursiveDecoder(input);
+    }
   }
-  let to = input.e.to;
-  let preEncode = to && !input.e.parser;
-  if (preEncode) {
-    input.s = json;
-    return jsonEncoder(input, input.e);
-  } else if (input.e.noValidation) {
-    input.s = json;
-    return input;
-  } else {
-    return recursiveDecoder(input);
+  try {
+    let attempt = scope(input);
+    attempt.e = string;
+    return parse$1(attempt);
+  } catch (exn) {
+    let errorDetails_0 = input.path;
+    let errorDetails_1 = "Can't decode " + toExpression(input.s) + " to JSON";
+    let errorDetails_2 = input.s;
+    let errorDetails = {
+      code: "unsupported_conversion",
+      path: errorDetails_0,
+      reason: errorDetails_1,
+      from: errorDetails_2,
+      to: json
+    };
+    throw new SuryError(errorDetails);
   }
 }
 
@@ -3392,6 +3405,242 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3490,242 +3739,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
     return completeObjectVal(v$2);
   }
   
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3027,7 +3027,9 @@ function jsonDecoder(input) {
     }
   }
   try {
-    input.e = string;
+    let expected$2 = copySchema(string);
+    expected$2.to = input.e;
+    input.e = expected$2;
     return parse$1(input);
   } catch (exn) {
     let errorDetails_0 = input.path;
@@ -3404,6 +3406,242 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3502,242 +3740,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
     return completeObjectVal(v$2);
   }
   
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -958,7 +958,7 @@ function mergeWithPathPrepend(val, parent, locationVar, appendSafe) {
 
 function unsupportedDecode(b, from, target) {
   let errorDetails_0 = b.path;
-  let errorDetails_1 = "Can't decode " + toExpression(from) + " to " + toExpression(target) + ". Use S.to to transform it to a compatible type";
+  let errorDetails_1 = "Can't decode " + toExpression(from) + " to " + toExpression(target) + ". Use S.to to define a custom decoder";
   let errorDetails = {
     code: "unsupported_decode",
     path: errorDetails_0,

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -956,11 +956,11 @@ function mergeWithPathPrepend(val, parent, locationVar, appendSafe) {
   }
 }
 
-function unsupportedConversion(b, from, target) {
+function unsupportedDecode(b, from, target) {
   let errorDetails_0 = b.path;
-  let errorDetails_1 = "Unsupported decode from " + toExpression(from) + " to " + toExpression(target);
+  let errorDetails_1 = "Can't decode " + toExpression(from) + " to " + toExpression(target);
   let errorDetails = {
-    code: "unsupported_conversion",
+    code: "unsupported_decode",
     path: errorDetails_0,
     reason: errorDetails_1,
     from: from,
@@ -1022,7 +1022,7 @@ function numberDecoder(input) {
         return input;
       }
     } else {
-      return unsupportedConversion(input, input.s, input.e);
+      return unsupportedDecode(input, input.s, input.e);
     }
   }
   let outputVar = varWithoutAllocation(input.g);
@@ -1065,7 +1065,7 @@ function stringDecoder(input) {
     } else if (inputTagFlag & 2) {
       return input;
     } else {
-      return unsupportedConversion(input, input.s, input.e);
+      return unsupportedDecode(input, input.s, input.e);
     }
   }
   let $$const = (""+input.s.const);
@@ -1088,7 +1088,7 @@ function booleanDecoder(input) {
     if (inputTagFlag & 8) {
       return input;
     } else {
-      return unsupportedConversion(input, input.s, input.e);
+      return unsupportedDecode(input, input.s, input.e);
     }
   }
   let outputVar = varWithoutAllocation(input.g);
@@ -1116,7 +1116,7 @@ function bigintDecoder(input) {
     } else if (inputTagFlag & 1024) {
       return input;
     } else {
-      return unsupportedConversion(input, input.s, input.e);
+      return unsupportedDecode(input, input.s, input.e);
     }
   }
   let outputVar = varWithoutAllocation(input.g);
@@ -1139,7 +1139,7 @@ function symbolDecoder(input) {
   } else if (inputTagFlag & 32768) {
     return input;
   } else {
-    return unsupportedConversion(input, input.s, input.e);
+    return unsupportedDecode(input, input.s, input.e);
   }
 }
 
@@ -1628,7 +1628,7 @@ function arrayDecoder(unknownInput) {
     }
     input = checks.length > 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
   } else {
-    input = unsupportedConversion(unknownInput, unknownInput.s, expectedSchema);
+    input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
   }
   let itemSchema = expectedSchema.additionalItems;
   if (itemSchema === "strip" || itemSchema === "strict") {
@@ -1725,7 +1725,7 @@ function objectDecoder(unknownInput) {
     }
     input = checks.length > 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
   } else {
-    input = unsupportedConversion(unknownInput, unknownInput.s, expectedSchema);
+    input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
   }
   let itemSchema = expectedSchema.additionalItems;
   let exit = 0;
@@ -1918,7 +1918,7 @@ function instanceDecoder(input) {
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
     return input;
   } else {
-    return unsupportedConversion(input, input.s, input.e);
+    return unsupportedDecode(input, input.s, input.e);
   }
 }
 
@@ -3036,7 +3036,7 @@ function jsonDecoder(input) {
     let errorDetails_1 = "Can't decode " + toExpression(input.s) + " to JSON";
     let errorDetails_2 = input.s;
     let errorDetails = {
-      code: "unsupported_conversion",
+      code: "unsupported_decode",
       path: errorDetails_0,
       reason: errorDetails_1,
       from: errorDetails_2,
@@ -3096,7 +3096,7 @@ function inlineJsonString(input, schema) {
   } else if (tagFlag & 12) {
     return "\"" + $$const + "\"";
   } else {
-    return unsupportedConversion(input, schema, input.e);
+    return unsupportedDecode(input, schema, input.e);
   }
 }
 
@@ -3112,7 +3112,7 @@ function constSchemaToJsonStringConst(input, target) {
   } else if (tagFlag & 12) {
     return (""+$$const);
   } else {
-    return unsupportedConversion(input, input.s, target);
+    return unsupportedDecode(input, input.s, target);
   }
 }
 
@@ -3175,7 +3175,7 @@ function jsonStringDecoder(input) {
     return next(input, "\"\\\"\"+" + input.i + "+\"\\\"\"", expectedSchema, undefined);
   }
   if (!(inputTagFlag & 192)) {
-    return unsupportedConversion(input, input.s, expectedSchema);
+    return unsupportedDecode(input, input.s, expectedSchema);
   }
   let jsonVal = parse$1(refine(input, undefined, undefined, json));
   let v = expectedSchema.space;
@@ -3277,7 +3277,7 @@ mut.decoder = input => {
   } else if (inputTagFlag & 8192 && input.s.class === mut.class) {
     return input;
   } else {
-    return unsupportedConversion(input, input.s, input.e);
+    return unsupportedDecode(input, input.s, input.e);
   }
 };
 

--- a/packages/sury/src/Sury.resi
+++ b/packages/sury/src/Sury.resi
@@ -264,7 +264,7 @@ and errorDetails =
     })
   // When an operation fails, because it's impossible or called incorrectly
   | @as("invalid_operation") InvalidOperation({path: Path.t, reason: string})
-  // When the value decode between two schemas is not supported
+  // When the value decoding between two schemas is not supported
   | @as("unsupported_decode")
   UnsupportedDecode({
       path: Path.t,

--- a/packages/sury/src/Sury.resi
+++ b/packages/sury/src/Sury.resi
@@ -264,9 +264,9 @@ and errorDetails =
     })
   // When an operation fails, because it's impossible or called incorrectly
   | @as("invalid_operation") InvalidOperation({path: Path.t, reason: string})
-  // When the value conversion between two schemas is not supported
-  | @as("unsupported_conversion")
-  UnsupportedConversion({
+  // When the value decode between two schemas is not supported
+  | @as("unsupported_decode")
+  UnsupportedDecode({
       path: Path.t,
       reason: string,
       from: schema<unknown>,

--- a/packages/sury/tests/S_jsonString_test.res
+++ b/packages/sury/tests/S_jsonString_test.res
@@ -206,12 +206,12 @@ test("Parses JSON string to symbol literal", t => {
 
   t->U.assertThrowsMessage(
     () => `true`->S.parseOrThrow(~to=schema),
-    `Can't decode JSON string to Symbol(foo). Use S.to to transform it to a compatible type`,
+    `Can't decode JSON string to Symbol(foo). Use S.to to define a custom decoder`,
   )
 
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.unknown),
-    `Can't decode Symbol(foo) to JSON string. Use S.to to transform it to a compatible type`,
+    `Can't decode Symbol(foo) to JSON string. Use S.to to define a custom decoder`,
   )
 })
 

--- a/packages/sury/tests/S_jsonString_test.res
+++ b/packages/sury/tests/S_jsonString_test.res
@@ -206,12 +206,12 @@ test("Parses JSON string to symbol literal", t => {
 
   t->U.assertThrowsMessage(
     () => `true`->S.parseOrThrow(~to=schema),
-    `Unsupported conversion from JSON string to Symbol(foo)`,
+    `Unsupported decode from JSON string to Symbol(foo)`,
   )
 
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.unknown),
-    `Unsupported conversion from Symbol(foo) to JSON string`,
+    `Unsupported decode from Symbol(foo) to JSON string`,
   )
 })
 

--- a/packages/sury/tests/S_jsonString_test.res
+++ b/packages/sury/tests/S_jsonString_test.res
@@ -206,12 +206,12 @@ test("Parses JSON string to symbol literal", t => {
 
   t->U.assertThrowsMessage(
     () => `true`->S.parseOrThrow(~to=schema),
-    `Unsupported decode from JSON string to Symbol(foo)`,
+    `Can't decode JSON string to Symbol(foo)`,
   )
 
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.unknown),
-    `Unsupported decode from Symbol(foo) to JSON string`,
+    `Can't decode Symbol(foo) to JSON string`,
   )
 })
 

--- a/packages/sury/tests/S_jsonString_test.res
+++ b/packages/sury/tests/S_jsonString_test.res
@@ -206,12 +206,12 @@ test("Parses JSON string to symbol literal", t => {
 
   t->U.assertThrowsMessage(
     () => `true`->S.parseOrThrow(~to=schema),
-    `Can't decode JSON string to Symbol(foo)`,
+    `Can't decode JSON string to Symbol(foo). Use S.to to transform it to a compatible type`,
   )
 
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.unknown),
-    `Can't decode Symbol(foo) to JSON string`,
+    `Can't decode Symbol(foo) to JSON string. Use S.to to transform it to a compatible type`,
   )
 })
 

--- a/packages/sury/tests/S_reverseConvertToJsonWith_test.res
+++ b/packages/sury/tests/S_reverseConvertToJsonWith_test.res
@@ -104,7 +104,7 @@ test("Doesn't allow to convert to JSON array with optional items", t => {
 
   t->U.assertThrowsMessage(
     () => [None]->S.decodeOrThrow(~from=schema, ~to=S.json),
-    "Failed at []: Can't decode boolean | undefined to JSON. Use S.to to transform it to a compatible type",
+    "Failed at []: Can't decode boolean | undefined to JSON. Use S.to to define a custom decoder",
   )
 })
 
@@ -113,7 +113,7 @@ test("Doesn't allow to encode tuple with optional item to JSON", t => {
 
   t->U.assertThrowsMessage(
     () => None->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode boolean | undefined to JSON. Use S.to to transform it to a compatible type`,
+    `Can't decode boolean | undefined to JSON. Use S.to to define a custom decoder`,
   )
 })
 
@@ -122,7 +122,7 @@ test("Allows to convert to JSON with option as dict field", t => {
 
   t->U.assertThrowsMessage(
     () => dict{"foo": None}->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Failed at []: Can't decode boolean | undefined to JSON. Use S.to to transform it to a compatible type`,
+    `Failed at []: Can't decode boolean | undefined to JSON. Use S.to to define a custom decoder`,
   )
 })
 
@@ -136,7 +136,7 @@ test("Fails to encode Function to JSON", t => {
   let schema = S.literal(fn)
   t->U.assertThrowsMessage(
     () => fn->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode Function to JSON. Use S.to to transform it to a compatible type`,
+    `Can't decode Function to JSON. Use S.to to define a custom decoder`,
   )
 })
 
@@ -146,7 +146,7 @@ test("Fails to encode Error literal to JSON", t => {
 
   t->U.assertThrowsMessage(
     () => error->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode [object Error] to JSON. Use S.to to transform it to a compatible type`,
+    `Can't decode [object Error] to JSON. Use S.to to define a custom decoder`,
   )
   t->Assert.is(error->S.decodeOrThrow(~from=schema, ~to=S.unknown), error)
   t->U.assertThrowsMessage(
@@ -160,7 +160,7 @@ test("Fails to encode Symbol to JSON", t => {
   let schema = S.literal(symbol)
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode Symbol() to JSON. Use S.to to transform it to a compatible type`,
+    `Can't decode Symbol() to JSON. Use S.to to define a custom decoder`,
   )
 })
 

--- a/packages/sury/tests/S_reverseConvertToJsonWith_test.res
+++ b/packages/sury/tests/S_reverseConvertToJsonWith_test.res
@@ -104,7 +104,7 @@ test("Doesn't allow to convert to JSON array with optional items", t => {
 
   t->U.assertThrowsMessage(
     () => [None]->S.decodeOrThrow(~from=schema, ~to=S.json),
-    "Failed at []: Unsupported conversion from boolean | undefined to JSON",
+    "Failed at []: Can't decode boolean | undefined to JSON",
   )
 })
 
@@ -113,7 +113,7 @@ test("Doesn't allow to encode tuple with optional item to JSON", t => {
 
   t->U.assertThrowsMessage(
     () => None->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Unsupported conversion from boolean | undefined to JSON`,
+    `Can't decode boolean | undefined to JSON`,
   )
 })
 
@@ -122,7 +122,7 @@ test("Allows to convert to JSON with option as dict field", t => {
 
   t->U.assertThrowsMessage(
     () => dict{"foo": None}->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Failed at []: Unsupported conversion from boolean | undefined to JSON`,
+    `Failed at []: Can't decode boolean | undefined to JSON`,
   )
 })
 
@@ -136,7 +136,7 @@ test("Fails to encode Function to JSON", t => {
   let schema = S.literal(fn)
   t->U.assertThrowsMessage(
     () => fn->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Unsupported conversion from Function to JSON`,
+    `Can't decode Function to JSON`,
   )
 })
 
@@ -146,7 +146,7 @@ test("Fails to encode Error literal to JSON", t => {
 
   t->U.assertThrowsMessage(
     () => error->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Unsupported conversion from [object Error] to JSON`,
+    `Can't decode [object Error] to JSON`,
   )
   t->Assert.is(error->S.decodeOrThrow(~from=schema, ~to=S.unknown), error)
   t->U.assertThrowsMessage(
@@ -160,7 +160,7 @@ test("Fails to encode Symbol to JSON", t => {
   let schema = S.literal(symbol)
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Unsupported conversion from Symbol() to JSON`,
+    `Can't decode Symbol() to JSON`,
   )
 })
 

--- a/packages/sury/tests/S_reverseConvertToJsonWith_test.res
+++ b/packages/sury/tests/S_reverseConvertToJsonWith_test.res
@@ -104,7 +104,7 @@ test("Doesn't allow to convert to JSON array with optional items", t => {
 
   t->U.assertThrowsMessage(
     () => [None]->S.decodeOrThrow(~from=schema, ~to=S.json),
-    "Failed at []: Can't decode boolean | undefined to JSON",
+    "Failed at []: Can't decode boolean | undefined to JSON. Use S.to to transform it to a compatible type",
   )
 })
 
@@ -113,7 +113,7 @@ test("Doesn't allow to encode tuple with optional item to JSON", t => {
 
   t->U.assertThrowsMessage(
     () => None->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode boolean | undefined to JSON`,
+    `Can't decode boolean | undefined to JSON. Use S.to to transform it to a compatible type`,
   )
 })
 
@@ -122,7 +122,7 @@ test("Allows to convert to JSON with option as dict field", t => {
 
   t->U.assertThrowsMessage(
     () => dict{"foo": None}->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Failed at []: Can't decode boolean | undefined to JSON`,
+    `Failed at []: Can't decode boolean | undefined to JSON. Use S.to to transform it to a compatible type`,
   )
 })
 
@@ -136,7 +136,7 @@ test("Fails to encode Function to JSON", t => {
   let schema = S.literal(fn)
   t->U.assertThrowsMessage(
     () => fn->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode Function to JSON`,
+    `Can't decode Function to JSON. Use S.to to transform it to a compatible type`,
   )
 })
 
@@ -146,7 +146,7 @@ test("Fails to encode Error literal to JSON", t => {
 
   t->U.assertThrowsMessage(
     () => error->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode [object Error] to JSON`,
+    `Can't decode [object Error] to JSON. Use S.to to transform it to a compatible type`,
   )
   t->Assert.is(error->S.decodeOrThrow(~from=schema, ~to=S.unknown), error)
   t->U.assertThrowsMessage(
@@ -160,7 +160,7 @@ test("Fails to encode Symbol to JSON", t => {
   let schema = S.literal(symbol)
   t->U.assertThrowsMessage(
     () => symbol->S.decodeOrThrow(~from=schema, ~to=S.json),
-    `Can't decode Symbol() to JSON`,
+    `Can't decode Symbol() to JSON. Use S.to to transform it to a compatible type`,
   )
 })
 

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -2473,7 +2473,7 @@ test("Recursive with self as transform target", (t) => {
       t.deepEqual(S.parser(nodeSchema)(`["[]","[]"]`), [[], []]);
     },
     {
-      message: "Can't decode Node to Node[]. Use S.to to transform it to a compatible type",
+      message: "Can't decode Node to Node[]. Use S.to to define a custom decoder",
     },
   );
 });

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -2473,7 +2473,7 @@ test("Recursive with self as transform target", (t) => {
       t.deepEqual(S.parser(nodeSchema)(`["[]","[]"]`), [[], []]);
     },
     {
-      message: "Can't decode Node to Node[]",
+      message: "Can't decode Node to Node[]. Use S.to to transform it to a compatible type",
     },
   );
 });

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -2601,6 +2601,17 @@ test("Decode from json", async (t) => {
   t.deepEqual(dateToJson({ field: new Date("2024-01-01T00:00:00.000Z") }), {
     field: "2024-01-01T00:00:00.000Z",
   });
+  t.deepEqual(
+    dateToJson.toString(),
+    `i=>{return {"field":i["field"].toISOString(),}}`,
+  );
+
+  // Date fields should work through the full jsonString pipeline
+  const dateToJsonString = S.decoder(dateSchema, S.jsonString);
+  t.deepEqual(
+    dateToJsonString({ field: new Date("2024-01-01T00:00:00.000Z") }),
+    `{"field":"2024-01-01T00:00:00.000Z"}`,
+  );
 });
 
 test("Decode from json string", async (t) => {

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -2473,7 +2473,7 @@ test("Recursive with self as transform target", (t) => {
       t.deepEqual(S.parser(nodeSchema)(`["[]","[]"]`), [[], []]);
     },
     {
-      message: "Unsupported conversion from Node to Node[]",
+      message: "Unsupported decode from Node to Node[]",
     },
   );
 });
@@ -2594,6 +2594,13 @@ test("Decode from json", async (t) => {
 
   t.deepEqual(S.decoder(S.json, schema)("hello"), "hello");
   t.deepEqual(S.decoder(S.json, schema)(null), undefined);
+
+  // Date fields should be encoded to ISO string when decoding to JSON
+  const dateSchema = S.schema({ field: S.date });
+  const dateToJson = S.decoder(dateSchema, S.json);
+  t.deepEqual(dateToJson({ field: new Date("2024-01-01T00:00:00.000Z") }), {
+    field: "2024-01-01T00:00:00.000Z",
+  });
 });
 
 test("Decode from json string", async (t) => {

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -868,7 +868,7 @@ test("Fails to parses async schema", async (t) => {
       typeof result.error.code,
       | "invalid_input"
       | "invalid_operation"
-      | "unsupported_conversion"
+      | "unsupported_decode"
       | "invalid_conversion"
       | "unrecognized_keys"
       | "custom"
@@ -2473,7 +2473,7 @@ test("Recursive with self as transform target", (t) => {
       t.deepEqual(S.parser(nodeSchema)(`["[]","[]"]`), [[], []]);
     },
     {
-      message: "Unsupported decode from Node to Node[]",
+      message: "Can't decode Node to Node[]",
     },
   );
 });

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -476,10 +476,10 @@ test("Coerce from object to string", t => {
 
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.parseOrThrow(~to=schema)
-  }, `Unsupported decode from { foo: string; } to string`)
+  }, `Can't decode { foo: string; } to string`)
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.decodeOrThrow(~from=schema, ~to=S.unknown)
-  }, `Unsupported decode from string to { foo: string; }`)
+  }, `Can't decode string to { foo: string; }`)
 })
 
 test("Coerce from string to JSON and then to bigint", t => {
@@ -695,7 +695,7 @@ test("Coerce from union to bigint", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Unsupported decode from boolean to bigint`,
+- Can't decode boolean to bigint`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)
@@ -766,7 +766,7 @@ test("Coerce from union to bigint and then to string", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Unsupported decode from boolean to bigint`,
+- Can't decode boolean to bigint`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -476,10 +476,10 @@ test("Coerce from object to string", t => {
 
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.parseOrThrow(~to=schema)
-  }, `Unsupported conversion from { foo: string; } to string`)
+  }, `Unsupported decode from { foo: string; } to string`)
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.decodeOrThrow(~from=schema, ~to=S.unknown)
-  }, `Unsupported conversion from string to { foo: string; }`)
+  }, `Unsupported decode from string to { foo: string; }`)
 })
 
 test("Coerce from string to JSON and then to bigint", t => {
@@ -695,7 +695,7 @@ test("Coerce from union to bigint", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Unsupported conversion from boolean to bigint`,
+- Unsupported decode from boolean to bigint`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)
@@ -766,7 +766,7 @@ test("Coerce from union to bigint and then to string", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Unsupported conversion from boolean to bigint`,
+- Unsupported decode from boolean to bigint`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -476,10 +476,10 @@ test("Coerce from object to string", t => {
 
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.parseOrThrow(~to=schema)
-  }, `Can't decode { foo: string; } to string. Use S.to to transform it to a compatible type`)
+  }, `Can't decode { foo: string; } to string. Use S.to to define a custom decoder`)
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.decodeOrThrow(~from=schema, ~to=S.unknown)
-  }, `Can't decode string to { foo: string; }. Use S.to to transform it to a compatible type`)
+  }, `Can't decode string to { foo: string; }. Use S.to to define a custom decoder`)
 })
 
 test("Coerce from string to JSON and then to bigint", t => {
@@ -695,7 +695,7 @@ test("Coerce from union to bigint", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Can't decode boolean to bigint. Use S.to to transform it to a compatible type`,
+- Can't decode boolean to bigint. Use S.to to define a custom decoder`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)
@@ -766,7 +766,7 @@ test("Coerce from union to bigint and then to string", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Can't decode boolean to bigint. Use S.to to transform it to a compatible type`,
+- Can't decode boolean to bigint. Use S.to to define a custom decoder`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -476,10 +476,10 @@ test("Coerce from object to string", t => {
 
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.parseOrThrow(~to=schema)
-  }, `Can't decode { foo: string; } to string`)
+  }, `Can't decode { foo: string; } to string. Use S.to to transform it to a compatible type`)
   t->U.assertThrowsMessage(() => {
     %raw(`{"foo": "bar"}`)->S.decodeOrThrow(~from=schema, ~to=S.unknown)
-  }, `Can't decode string to { foo: string; }`)
+  }, `Can't decode string to { foo: string; }. Use S.to to transform it to a compatible type`)
 })
 
 test("Coerce from string to JSON and then to bigint", t => {
@@ -695,7 +695,7 @@ test("Coerce from union to bigint", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Can't decode boolean to bigint`,
+- Can't decode boolean to bigint. Use S.to to transform it to a compatible type`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)
@@ -766,7 +766,7 @@ test("Coerce from union to bigint and then to string", t => {
       true->S.parseOrThrow(~to=schema)
     },
     `Expected string | number | boolean, received true
-- Can't decode boolean to bigint`,
+- Can't decode boolean to bigint. Use S.to to transform it to a compatible type`,
   )
   t->U.assertThrowsMessage(() => {
     123n->S.parseOrThrow(~to=schema)


### PR DESCRIPTION
## Summary
This PR renames the `unsupported_conversion` error code to `unsupported_decode` and improves the error message to be more helpful by suggesting the use of `S.to` for custom decoders.

## Key Changes

- **Error code rename**: Changed `unsupported_conversion` to `unsupported_decode` throughout the codebase to better reflect that the error occurs during decoding operations
- **Improved error messages**: Updated error message from `"Unsupported conversion from X to Y"` to `"Can't decode X to Y. Use S.to to define a custom decoder"` to provide actionable guidance
- **JSON decoder enhancement**: Modified the `jsonDecoder` to automatically handle non-JSON types (like `S.date`, `S.bigint`) by attempting to parse them as strings with a fallback to the unsupported_decode error
- **Code reorganization**: Reordered several function definitions (`traverseDefinition`, `shapedSerializer`, `getShapedSerializerOutput`, `definitionToSchema`) for better logical grouping without changing functionality
- **Test updates**: Updated all test assertions to reflect the new error code and message format

## Implementation Details

The JSON decoder now includes a try-catch block that attempts to coerce non-JSON types to strings before decoding, enabling seamless conversion of types like dates and bigints when decoding to JSON format. This provides better interoperability while maintaining clear error messages when conversions are genuinely unsupported.

https://claude.ai/code/session_019k2RRqbaYzaLzjH3m9BiRE