### PR TITLE
Support custom type error messages via S.meta errorMessage

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1348,14 +1348,27 @@ module Builder = {
       let received = input.schema->castToPublic
       let path = input.path
       let expected = input.expected
-      value =>
-        makeInvalidInputDetails(
-          ~expected,
-          ~received,
-          ~path,
-          ~input=value,
-          ~includeInput=true,
-        )
+      let override = switch expected.errorMessage {
+      | Some(em) =>
+        let d: dict<string> = em->Obj.magic
+        switch d->X.Dict.getUnsafeOption("type") {
+        | Some(m) => Some(m)
+        | None => d->X.Dict.getUnsafeOption("_")
+        }
+      | None => None
+      }
+      switch override {
+      | Some(m) => _value => Custom({reason: m, path})
+      | None =>
+        value =>
+          makeInvalidInputDetails(
+            ~expected,
+            ~received,
+            ~path,
+            ~input=value,
+            ~includeInput=true,
+          )
+      }
     }
 
 

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -613,7 +613,23 @@ function failInvalidType(input) {
   let received = input.s;
   let path = input.path;
   let expected = input.e;
-  return value => makeInvalidInputDetails(expected, received, path, value, true, undefined);
+  let em = expected.errorMessage;
+  let override;
+  if (em !== undefined) {
+    let m = em["type"];
+    override = m !== undefined ? m : em["_"];
+  } else {
+    override = undefined;
+  }
+  if (override !== undefined) {
+    return _value => ({
+      code: "custom",
+      path: path,
+      reason: override
+    });
+  } else {
+    return value => makeInvalidInputDetails(expected, received, path, value, true, undefined);
+  }
 }
 
 function failWithErrorMessage(key, defaultMessage) {
@@ -3450,62 +3466,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3606,18 +3566,70 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
     }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function traverseDefinition(definition, onNode) {
@@ -3662,14 +3674,13 @@ function traverseDefinition(definition, onNode) {
   return mut$2;
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
 }
 
 function nested(fieldName) {
@@ -3738,13 +3749,18 @@ function nested(fieldName) {
   return ctx$1;
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
     }
-    
-  });
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function getShapedParserOutput(input, targetSchema) {
@@ -3786,6 +3802,12 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
+}
+
 function shapedParser(input) {
   let flattened = input.e.flattened;
   if (flattened !== undefined) {
@@ -3807,12 +3829,6 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return output;
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/tests/S_meta_errorMessage_test.res
+++ b/packages/sury/tests/S_meta_errorMessage_test.res
@@ -68,6 +68,24 @@ test("Override pattern message via S.meta", t => {
   t->U.assertThrowsMessage(() => "abc"->S.parseOrThrow(~to=schema), `Override`)
 })
 
+test("Override type error message via S.meta on S.string", t => {
+  let schema = S.string->S.meta({errorMessage: {type_: "Must be a string"}})
+
+  t->U.assertThrowsMessage(() => 123->S.parseOrThrow(~to=schema), `Must be a string`)
+})
+
+test("Override type error message via S.meta on S.int", t => {
+  let schema = S.int->S.meta({errorMessage: {type_: "Must be an integer"}})
+
+  t->U.assertThrowsMessage(() => "abc"->S.parseOrThrow(~to=schema), `Must be an integer`)
+})
+
+test("Catch-all _ is used for type error when no specific type_ is set", t => {
+  let schema = S.string->S.meta({errorMessage: {catchAll: "Bad value"}})
+
+  t->U.assertThrowsMessage(() => 123->S.parseOrThrow(~to=schema), `Bad value`)
+})
+
 test("S.meta does not mutate the original schema", t => {
   let original = S.string->S.min(1)
   let _ = original->S.meta({errorMessage: {minLength: "Custom"}})


### PR DESCRIPTION
## Summary
This PR adds support for overriding type validation error messages through the `S.meta` function's `errorMessage` configuration. When a type validation fails, the schema can now use a custom error message specified via `errorMessage.type_` or fall back to `errorMessage._` (catch-all).

## Key Changes
- **Enhanced `failInvalidType` function**: Modified to check for custom error messages in the schema's `errorMessage` metadata. If a `type_` or catch-all `_` message is defined, it returns a custom error response instead of the default type mismatch details.
- **Code reorganization**: Reordered several function definitions in the compiled output for better logical grouping (moved `prepareShapedSerializerAcc`, `shapedSerializer`, `definitionToSchema`, and `getValByFrom` to more appropriate locations).
- **Test coverage**: Added three new test cases validating:
  - Custom type error messages on `S.string`
  - Custom type error messages on `S.int`
  - Fallback to catch-all `_` message when `type_` is not specified

## Implementation Details
- The override logic checks `expected.errorMessage` for a `type_` property first, then falls back to `_` (catch-all)
- When an override is found, the error response uses the custom `reason` string with the validation path
- When no override exists, the original `makeInvalidInputDetails` behavior is preserved
- The implementation maintains backward compatibility - schemas without custom error messages work exactly as before

https://claude.ai/code/session_01UvZ27AQNJ8sKHtzEgKJzMk