### PR TITLE
Remove unnecessary reverse call in error message generation

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5604,7 +5604,7 @@ module Schema = {
           }
           input->B.invalidOperation(
             ~description={
-              `Missing input for ${targetSchema->reverse->castToPublic->toExpression}` ++
+              `Missing input for ${targetSchema->castToPublic->toExpression}` ++
               switch path {
               | "" => ""
               | _ => ` at ${path}`

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3676,7 +3676,7 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
       let from = targetSchema.from;
       let path$1 = from !== undefined ? path + from.map(item => "[\"" + item + "\"]").join("") : path;
       let tmp$2 = path$1 === "" ? "" : " at " + path$1;
-      invalidOperation(input, "Missing input for " + toExpression(reverse(targetSchema)) + tmp$2);
+      invalidOperation(input, "Missing input for " + toExpression(targetSchema) + tmp$2);
     }
     return completeObjectVal(v$2);
   }


### PR DESCRIPTION
## Summary
Removed an unnecessary `reverse` function call when generating error messages for missing input in the schema validation logic.

## Key Changes
- Removed `->reverse` from the targetSchema expression in the error message for missing input
- The error message now directly calls `castToPublic->toExpression` on targetSchema without the intermediate reverse operation
- Updated both the ReScript source file and its compiled JavaScript output

## Implementation Details
The `reverse` call appeared to be redundant in this context. The error message generation for missing input now directly converts the targetSchema to its public expression representation without the unnecessary transformation step. This simplifies the code while maintaining the same error reporting functionality.

https://claude.ai/code/session_01ARzqrRDCKosCbo2QiiVHjr