### PR TITLE
Fix recursive schema reuse in transform chains

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3170,6 +3170,9 @@ let recursiveDecoder = Builder.make((~input) => {
 
   output.prev = None
   output.codeFromPrev = output->B.mergeWithPathPrepend(~parent=input)
+  // Restore allocate after merge deleted it, since this val may be reused as
+  // input to a subsequent parser (e.g. S.transform on a recursive schema).
+  output.allocate = B.initialAllocate
   output.prev = Some(input)
 
   output

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1953,6 +1953,7 @@ function recursiveDecoder(input) {
   }
   output.prev = undefined;
   output.cp = mergeWithPathPrepend(output, input, undefined, undefined);
+  output.a = initialAllocate;
   output.prev = input;
   return output;
 }

--- a/packages/sury/tests/S_recursive_test.res
+++ b/packages/sury/tests/S_recursive_test.res
@@ -439,7 +439,7 @@ test("Shallowly transforms object when added transform to the S.recursive result
     ~schema=nodeSchema,
     ~op=#Parse,
     `i=>{let v0;v0=e[0](i);let v1;try{v1=e[1](v0)}catch(x){e[2](x)}return v1}
-  Node: i=>{typeof i==="object"&&i||e[3](i);let v0=i["Id"],v1=i["Children"];typeof v0==="string"||e[0](v0);Array.isArray(v1)||e[2](v1);let v5=new Array(v1.length);for(let v2=0;v2<v1.length;++v2){try{let v3;v3=e[1]["unknown->Node--0"](v1[v2]);v5[v2]=v3}catch(v4){v4.path="[\\"Children\\"]"+'["'+v2+'"]'+v4.path;throw v4}}return {"id":v0,"children":v5,}}`,
+Node: i=>{typeof i==="object"&&i||e[3](i);let v0=i["Id"],v1=i["Children"];typeof v0==="string"||e[0](v0);Array.isArray(v1)||e[2](v1);let v5=new Array(v1.length);for(let v2=0;v2<v1.length;++v2){try{let v3;v3=e[1]["unknown->Node--0"](v1[v2]);v5[v2]=v3}catch(v4){v4.path="[\\"Children\\"]"+'["'+v2+'"]'+v4.path;throw v4}}return {"id":v0,"children":v5,}}`,
   )
   t->U.assertCompiledCode(
     ~schema=nodeSchema,

--- a/packages/sury/tests/S_recursive_test.res
+++ b/packages/sury/tests/S_recursive_test.res
@@ -444,8 +444,8 @@ Node: i=>{typeof i==="object"&&i||e[3](i);let v0=i["Id"],v1=i["Children"];typeof
   t->U.assertCompiledCode(
     ~schema=nodeSchema,
     ~op=#ReverseConvert,
-    `i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}let v1;v1=e[2](v0);return v1}
-Node: i=>{let v0=i["children"],v5=new Array(v0.length);for(let v1=0;v1<v0.length;++v1){let v4;try{let v3=e[0][0](v0[v1]);v4=v3}catch(v2){if(v2&&v2.s===s){v2.path="[\\"children\\"]"+'["'+v1+'"]'+v2.path}throw v2}v5[v1]=v4}return {"Id":i["id"],"Children":v5,}}`,
+    ~embedded=[],
+    `i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}let v1;v1=e[2](v0);return v1}`,
   )
 })
 

--- a/packages/sury/tests/S_recursive_test.res
+++ b/packages/sury/tests/S_recursive_test.res
@@ -441,11 +441,15 @@ test("Shallowly transforms object when added transform to the S.recursive result
     `i=>{let v0;v0=e[0](i);let v1;try{v1=e[1](v0)}catch(x){e[2](x)}return v1}
 Node: i=>{typeof i==="object"&&i||e[3](i);let v0=i["Id"],v1=i["Children"];typeof v0==="string"||e[0](v0);Array.isArray(v1)||e[2](v1);let v5=new Array(v1.length);for(let v2=0;v2<v1.length;++v2){try{let v3;v3=e[1]["unknown->Node--0"](v1[v2]);v5[v2]=v3}catch(v4){v4.path="[\\"Children\\"]"+'["'+v2+'"]'+v4.path;throw v4}}return {"id":v0,"children":v5,}}`,
   )
+  let reversedDefs =
+    ((nodeSchema->S.reverse->S.untag).to->Option.getUnsafe->S.untag).defs->Option.getUnsafe
+  let recKey = `${(S.unknown->S.untag).seq->Float.toString}-${(reversedDefs->Dict.getUnsafe("Node")->S.untag).seq->Float.toString}--0`
   t->U.assertCompiledCode(
     ~schema=nodeSchema,
     ~op=#ReverseConvert,
-    ~embedded=[],
-    `i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}let v1;v1=e[2](v0);return v1}`,
+    ~embedded=[("Node", 2)],
+    `i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}let v1;v1=e[2](v0);return v1}
+Node: i=>{typeof i==="object"&&i||e[3](i);let v0=i["id"],v1=i["children"];typeof v0==="string"||e[0](v0);Array.isArray(v1)||e[2](v1);let v5=new Array(v1.length);for(let v2=0;v2<v1.length;++v2){try{let v3;v3=e[1]["${recKey}"](v1[v2]);v5[v2]=v3}catch(v4){v4.path="[\\"children\\"]"+'["'+v2+'"]'+v4.path;throw v4}}return {"Id":v0,"Children":v5,}}`,
   )
 })
 


### PR DESCRIPTION
## Summary
Fixes an issue where recursive schemas could not be properly reused as input to subsequent parsers (e.g., when wrapped with `S.transform`). The problem was that the allocate state was being deleted during code merging and not restored for potential reuse.

## Key Changes
- **Sury.res**: Restore the `allocate` field to its initial state after merging code in `recursiveDecoder`. This ensures the output can be safely used as input to subsequent parsers while maintaining the correct code generation path.
- **Sury.res.mjs**: Apply the same fix to the compiled JavaScript output, restoring `output.a` (allocate) to `initialAllocate` after the merge operation.
- **Test updates**: Updated `S_recursive_test.res` to verify the fix works correctly:
  - Added computation of the recursive key for proper code generation
  - Updated the `ReverseConvert` operation test to include embedded schema references
  - Verified that the generated code correctly handles the recursive transformation chain

## Implementation Details
The fix ensures that after a recursive decoder's code is merged with path prepending, the allocate state is explicitly restored. This allows the recursive schema output to be properly reused in transformation chains without breaking code generation for subsequent operations.

https://claude.ai/code/session_011o78ugN3wrSs59TQiCHQtK