### PR TITLE
Implement three-tier union dispatch algorithm for source-to-target matching

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -41,6 +41,8 @@
 
 When compiling `source -> targetUnion` (via `S.to` or reversal), matching uses a three-tier algorithm based on the source's derived tag. The derived tag is the tag at compile time, which may be narrower than the tag set at schema creation (upstream transformations can narrow it). When the source is itself a union, the algorithm is applied independently for each source variant.
 
+When the source is `unknown` (no derived tag), the matching logic is ignored: the tag-based tiers do not apply, and target variants are attempted directly in target-union order at runtime.
+
 1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: target variants with a matching `const`/`format` (string literals, `Int32`, etc.) are attempted first in target-union order, then remaining catch-all same-tag variants in target-union order. Variants with a different tag are never tried from here — if all branches in the group fail, the match errors.
 2. **Nullish bridge.** Applied only when tier 1's group is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant if present, exclusively.
 3. **Fallback.** Applied only when tiers 1 and 2 are both empty. Attempt to build a decoder for every target variant in target-union order. This is where cross-type coercions live: `number`/`bigint` → `string` via `""+i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-const matches like `"null" → null`, etc.

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,7 +3,7 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 13 failing tests
+# Total: 11 failing tests
 
   ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
@@ -13,8 +13,6 @@
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union (with an item transformed to) Should apply refinement after the item transformation
-  ✘ [fail]: S_to_test.res › Coerce from union to wider union should keep the original value type
   ✘ [fail]: S_to_test.res › Coerce string to custom JSON schema I don't know what we expect here, but currently it works this way
-  ✘ [fail]: S_to_test.res › Transform from union to wider union with different items order (applies decoder to both one at a time)
   ✘ [fail]: S_union_test.res › Compiled serialize code snapshot of crazy union
   ✘ [fail]: S_union_test.res › Serializes when second struct misses serializer

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3639,26 +3639,27 @@ module Union = {
         )
       ) {
         let sourceKey = toKey(input.schema)
-        let bridge = ref("")
-        let needNullBridge = initialInputTagFlag->Flag.unsafeHas(TagFlag.undefined)
-        let needUndefinedBridge = initialInputTagFlag->Flag.unsafeHas(TagFlag.null)
+        let hasNull = ref(false)
+        let hasUndefined = ref(false)
         let len = schemas->Js.Array2.length
         let i = ref(0)
         while activeKey.contents === "" && i.contents < len {
           let s = schemas->Js.Array2.unsafe_get(i.contents)
           if toKey(s) === sourceKey {
             activeKey := sourceKey
-          } else if bridge.contents === "" {
-            if needNullBridge && s.tag === nullTag {
-              bridge := (nullTag :> string)
-            } else if needUndefinedBridge && s.tag === undefinedTag {
-              bridge := (undefinedTag :> string)
-            }
+          } else if s.tag === nullTag {
+            hasNull := true
+          } else if s.tag === undefinedTag {
+            hasUndefined := true
           }
           i := i.contents + 1
         }
         if activeKey.contents === "" {
-          activeKey := bridge.contents
+          if initialInputTagFlag->Flag.unsafeHas(TagFlag.undefined) && hasNull.contents {
+            activeKey := (nullTag :> string)
+          } else if initialInputTagFlag->Flag.unsafeHas(TagFlag.null) && hasUndefined.contents {
+            activeKey := (undefinedTag :> string)
+          }
         }
       }
       let activeKey = activeKey.contents

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3568,6 +3568,11 @@ module Union = {
   @unboxed
   type itemCode = Single(string) | Multiple(array<string>)
 
+  let toKey = (schema: internal): string =>
+    schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.instance)
+      ? (schema.class->Obj.magic)["name"]
+      : (schema.tag :> string)
+
   let isPriority = (tagFlag, byKey: dict<array<unknown>>) => {
     (tagFlag->Flag.unsafeHas(TagFlag.array->Flag.with(TagFlag.instance)) &&
       byKey->Stdlib.Dict.has((objectTag: tag :> string))) ||
@@ -3624,6 +3629,39 @@ module Union = {
       ) {
         input.schema = unknown
       }
+
+      let activeKey = ref("")
+      if (
+        !(
+          initialInputTagFlag->Flag.unsafeHas(
+            TagFlag.union->Flag.with(TagFlag.ref)->Flag.with(TagFlag.unknown),
+          )
+        )
+      ) {
+        let sourceKey = toKey(input.schema)
+        let bridge = ref("")
+        let needNullBridge = initialInputTagFlag->Flag.unsafeHas(TagFlag.undefined)
+        let needUndefinedBridge = initialInputTagFlag->Flag.unsafeHas(TagFlag.null)
+        let len = schemas->Js.Array2.length
+        let i = ref(0)
+        while activeKey.contents === "" && i.contents < len {
+          let s = schemas->Js.Array2.unsafe_get(i.contents)
+          if toKey(s) === sourceKey {
+            activeKey := sourceKey
+          } else if bridge.contents === "" {
+            if needNullBridge && s.tag === nullTag {
+              bridge := (nullTag :> string)
+            } else if needUndefinedBridge && s.tag === undefinedTag {
+              bridge := (undefinedTag :> string)
+            }
+          }
+          i := i.contents + 1
+        }
+        if activeKey.contents === "" {
+          activeKey := bridge.contents
+        }
+      }
+      let activeKey = activeKey.contents
 
       let initialInline = input.inline
 
@@ -3868,12 +3906,12 @@ module Union = {
         updatedSchemas->Js.Array2.push(schema)->ignore
         let tag = schema.tag
         let tagFlag = TagFlag.get(tag)
-        let key =
-          tagFlag->Flag.unsafeHas(TagFlag.instance)
-            ? (schema.class->Obj.magic)["name"]
-            : (tag :> string)
+        let key = toKey(schema)
 
-        if (
+        if activeKey !== "" && activeKey !== key {
+          // not in active tier — skip
+          ()
+        } else if (
           tagFlag->Flag.unsafeHas(TagFlag.undefined) &&
             selfSchema->Obj.magic->Stdlib.Dict.has("fromDefault")
         ) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2272,6 +2272,14 @@ function factory(item) {
   return mut;
 }
 
+function toKey(schema) {
+  if (flags[schema.type] & 8192) {
+    return schema.class.name;
+  } else {
+    return schema.type;
+  }
+}
+
 function isPriority(tagFlag, byKey) {
   if (tagFlag & 8320 && objectTag in byKey) {
     return true;
@@ -2311,6 +2319,34 @@ function unionDecoder(input) {
   if (input.s.encoder === undefined && initialInputTagFlag & 768) {
     input.s = unknown;
   }
+  let activeKey = "";
+  if (!(initialInputTagFlag & 769)) {
+    let sourceKey = toKey(input.s);
+    let bridge = "";
+    let needNullBridge = initialInputTagFlag & 16;
+    let needUndefinedBridge = initialInputTagFlag & 32;
+    let len = schemas.length;
+    let i = 0;
+    while (activeKey === "" && i < len) {
+      let s = schemas[i];
+      if (toKey(s) === sourceKey) {
+        activeKey = sourceKey;
+      } else if (bridge === "") {
+        if (needNullBridge && s.type === nullTag) {
+          bridge = nullTag;
+        } else if (needUndefinedBridge && s.type === undefinedTag) {
+          bridge = undefinedTag;
+        }
+        
+      }
+      i = i + 1 | 0;
+    };
+    if (activeKey === "") {
+      activeKey = bridge;
+    }
+    
+  }
+  let activeKey$1 = activeKey;
   let initialInline = input.i;
   let fail = caught => embed(input, function () {
     let args = arguments;
@@ -2487,8 +2523,8 @@ function unionDecoder(input) {
     updatedSchemas.push(schema);
     let tag = schema.type;
     let tagFlag = flags[tag];
-    let key = tagFlag & 8192 ? schema.class.name : tag;
-    if (!(tagFlag & 16 && "fromDefault" in selfSchema)) {
+    let key = toKey(schema);
+    if ((activeKey$1 === "" || activeKey$1 === key) && !(tagFlag & 16 && "fromDefault" in selfSchema)) {
       let initialArr = byKey[key];
       if (initialArr !== undefined) {
         if (tagFlag & 64 && nestedLoc in schema.properties) {
@@ -3438,60 +3474,79 @@ function traverseDefinition(definition, onNode) {
   return mut$2;
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
     }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
+    
+  });
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
     }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3594,103 +3649,60 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
     }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
     }
-    
-  });
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
+    accAtFrom.val = input;
+    return;
   }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function getShapedParserOutput(input, targetSchema) {
@@ -3732,6 +3744,36 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
+}
+
 function shapedParser(input) {
   let flattened = input.e.flattened;
   if (flattened !== undefined) {
@@ -3753,12 +3795,6 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return output;
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2322,27 +2322,28 @@ function unionDecoder(input) {
   let activeKey = "";
   if (!(initialInputTagFlag & 769)) {
     let sourceKey = toKey(input.s);
-    let bridge = "";
-    let needNullBridge = initialInputTagFlag & 16;
-    let needUndefinedBridge = initialInputTagFlag & 32;
+    let hasNull = false;
+    let hasUndefined = false;
     let len = schemas.length;
     let i = 0;
     while (activeKey === "" && i < len) {
       let s = schemas[i];
       if (toKey(s) === sourceKey) {
         activeKey = sourceKey;
-      } else if (bridge === "") {
-        if (needNullBridge && s.type === nullTag) {
-          bridge = nullTag;
-        } else if (needUndefinedBridge && s.type === undefinedTag) {
-          bridge = undefinedTag;
-        }
-        
+      } else if (s.type === nullTag) {
+        hasNull = true;
+      } else if (s.type === undefinedTag) {
+        hasUndefined = true;
       }
       i = i + 1 | 0;
     };
     if (activeKey === "") {
-      activeKey = bridge;
+      if (initialInputTagFlag & 16 && hasNull) {
+        activeKey = nullTag;
+      } else if (initialInputTagFlag & 32 && hasUndefined) {
+        activeKey = undefinedTag;
+      }
+      
     }
     
   }
@@ -3432,121 +3433,60 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = "~" + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
-        throw new Error("[Sury] " + message);
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
       }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
       }
-      return result;
+    } else {
+      accAtFrom = acc;
     }
-    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
-    throw new Error("[Sury] " + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3649,60 +3589,145 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
     }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
     }
-    accAtFrom.val = input;
-    return;
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
   }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
   }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
   }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = "~" + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error("[Sury] " + ("The field " + inlinedLocation + " defined twice"));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = factory$2(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = "Unsupported nested flatten for transformed object schema " + toExpression(schema);
+        throw new Error("[Sury] " + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = "Can't flatten " + toExpression(schema) + " schema";
+    throw new Error("[Sury] " + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
 }
 
 function getShapedParserOutput(input, targetSchema) {
@@ -3744,36 +3769,6 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
-}
-
 function shapedParser(input) {
   let flattened = input.e.flattened;
   if (flattened !== undefined) {
@@ -3795,6 +3790,12 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return output;
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -894,3 +894,71 @@ test("Tier 3: no source-tag match — coercion fallback retained", t => {
     `i=>{typeof i==="boolean"||e[2](i);try{i=""+i}catch(e0){try{throw e[0]}catch(e1){e[1](i,e0,e1)}}return i}`,
   )
 })
+
+test("Tier 2: nullish bridge — undefined source uses opposite null target when no undefined target", t => {
+  let schema =
+    S.unit->S.to(
+      S.union([S.string->S.castToUnknown, S.literal(%raw(`null`))->S.castToUnknown]),
+    )
+
+  // undefined bridges to null. The string variant is never compiled into the dispatch.
+  t->Assert.deepEqual(()->S.parseOrThrow(~to=schema), %raw(`null`))
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Expected undefined, received "hello"`,
+  )
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{i===void 0||e[1](i);try{i=null}catch(e1){e[0](i,e1)}return i}`,
+  )
+})
+
+test("Tier 1 instance: same class wins, other instance branch never compiled", t => {
+  let schema =
+    S.instance(%raw(`Set`))->S.to(
+      S.union([
+        S.instance(%raw(`Map`))->Obj.magic,
+        S.instance(%raw(`Set`))->Obj.magic,
+      ]),
+    )
+
+  t->Assert.deepEqual(
+    %raw(`new Set(["a"])`)->S.parseOrThrow(~to=schema),
+    %raw(`new Set(["a"])`),
+  )
+  t->U.assertThrowsMessage(
+    () => %raw(`new Map()`)->S.parseOrThrow(~to=schema),
+    `Expected Set, received [object Map]`,
+  )
+
+  // Generated dispatch only checks `i instanceof Set` — Map branch absent.
+  t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{i instanceof e[0]||e[1](i);return i}`)
+  t->U.assertCompiledCodeIsNoop(~schema, ~op=#Convert)
+})
+
+test("Tier 3 instance: source class absent from target — coercion fallback retained", t => {
+  let schema =
+    S.instance(%raw(`Set`))->S.to(
+      S.union([S.string->S.castToUnknown, S.instance(%raw(`Map`))->Obj.magic]),
+    )
+
+  // Set source matches neither string nor Map by class name → tier-3 fallback.
+  t->U.assertThrowsMessage(
+    () => %raw(`new Set()`)->S.parseOrThrow(~to=schema),
+    `Expected string | Map, received [object Set]
+- Can't decode Set to string. Use S.to to define a custom decoder
+- Can't decode Set to Map. Use S.to to define a custom decoder`,
+  )
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Expected Set, received "hello"`,
+  )
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{i instanceof e[3]||e[4](i);try{throw e[0]}catch(e0){try{throw e[1]}catch(e1){e[2](i,e0,e1)}}return i}`,
+  )
+})

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -962,3 +962,32 @@ test("Tier 3 instance: source class absent from target — coercion fallback ret
     `i=>{i instanceof e[3]||e[4](i);try{throw e[0]}catch(e0){try{throw e[1]}catch(e1){e[2](i,e0,e1)}}return i}`,
   )
 })
+
+test("Tier 1 instance: S.date -> S.union([S.string, S.date]) keeps Date identity", t => {
+  let schema = S.date->S.to(S.union([S.string->S.castToUnknown, S.date->S.castToUnknown]))
+
+  let d = Date.fromString("2024-01-01T00:00:00Z")
+  t->Assert.deepEqual(d->S.parseOrThrow(~to=schema), d->Obj.magic)
+  t->U.assertThrowsMessage(
+    () => %raw(`"2024-01-01"`)->S.parseOrThrow(~to=schema),
+    `Expected Date, received "2024-01-01"`,
+  )
+  t->U.assertThrowsMessage(
+    () => %raw(`new Date("invalid")`)->S.parseOrThrow(~to=schema),
+    `Expected Date, received [object Date]`,
+  )
+
+  // Forward dispatch only checks the Date branch; the string variant is absent.
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{i instanceof e[1]||e[2](i);!Number.isNaN(i.getTime())||e[0](i);return i}`,
+  )
+  t->U.assertCompiledCodeIsNoop(~schema, ~op=#Convert)
+  // Reverse handles both source variants: parse string as Date, or pass Date through.
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#ReverseConvert,
+    `i=>{if(typeof i==="string"){let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);i=new Date(i)}else if(!(i instanceof e[1])){e[2](i)}return i}`,
+  )
+})

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -819,22 +819,18 @@ test("Fails to transform union to union to string", t => {
   }, "Expected string | number, received true")
 })
 
-test(
-  "Transform from union to wider union with different items order (applies decoder to both one at a time)",
-  t => {
-    let schema =
-      S.union([S.string->S.castToUnknown, S.float->S.castToUnknown])->S.to(
-        S.union([S.float->S.castToUnknown, S.string->S.castToUnknown, S.bool->S.castToUnknown]),
-      )
-
-    t->U.assertThrowsMessage(() => {
-      true->S.parseOrThrow(~to=schema)
-    }, "Expected string | number, received true")
-    t->U.assertCompiledCode(
-      ~schema,
-      ~op=#Parse,
-      // TODO: Can be optimized to remove the second check
-      `i=>{if(!(typeof i==="string"||typeof i==="number"&&!Number.isNaN(i))){e[0](i)}if(!(typeof i==="number"&&!Number.isNaN(i)||typeof i==="string"||typeof i==="boolean")){e[1](i)}return i}`,
+test("Transform from union to wider union with different items order keeps source type", t => {
+  let schema =
+    S.union([S.string->S.castToUnknown, S.float->S.castToUnknown])->S.to(
+      S.union([S.float->S.castToUnknown, S.string->S.castToUnknown, S.bool->S.castToUnknown]),
     )
-  },
-)
+
+  t->U.assertThrowsMessage(() => {
+    true->S.parseOrThrow(~to=schema)
+  }, "Expected string | number, received true")
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{if(!(typeof i==="string"||typeof i==="number"&&!Number.isNaN(i))){e[0](i)}return i}`,
+  )
+})

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -991,3 +991,21 @@ test("Tier 1 instance: S.date -> S.union([S.string, S.date]) keeps Date identity
     `i=>{if(typeof i==="string"){let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);i=new Date(i)}else if(!(i instanceof e[1])){e[2](i)}return i}`,
   )
 })
+
+test("Tier 1 over tier 2: undefined -> [null, undefined] keeps undefined (tier-1 wins)", t => {
+  let schema =
+    S.unit->S.to(
+      S.union([S.literal(%raw(`null`))->S.castToUnknown, S.unit->S.castToUnknown]),
+    )
+
+  // The undefined target is present, so tier-1 must win — undefined stays undefined.
+  // The null bridge must NOT be applied even though null is also a target.
+  t->Assert.deepEqual(()->S.parseOrThrow(~to=schema), %raw(`undefined`))
+  t->U.assertThrowsMessage(
+    () => %raw(`null`)->S.parseOrThrow(~to=schema),
+    `Expected undefined, received null`,
+  )
+
+  // Generated dispatch only checks `i===void 0` — the null branch is absent.
+  t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{i===void 0||e[0](i);return i}`)
+})

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -1009,3 +1009,36 @@ test("Tier 1 over tier 2: undefined -> [null, undefined] keeps undefined (tier-1
   // Generated dispatch only checks `i===void 0` — the null branch is absent.
   t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{i===void 0||e[0](i);return i}`)
 })
+
+test("Tier 3 fallback for unknown source — transform on unknown variant still runs", t => {
+  // Source is S.unknown. Even though the target has an `unknown` variant
+  // (the second one, with a transform), tier-1 must NOT fire here: an
+  // unknown source has no derived tag, so dispatch falls through to
+  // tier-3 trial and tries `string` first, then the transformed unknown.
+  let schema =
+    S.unknown->S.to(
+      S.union([
+        S.string->S.castToUnknown,
+        S.unknown
+        ->S.transform(_ => {
+          parser: v => Some(v),
+          serializer: v => v->Obj.magic,
+        })
+        ->S.castToUnknown,
+      ]),
+    )
+
+  // String input matches the string variant — passes through as-is.
+  t->Assert.deepEqual("abc"->S.parseOrThrow(~to=schema), %raw(`"abc"`))
+  // Non-string input fails the string check, falls through to the unknown
+  // variant, which applies the transform (wraps in Some).
+  t->Assert.deepEqual(123->S.parseOrThrow(~to=schema), Some(123)->Obj.magic)
+
+  // Generated code is the tier-3 trial chain — string check first, then
+  // the transformed unknown branch in a catch.
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{try{typeof i==="string"||e[0](i);}catch(e1){try{let v0;try{v0=e[1](i)}catch(x){e[2](x)}i=v0}catch(e2){e[3](i,e1,e2)}}return i}`,
+  )
+})

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -834,3 +834,63 @@ test("Transform from union to wider union with different items order keeps sourc
     `i=>{if(!(typeof i==="string"||typeof i==="number"&&!Number.isNaN(i))){e[0](i)}return i}`,
   )
 })
+
+test("Tier 1: source tag matches a target variant — identity wins, no cross-type coercion", t => {
+  let schema = S.string->S.to(S.union([S.bool->S.castToUnknown, S.string->S.castToUnknown]))
+
+  // String input flows through as a string. The bool variant is never tried,
+  // so "true"/"false" are NOT coerced to bool.
+  t->Assert.deepEqual("true"->S.parseOrThrow(~to=schema), %raw(`"true"`))
+  t->Assert.deepEqual("false"->S.parseOrThrow(~to=schema), %raw(`"false"`))
+  t->Assert.deepEqual("anything"->S.parseOrThrow(~to=schema), %raw(`"anything"`))
+  t->U.assertThrowsMessage(
+    () => true->S.parseOrThrow(~to=schema),
+    `Expected string, received true`,
+  )
+
+  t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{typeof i==="string"||e[0](i);return i}`)
+  t->U.assertCompiledCodeIsNoop(~schema, ~op=#Convert)
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#ReverseConvert,
+    `i=>{if(typeof i==="boolean"){i=""+i}else if(!(typeof i==="string")){e[0](i)}return i}`,
+  )
+})
+
+test("Tier 2: nullish bridge — null source uses opposite undefined target when no null target", t => {
+  let schema =
+    S.literal(%raw(`null`))->S.to(S.union([S.string->S.castToUnknown, S.unit->S.castToUnknown]))
+
+  // null bridges to undefined (the opposite-nullish target). The string
+  // variant is never compiled into the dispatch.
+  t->Assert.deepEqual(%raw(`null`)->S.parseOrThrow(~to=schema), %raw(`undefined`))
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Expected null, received "hello"`,
+  )
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{i===null||e[1](i);try{i=void 0}catch(e1){e[0](i,e1)}return i}`,
+  )
+})
+
+test("Tier 3: no source-tag match — coercion fallback retained", t => {
+  let schema = S.bool->S.to(S.union([S.string->S.castToUnknown, S.float->S.castToUnknown]))
+
+  // Source tag (boolean) matches no target tag → fall through to today's
+  // trial-coercion behavior. bool→string via `""+i` succeeds.
+  t->Assert.deepEqual(true->S.parseOrThrow(~to=schema), %raw(`"true"`))
+  t->Assert.deepEqual(false->S.parseOrThrow(~to=schema), %raw(`"false"`))
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Expected boolean, received "hello"`,
+  )
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{typeof i==="boolean"||e[2](i);try{i=""+i}catch(e0){try{throw e[0]}catch(e1){e[1](i,e0,e1)}}return i}`,
+  )
+})


### PR DESCRIPTION
## Summary

This PR implements a sophisticated three-tier algorithm for matching source types to target union variants when using `S.to()` transformations. The algorithm prioritizes identity preservation, nullish bridging, and coercion fallbacks to generate more efficient and predictable compiled code.

## Key Changes

- **Tier 1 (Identity)**: When the source type exactly matches a target variant, that variant is used directly without attempting other branches. This prevents unintended coercions (e.g., string "true" won't be coerced to boolean).

- **Tier 2 (Nullish Bridge)**: When source is null/undefined but no matching target exists, the opposite nullish type (undefined↔null) is used as a bridge if available.

- **Tier 3 (Coercion Fallback)**: When source type matches no target, the system falls back to trial-and-error coercion attempts (existing behavior).

- **Added `toKey()` helper**: Extracts a comparable key from schemas, handling both primitive types and class instances uniformly.

- **Active key tracking**: The `unionDecoder` function now computes an `activeKey` at the start, determining which tier applies and filtering variant compilation accordingly.

- **Conditional variant compilation**: Variants are only compiled into the dispatch logic if they match the active key or if no active key is set (tier-3 fallback).

## Implementation Details

- The algorithm checks source type against target variants before generating code, reducing unnecessary branches in compiled output.
- Instance types (classes) are matched by class name rather than type tag.
- Tier-1 matching prevents the null↔undefined bridge from applying when an exact match exists.
- Comprehensive test coverage validates all three tiers, edge cases (dates, custom classes), and tier precedence rules.
- Generated code is significantly more efficient for common cases (identity matches), with fewer try-catch blocks and type checks.

https://claude.ai/code/session_01UWGvjaDG3qENdRSqoTE4Z3