### PR TITLE
Fix literal decoder validation in union types with noValidation

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -2133,7 +2133,7 @@ let jsonName = `JSON`
 
 let literalDecoder = Builder.make((~input) => {
   let expectedSchema = input.expected
-  if expectedSchema.noValidation->X.Option.getUnsafe {
+  if expectedSchema.noValidation->X.Option.getUnsafe && !(input.isUnion->X.Option.getUnsafe) {
     input->B.nextConst(~schema=expectedSchema)
   } else if input.schema->isLiteral {
     if input.schema.const === expectedSchema.const {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1196,7 +1196,7 @@ let jsonName = "JSON";
 
 function literalDecoder(input) {
   let expectedSchema = input.e;
-  if (expectedSchema.noValidation) {
+  if (expectedSchema.noValidation && !input.u) {
     return nextConst(input, expectedSchema, undefined);
   }
   if (constField in input.s) {

--- a/packages/sury/tests/S_noValidation_test.res
+++ b/packages/sury/tests/S_noValidation_test.res
@@ -43,4 +43,9 @@ test("Union dispatch still works when a case has noValidation", t => {
     () => "c"->S.parseOrThrow(~to=schema),
     `Expected "a" | "b", received "c"`,
   )
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{if(!(typeof i==="string"&&(i==="a"||i==="b"))){e[0](i)}return i}`,
+  )
 })


### PR DESCRIPTION
## Summary
Fixed a bug where the literal decoder was skipping validation for union type cases marked with `noValidation`, causing incorrect parsing behavior.

## Key Changes
- Modified `literalDecoder` to only skip validation when `noValidation` is set AND the schema is not part of a union type
- Added check `&& !(input.isUnion->X.Option.getUnsafe)` in ReScript source and `&& !input.u` in compiled JavaScript
- Added test case to verify compiled code output for union dispatch with noValidation

## Implementation Details
The fix ensures that even when a literal schema has `noValidation` enabled, validation is still performed if that schema is being used as a case within a union type. This prevents the decoder from accepting invalid values that don't match any of the union's expected cases. The validation is only truly skipped for standalone literal schemas with `noValidation` set.

https://claude.ai/code/session_01FsTNUyPLppGM7LLQHFLer2