### PR TITLE
Refactor refiner application into shared helpers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 1. **DX** — intuitive public API and error messages.
 2. **Performance** — generated code is the hot path; avoid extra vars, allocations, double validation; inline over indirect.
-3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.applyInputRefiner`, `B.applyRefiner`) over duplicated codegen.
+3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.applyInputRefiner`, `B.applyOutputRefiner`) over duplicated codegen.
 
 Tiebreaker: shortest *generated* code wins over shortest *library* code (runtime ships per-schema, library ships once).
 
@@ -41,7 +41,7 @@ The parse loop (around `expected.decoder(~input)`) applies `inputRefiner`/`refin
 - They know the optimal injection points: `inputRefiner` on the *raw input* before field decoding (short-circuits before allocation); `refiner` on the *assembled output*.
 - The generic fallback would force materializing an output val even when nothing else needs it.
 
-Use the two shared helpers — `B.applyInputRefiner(~val, ~schema)` and `B.applyRefiner(~val, ~schema)` — at the right insertion points. Split into two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
+Use the two shared helpers — `B.applyInputRefiner(~val, ~schema)` and `B.applyOutputRefiner(~val, ~schema)` — at the right insertion points. Split into two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
 
 Async output refiner must run inside `.then()` on the resolved value, never on the Promise wrapper.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,10 +25,10 @@ Decoder takes a single schema, Input → Output. Schemas joined by `.to` form on
 
 Per-schema execution order:
 
-1. **decoder** — narrow input to schema's Input type (may skip to Output if no `inputRefiner`).
-2. **decoder** — Input → Output (e.g. decode nested fields).
-3. **inputRefiner** — user validations on Input.
-4. **refiner** — user validations on Output.
+1. **decoder** — narrow input to schema's Input type.
+2. **inputRefiner** — user validations on the typed Input (pre-transform).
+3. **decoder** — Input → Output (e.g. decode nested fields).
+4. **refiner** — user validations on the assembled Output.
 5. If `.to`: **parser** (custom Output → `.to` Input) OR **encoder** (default Output → `.to` Input) + recurse into `.to.decoder`.
 
 `S.reverse` swaps `inputRefiner ↔ refiner`, `parser ↔ serializer`, and reverses the `.to` chain.
@@ -38,10 +38,14 @@ Per-schema execution order:
 The parse loop (around `expected.decoder(~input)`) applies `inputRefiner`/`refiner` **only for primitive decoders** — ones whose result has `isOutput !== Some(true)`. It pushes them as checks via `B.refine`.
 
 **Advanced decoders** (`objectDecoder`, `arrayDecoder`, tuple, union, recursive — anything that sets `isOutput = Some(true)`) own refiner application themselves, because:
-- They know the optimal injection points: `inputRefiner` after field decoding (so item type-narrows fire first), `refiner` on the assembled output.
+- They know the optimal injection points: `inputRefiner` is pushed onto the *input* val's checks so its predicate observes the pre-transform input; `refiner` wraps the assembled output so its predicate observes the final shape.
 - The generic fallback would force materializing an output val even when nothing else needs it.
 
-Use the two shared helpers — `B.markInput(~val, ~schema)` and `B.markOutput(~val, ~schema)` — at the right insertion points. Each one applies its side's refiner via `B.refine` and sets the corresponding `isInput` / `isOutput` flag. Split into two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
+Use the two shared helpers:
+- `B.markInput(~val, ~schema)` — mutates `val.checks` (pushes the input refiner) and sets `isInput = Some(true)`. Call it on the *input* val (e.g. `input->B.markInput`).
+- `B.markOutput(~val, ~schema)` — wraps `val` via `B.refine` with the output refiner and sets `isOutput = Some(true)` on the wrapper. Call it on the *result* val.
+
+Two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
 
 Async output refiner must run inside `.then()` on the resolved value, never on the Promise wrapper.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,127 +1,70 @@
 # Sury Architecture
 
-## Primary Goals
+## Goals (priority order on conflict)
 
-Sury optimizes for three goals — in this order, when they conflict:
+1. **DX** — intuitive public API and error messages.
+2. **Performance** — generated code is the hot path; avoid extra vars, allocations, double validation; inline over indirect.
+3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.applyInputRefiner`, `B.applyRefiner`) over duplicated codegen.
 
-1. **DX** — public API and error messages must be intuitive. Schema authors and consumers should not need to know how the compiler works.
-2. **High performance** — generated code is the hot path. Avoid redundant work (extra variables, unused allocations, double validation) and prefer inlining over indirection.
-3. **Minimal bundle size** — every byte of `Sury.res.mjs` ships to the browser. Prefer reusable helpers (`B.refine`, `B.applyRefiners`, etc.) over duplicated codegen branches; prefer one well-named primitive over several near-duplicates.
+Tiebreaker: shortest *generated* code wins over shortest *library* code (runtime ships per-schema, library ships once).
 
-When in doubt: pick the option that produces the shortest *generated* code at runtime AND the shortest *library* code at compile time. If those conflict, runtime wins (it ships per-schema, library code ships once).
+## Input vs Output
 
-## Schema Input and Output Types
+A schema has an Input type and an Output type. They differ when the schema or any nested item has a transformation.
 
-A schema represents two types: Input and Output.
-
-### Example 1: Same Input and Output
-
-```typescript
-S.string
-// Input: string
-// Output: string
+```ts
+S.string                                          // string → string
+S.schema({ foo: S.string.with(S.to, S.number) })  // {foo:string} → {foo:number}
 ```
 
-### Example 2: Different Input and Output
+Schema modifiers (`.with(S.refine, …)`, etc.) apply to the **output** type. `inputRefiner` and `refiner` are stored separately so `S.reverse` can swap them. Every schema must be reversible (Input→Output ↔ Output→Input) unless explicitly opted out. Modifiers like `name` and built-in refinements apply to both sides.
 
-```typescript
-S.schema({
-  foo: S.string.with(S.to, S.number)
-})
-// Input: { foo: string }
-// Output: { foo: number }
-```
+## Decode pipeline
 
-The input and output differ because nested items have transformations, even though the schema itself does not have a `.to` property.
+Decoder takes a single schema, Input → Output. Schemas joined by `.to` form one fused transformation pipeline.
 
-## Modifying a Schema
+Per-schema execution order:
 
-When modifying a schema, the modification applies to the output type.
+1. **decoder** — narrow input to schema's Input type (may skip to Output if no `inputRefiner`).
+2. **inputRefiner** — user validations on Input.
+3. **decoder** — Input → Output (e.g. decode nested fields).
+4. **refiner** — user validations on Output.
+5. If `.to`: **parser** (custom Output → `.to` Input) OR **encoder** (default Output → `.to` Input) + recurse into `.to.decoder`.
 
-```typescript
-S.schema({
-  foo: S.string.with(S.to, S.number)
-}).with(S.refine, () => {...})
-```
+`S.reverse` swaps `inputRefiner ↔ refiner`, `parser ↔ serializer`, and reverses the `.to` chain.
 
-Since this schema does not have `.to`, `inputRefiner` and `refiner` must be stored separately to support `S.reverse`. Every schema should be reversible from Input→Output to Output→Input, unless explicitly prevented.
+## Refiner ownership
 
-For modifications like `name` or built-in refinements that do not affect nested items, they apply to both input and output without differentiation.
+The parse loop (around `expected.decoder(~input)`) applies `inputRefiner`/`refiner` **only for primitive decoders** — ones whose result has `isOutput !== Some(true)`. It pushes them as checks via `B.refine`.
 
-## Decode Function
+**Advanced decoders** (`objectDecoder`, `arrayDecoder`, tuple, union, recursive — anything that sets `isOutput = Some(true)`) own refiner application themselves, because:
+- They know the optimal injection points: `inputRefiner` on the *raw input* before field decoding (short-circuits before allocation); `refiner` on the *assembled output*.
+- The generic fallback would force materializing an output val even when nothing else needs it.
 
-The decode function is created from a single schema and transforms the schema's Input to Output. When multiple schemas are joined by the `.to` property, they are automatically combined into a single transformation pipeline.
+Use the two shared helpers — `B.applyInputRefiner(~val, ~schema)` and `B.applyRefiner(~val, ~schema)` — at the right insertion points. Split into two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
 
-## Schema Properties and Execution Order
+Async output refiner must run inside `.then()` on the resolved value, never on the Promise wrapper.
 
-Schema properties are executed in the following order:
+## Async
 
-1. **decoder** - If input val differs from the schema, decode it to the schema's input type. May skip directly to schema output if there is no inputRefiner.
-
-2. **inputRefiner** - Custom validations on the input part of the schema value.
-
-3. **decoder** - Decodes input to output for the current schema. Typically required to decode nested items such as object fields.
-
-4. **refiner** - Custom validations on the output part of the schema value.
-
-### If Schema Has `.to` Property
-
-5. **parser** - Custom transformation logic to the `.to` schema. The serializer is the reverse of parser.
-
-### If There Is No Parser
-
-5. **encoder** - Transformation logic from the current schema's output to the `.to` schema's input.
-
-6. **.to.decoder** - Starts the cycle from the beginning with the `.to` schema.
-
-### Refiner Application — Who Is Responsible
-
-The parse loop (in `parse`, around the `expected.decoder(~input)` call) handles refiner application **only for primitive decoders** — those that return a val with `isOutput !== Some(true)`. For these, the loop checks `expected.inputRefiner` / `expected.refiner` and pushes them as checks via `B.refine`.
-
-**Advanced decoders that mark their output `isOutput = Some(true)` (i.e., decoders that produce an internally-transformed value, such as `objectDecoder`, `arrayDecoder`, tuple, union, recursive) own refiner application themselves.** The generic post-decoder fallback is intentionally skipped because:
-
-- The advanced decoder knows the optimal injection points: `inputRefiner` runs on the *original input* before field/item decoding (so a failure short-circuits before any allocation); `refiner` runs on the *assembled output* (so it observes the transformed shape).
-- Applying refiners generically after the fact would force the decoder to emit a materialized output value even when nothing else needed it, costing bundle size and runtime allocation.
-
-Two shared helpers — `B.applyInputRefiner(~val, ~schema)` and `B.applyRefiner(~val, ~schema)` — exist so each advanced decoder can call them without duplicating the `hasInputRefiner` / `hasRefiner` boilerplate. Two separate functions (rather than a single `~which` parameter) let the bundler dead-code-eliminate whichever one a given decoder doesn't use. If you implement a new advanced decoder, you **must** call both at the appropriate insertion points; otherwise user-supplied `S.refine` is silently dropped.
-
-For async paths, the output refiner must be invoked on the *resolved* value inside the Promise's `.then` callback — never on the Promise wrapper itself.
-
-## Reversal with S.reverse
-
-`S.reverse` swaps:
-
-- `inputRefiner` ↔ `refiner`
-- `parser` ↔ `serializer`
-- Reverses the `.to` chain direction
-
-## Async Support
-
-Every transformation may return an async value. To continue the transformation chain:
-
-1. Append `.then()` and continue the logic in the callback function.
-2. For nested items (e.g., object fields, array items), create a promise that collects all inner items with `Promise.all()`.
+Any transformation may be async. Continue the chain via `.then()`. For nested items (object fields, array items), aggregate with `Promise.all()`.
 
 ## Val
 
-The `val` represents a value at a specific point in time during compilation. Each `val` reflects a specific value type at that moment.
+A `val` is the compile-time view of a runtime value at one point in the generated code.
 
-Key properties:
+Core fields:
+- `schema` — actual type at this point
+- `expected` — schema to build decoder for
+- `var()` — variable name in generated code
+- `inline` — inline expression form
+- `path` — location in input (for errors)
 
-- `schema` - The actual type of the value at this point
-- `expected` - The schema to build decoder for
-- `var` - Returns the variable name in generated code
-- `inline` - The value as an inline code expression
-- `path` - Current location in the data structure (for error messages)
+Transformation chain (relative to `.prev`):
+- `prev` — previous val in the chain
+- `code` — codegen from `.prev` to this val
+- `validation` — type-check condition from `.prev` (distinct from user refiners)
 
-Transformation tracking (relative to `.prev`):
-
-- `prev` - The previous val in the chain, indicating where this value originated from
-- `code` - Generated code describing the transformation from `.prev` to this val
-- `validation` - Type check condition from `.prev` (e.g., `typeof x === "string"`). Different from custom refiners.
-
-This design allows tracing back through the transformation history, where each step records what code was generated and what validations were applied to get from the previous state to the current one.
-
-- `B.refine` allows to modify the value, by cloning, while keeping the var allocation link.
-
-- `skipTo` is used to abort the parse after finishing current decoder. Ideally to get rid of it and use `val.expected` instead.
+Helpers:
+- `B.refine` — clones a val to attach checks, keeping the var-allocation link.
+- `skipTo` — abort parse after current decoder. Prefer `val.expected`; aim to remove `skipTo`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 1. **DX** — intuitive public API and error messages.
 2. **Performance** — generated code is the hot path; avoid extra vars, allocations, double validation; inline over indirect.
-3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.applyInputRefiner`, `B.applyOutputRefiner`) over duplicated codegen.
+3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.markInput`, `B.markOutput`) over duplicated codegen.
 
 Tiebreaker: shortest *generated* code wins over shortest *library* code (runtime ships per-schema, library ships once).
 
@@ -26,8 +26,8 @@ Decoder takes a single schema, Input → Output. Schemas joined by `.to` form on
 Per-schema execution order:
 
 1. **decoder** — narrow input to schema's Input type (may skip to Output if no `inputRefiner`).
-2. **inputRefiner** — user validations on Input.
-3. **decoder** — Input → Output (e.g. decode nested fields).
+2. **decoder** — Input → Output (e.g. decode nested fields).
+3. **inputRefiner** — user validations on Input.
 4. **refiner** — user validations on Output.
 5. If `.to`: **parser** (custom Output → `.to` Input) OR **encoder** (default Output → `.to` Input) + recurse into `.to.decoder`.
 
@@ -38,10 +38,10 @@ Per-schema execution order:
 The parse loop (around `expected.decoder(~input)`) applies `inputRefiner`/`refiner` **only for primitive decoders** — ones whose result has `isOutput !== Some(true)`. It pushes them as checks via `B.refine`.
 
 **Advanced decoders** (`objectDecoder`, `arrayDecoder`, tuple, union, recursive — anything that sets `isOutput = Some(true)`) own refiner application themselves, because:
-- They know the optimal injection points: `inputRefiner` on the *raw input* before field decoding (short-circuits before allocation); `refiner` on the *assembled output*.
+- They know the optimal injection points: `inputRefiner` after field decoding (so item type-narrows fire first), `refiner` on the assembled output.
 - The generic fallback would force materializing an output val even when nothing else needs it.
 
-Use the two shared helpers — `B.applyInputRefiner(~val, ~schema)` and `B.applyOutputRefiner(~val, ~schema)` — at the right insertion points. Split into two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
+Use the two shared helpers — `B.markInput(~val, ~schema)` and `B.markOutput(~val, ~schema)` — at the right insertion points. Each one applies its side's refiner via `B.refine` and sets the corresponding `isInput` / `isOutput` flag. Split into two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
 
 Async output refiner must run inside `.then()` on the resolved value, never on the Promise wrapper.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,15 @@
 # Sury Architecture
 
+## Primary Goals
+
+Sury optimizes for three goals — in this order, when they conflict:
+
+1. **DX** — public API and error messages must be intuitive. Schema authors and consumers should not need to know how the compiler works.
+2. **High performance** — generated code is the hot path. Avoid redundant work (extra variables, unused allocations, double validation) and prefer inlining over indirection.
+3. **Minimal bundle size** — every byte of `Sury.res.mjs` ships to the browser. Prefer reusable helpers (`B.refine`, `B.applyRefiners`, etc.) over duplicated codegen branches; prefer one well-named primitive over several near-duplicates.
+
+When in doubt: pick the option that produces the shortest *generated* code at runtime AND the shortest *library* code at compile time. If those conflict, runtime wins (it ships per-schema, library code ships once).
+
 ## Schema Input and Output Types
 
 A schema represents two types: Input and Output.
@@ -63,6 +73,17 @@ Schema properties are executed in the following order:
 5. **encoder** - Transformation logic from the current schema's output to the `.to` schema's input.
 
 6. **.to.decoder** - Starts the cycle from the beginning with the `.to` schema.
+
+### Refiner Application — Who Is Responsible
+
+The parse loop (in `parse`, around the `expected.decoder(~input)` call) handles refiner application **only for primitive decoders** — those that return a val with `isOutput !== Some(true)`. For these, the loop checks `expected.inputRefiner` / `expected.refiner` and pushes them as checks via `B.refine`.
+
+**Advanced decoders that mark their output `isOutput = Some(true)` (i.e., decoders that produce an internally-transformed value, such as `objectDecoder`, `arrayDecoder`, tuple, union, recursive) own refiner application themselves.** The generic post-decoder fallback is intentionally skipped because:
+
+- The advanced decoder knows the optimal injection points: `inputRefiner` runs on the *original input* before field/item decoding (so a failure short-circuits before any allocation); `refiner` runs on the *assembled output* (so it observes the transformed shape).
+- Applying refiners generically after the fact would force the decoder to emit a materialized output value even when nothing else needed it, costing bundle size and runtime allocation.
+
+A shared `B.applyRefiners(~val, ~schema, ~which=#Input | #Output)` helper exists so each advanced decoder can call it without duplicating the `hasInputRefiner` / `hasRefiner` boilerplate. If you implement a new advanced decoder, you **must** call this helper at both insertion points; otherwise user-supplied `S.refine` is silently dropped.
 
 ## Reversal with S.reverse
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,9 @@ The parse loop (in `parse`, around the `expected.decoder(~input)` call) handles 
 - The advanced decoder knows the optimal injection points: `inputRefiner` runs on the *original input* before field/item decoding (so a failure short-circuits before any allocation); `refiner` runs on the *assembled output* (so it observes the transformed shape).
 - Applying refiners generically after the fact would force the decoder to emit a materialized output value even when nothing else needed it, costing bundle size and runtime allocation.
 
-A shared `B.applyRefiners(~val, ~schema, ~which=#Input | #Output)` helper exists so each advanced decoder can call it without duplicating the `hasInputRefiner` / `hasRefiner` boilerplate. If you implement a new advanced decoder, you **must** call this helper at both insertion points; otherwise user-supplied `S.refine` is silently dropped.
+Two shared helpers — `B.applyInputRefiner(~val, ~schema)` and `B.applyRefiner(~val, ~schema)` — exist so each advanced decoder can call them without duplicating the `hasInputRefiner` / `hasRefiner` boilerplate. Two separate functions (rather than a single `~which` parameter) let the bundler dead-code-eliminate whichever one a given decoder doesn't use. If you implement a new advanced decoder, you **must** call both at the appropriate insertion points; otherwise user-supplied `S.refine` is silently dropped.
+
+For async paths, the output refiner must be invoked on the *resolved* value inside the Promise's `.then` callback — never on the Promise wrapper itself.
 
 ## Reversal with S.reverse
 

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,12 +3,13 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 11 failing tests
+# Total: 12 failing tests
 
   ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
+  ✘ [fail]: S_refine_test.res › inputRefiner observes pre-transform input on a reversed transforming schema
   ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,12 +3,13 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 11 failing tests
+# Total: 12 failing tests
 
   ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
+  ✘ [fail]: S_refine_test.res › Refiner application order: type-narrow first, then inputRefiner, then output refiner
   ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -5,13 +5,13 @@
 #
 # Total: 13 failing tests
 
-  ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
+  ✘ [fail]: S_refine_test.res › Output refine on a tuple runs on the assembled tuple
+  ✘ [fail]: S_refine_test.res › Refiner runs on S.compactColumns
   ✘ [fail]: S_refine_test.res › Refiner runs on S.shape
   ✘ [fail]: S_refine_test.res › Successfully parses
-  ✘ [fail]: S_refine_test.res › inputRefiner runs on reversed S.shape
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union (with an item transformed to) Should apply refinement after the item transformation

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,13 +3,14 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 12 failing tests
+# Total: 13 failing tests
 
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
   ✘ [fail]: S_refine_test.res › Output refine on a tuple runs on the assembled tuple
   ✘ [fail]: S_refine_test.res › Refiner runs on S.compactColumns
+  ✘ [fail]: S_refine_test.res › Refiner runs on S.shape
   ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,14 +3,13 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 13 failing tests
+# Total: 12 failing tests
 
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
   ✘ [fail]: S_refine_test.res › Output refine on a tuple runs on the assembled tuple
   ✘ [fail]: S_refine_test.res › Refiner runs on S.compactColumns
-  ✘ [fail]: S_refine_test.res › Refiner runs on S.shape
   ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,13 +3,15 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 11 failing tests
+# Total: 13 failing tests
 
   ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
+  ✘ [fail]: S_refine_test.res › Refiner runs on S.shape
   ✘ [fail]: S_refine_test.res › Successfully parses
+  ✘ [fail]: S_refine_test.res › inputRefiner runs on reversed S.shape
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union (with an item transformed to) Should apply refinement after the item transformation

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,13 +3,12 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 12 failing tests
+# Total: 11 failing tests
 
   ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
-  ✘ [fail]: S_refine_test.res › inputRefiner observes pre-transform input on a reversed transforming schema
   ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union

--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,13 +3,12 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 12 failing tests
+# Total: 11 failing tests
 
   ✘ [fail]: S_noValidation_test.res › Union dispatch still works when a case has noValidation
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
   ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
   ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
-  ✘ [fail]: S_refine_test.res › Refiner application order: type-narrow first, then inputRefiner, then output refiner
   ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5802,9 +5802,9 @@ let compactColumnsDecoder = (~input) => {
         } else {
           input
         }
+        let _: val = input->B.markInput(~schema=selfSchema)
         let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
-        output.isOutput = Some(true)
-        output
+        output->B.markOutput(~schema=selfSchema)
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         let input = if isUnknownInput {
@@ -5898,9 +5898,9 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=new Array(Math.max(${lengthCode.contents}))`)
 
+        let _: val = input->B.markInput(~schema=selfSchema)
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
-        output.isOutput = Some(true)
 
         // Wrap the row body in a single try/catch that prepends the row index to
         // any thrown error — giving paths like ["0"]["bar"]. A single wrapper is
@@ -5933,11 +5933,12 @@ let compactColumnsDecoder = (~input) => {
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrappedBody}}`
 
-        if hasAsync.contents {
+        let result = if hasAsync.contents {
           output->B.asyncVal(`Promise.all(${outputVar})`)
         } else {
           output
         }
+        result->B.markOutput(~schema=selfSchema)
       } else {
         // Reverse direction: rows → columnar
         // When the declared source type is unknown, field values have
@@ -5989,9 +5990,9 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
 
+        let _: val = input->B.markInput(~schema=selfSchema)
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
-        output.isOutput = Some(true)
         let loopBody = perFieldCode.contents ++ settingCode.contents
         let wrappedBody = if needsPerFieldTransform && perFieldCode.contents !== "" {
           let errorVar = input.global->B.varWithoutAllocation
@@ -6002,7 +6003,7 @@ let compactColumnsDecoder = (~input) => {
         output.codeFromPrev =
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${inputVar}.length;++${iteratorVar}){${wrappedBody}}`
-        output
+        output->B.markOutput(~schema=selfSchema)
       }
     }
   }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1565,32 +1565,40 @@ module Builder = {
       }
     }
 
-    // Mark a val as a fully-validated Input: applies the schema's input
-    // refiner (if any) and sets `isInput = Some(true)`. Returns the same
-    // val if no refiner / empty checks, otherwise a `refine`-cloned val
-    // carrying the checks. Advanced decoders (object, array, tuple, union,
+    // Mark a val as a fully-validated Input: pushes the schema's input
+    // refiner checks (if any) onto the val's own checks array, then sets
+    // `isInput = Some(true)`. Mutates `val` in place — call sites typically
+    // pass the *input* val itself so the emitted check references the
+    // pre-transform input variable. For advanced decoders, that means
+    // calling `input->markInput` rather than `result->markInput`; the
+    // input val's slot in `merge` emits the user check right after its
+    // existing type-narrow checks, before field decoding code. Pair with
+    // `markOutput`. Advanced decoders (object, array, tuple, union,
     // recursive) MUST call this themselves; the parse-loop fallback only
-    // fires for primitive decoders (`isOutput !== Some(true)`). Pair with
-    // `markOutput`; call this one first so input checks emit ahead of
-    // output checks.
+    // fires for primitive decoders (`isOutput !== Some(true)`).
     let markInput = (val: val, ~schema: internal) => {
-      let val = switch schema.inputRefiner {
+      switch schema.inputRefiner {
       | Some(fn) => {
           let checks = fn(~input=val)
-          checks->Js.Array2.length > 0 ? val->refine(~checks) : val
+          for i in 0 to checks->Js.Array2.length - 1 {
+            val->pushCheck(checks->Js.Array2.unsafe_get(i))
+          }
         }
-      | None => val
+      | None => ()
       }
       val.isInput = Some(true)
       val
     }
 
-    // Mark a val as a fully-validated Output: applies the schema's output
-    // refiner (if any) and sets `isOutput = Some(true)`. Same ownership
-    // rule as `markInput`. For async decoders, the check must be injected
-    // inside the `.then` callback on the resolved value, not on the
-    // Promise wrapper — current object/array decoders still emit on the
-    // wrapper for async, which is a known follow-up.
+    // Mark a val as a fully-validated Output: wraps via `refine` with the
+    // schema's output refiner checks (if any) so the emitted check
+    // references the post-decode output variable (the wrapper's `prev` is
+    // the assembled output val). Then sets `isOutput = Some(true)` on the
+    // returned val. Same ownership rule as `markInput`. For async decoders,
+    // the check must be injected inside the `.then` callback on the
+    // resolved value, not on the Promise wrapper — current object/array
+    // decoders still emit on the wrapper for async, which is a known
+    // follow-up.
     let markOutput = (val: val, ~schema: internal) => {
       let val = switch schema.refiner {
       | Some(fn) => {
@@ -3082,14 +3090,17 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
       }
     }
   }
-  // Apply user-supplied refiners after field decoding: inputRefiner first
-  // (so input checks emit before output checks), then output refiner. The
-  // mark helpers also set isInput / isOutput so the parse-loop primitive
-  // fallback skips this val. Async object refiners still emit on the
-  // Promise wrapper — follow-up.
-  result
-  ->B.markInput(~schema=expectedSchema)
-  ->B.markOutput(~schema=expectedSchema)
+  // Apply user-supplied refiners after field decoding. `markInput` is
+  // called on the *input* val so the input refiner check is pushed onto
+  // input.checks (alongside the type-narrow) and the emitted check
+  // references the pre-transform input variable — required for inputRefiner
+  // predicates that observe input-shape fields. `markOutput` wraps the
+  // assembled result so its check references the post-decode output. Both
+  // also set isInput / isOutput so the parse-loop primitive fallback skips
+  // this val. Async object refiners still emit on the Promise wrapper —
+  // follow-up.
+  let _: val = input->B.markInput(~schema=expectedSchema)
+  result->B.markOutput(~schema=expectedSchema)
 }
 
 let recursiveDecoder = Builder.make((~input) => {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1570,7 +1570,7 @@ module Builder = {
     // checks. Advanced decoders (object, array, tuple, union, recursive)
     // MUST call this themselves; the parse-loop fallback only fires for
     // primitive decoders (`isOutput !== Some(true)`). Pair with
-    // `applyRefiner`; call this one first so input checks emit ahead of
+    // `applyOutputRefiner`; call this one first so input checks emit ahead of
     // output checks.
     let applyInputRefiner = (val: val, ~schema: internal) => {
       switch schema.inputRefiner {
@@ -1587,7 +1587,7 @@ module Builder = {
     // must be injected inside the `.then` callback on the resolved value,
     // not on the Promise wrapper — current object/array decoders still emit
     // on the wrapper for async, which is a known follow-up.
-    let applyRefiner = (val: val, ~schema: internal) => {
+    let applyOutputRefiner = (val: val, ~schema: internal) => {
       switch schema.refiner {
       | Some(fn) => {
           let checks = fn(~input=val)
@@ -2356,7 +2356,7 @@ let rec parse = (input: val) => {
         if !(valRef.contents.isOutput->Option.getUnsafe) {
           let schema = valRef.contents.expected
           valRef := valRef.contents->B.applyInputRefiner(~schema)
-          valRef := valRef.contents->B.applyRefiner(~schema)
+          valRef := valRef.contents->B.applyOutputRefiner(~schema)
           valRef.contents.isInput = Some(true)
           valRef.contents.isOutput = Some(true)
         }
@@ -3085,7 +3085,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
   let result =
     result
     ->B.applyInputRefiner(~schema=expectedSchema)
-    ->B.applyRefiner(~schema=expectedSchema)
+    ->B.applyOutputRefiner(~schema=expectedSchema)
   result.isInput = Some(true)
   result.isOutput = Some(true)
   result

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1565,19 +1565,32 @@ module Builder = {
       }
     }
 
-    // Mutates `val`: pushes the schema's input refiner checks onto
-    // `val.checks` and sets `isInput = Some(true)`. Call on the *input*
-    // val so the check observes the pre-transform variable. Advanced
-    // decoders must call this themselves; parse-loop covers primitives.
+    // Pushes the schema's input refiner checks onto `val.checks` (so the
+    // check observes the pre-transform variable via `val.prev.var()`),
+    // then sets `isInput = Some(true)`. When `val.prev` is None (e.g.
+    // primitive decoder returned the operationArg val unchanged), wraps
+    // via `refine` instead so emit has a prev.var() to reference.
+    // Advanced decoders must call this themselves; parse-loop covers
+    // primitives.
     let markInput = (val: val, ~schema: internal) => {
-      switch schema.inputRefiner {
+      let val = switch schema.inputRefiner {
       | Some(fn) => {
           let checks = fn(~input=val)
-          for i in 0 to checks->Js.Array2.length - 1 {
-            val->pushCheck(checks->Js.Array2.unsafe_get(i))
+          if checks->Js.Array2.length > 0 {
+            switch val.prev {
+            | Some(_) => {
+                for i in 0 to checks->Js.Array2.length - 1 {
+                  val->pushCheck(checks->Js.Array2.unsafe_get(i))
+                }
+                val
+              }
+            | None => val->refine(~checks)
+            }
+          } else {
+            val
           }
         }
-      | None => ()
+      | None => val
       }
       val.isInput = Some(true)
       val

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1565,36 +1565,42 @@ module Builder = {
       }
     }
 
-    // Apply a schema's input refiner to a val. Returns the same val if no
-    // refiner / empty checks, otherwise a `refine`-cloned val carrying the
-    // checks. Advanced decoders (object, array, tuple, union, recursive)
-    // MUST call this themselves; the parse-loop fallback only fires for
-    // primitive decoders (`isOutput !== Some(true)`). Pair with
-    // `applyOutputRefiner`; call this one first so input checks emit ahead of
+    // Mark a val as a fully-validated Input: applies the schema's input
+    // refiner (if any) and sets `isInput = Some(true)`. Returns the same
+    // val if no refiner / empty checks, otherwise a `refine`-cloned val
+    // carrying the checks. Advanced decoders (object, array, tuple, union,
+    // recursive) MUST call this themselves; the parse-loop fallback only
+    // fires for primitive decoders (`isOutput !== Some(true)`). Pair with
+    // `markOutput`; call this one first so input checks emit ahead of
     // output checks.
-    let applyInputRefiner = (val: val, ~schema: internal) => {
-      switch schema.inputRefiner {
+    let markInput = (val: val, ~schema: internal) => {
+      let val = switch schema.inputRefiner {
       | Some(fn) => {
           let checks = fn(~input=val)
           checks->Js.Array2.length > 0 ? val->refine(~checks) : val
         }
       | None => val
       }
+      val.isInput = Some(true)
+      val
     }
 
-    // Apply a schema's output refiner to a val (the assembled output). Same
-    // ownership rule as `applyInputRefiner`. For async decoders, the check
-    // must be injected inside the `.then` callback on the resolved value,
-    // not on the Promise wrapper — current object/array decoders still emit
-    // on the wrapper for async, which is a known follow-up.
-    let applyOutputRefiner = (val: val, ~schema: internal) => {
-      switch schema.refiner {
+    // Mark a val as a fully-validated Output: applies the schema's output
+    // refiner (if any) and sets `isOutput = Some(true)`. Same ownership
+    // rule as `markInput`. For async decoders, the check must be injected
+    // inside the `.then` callback on the resolved value, not on the
+    // Promise wrapper — current object/array decoders still emit on the
+    // wrapper for async, which is a known follow-up.
+    let markOutput = (val: val, ~schema: internal) => {
+      let val = switch schema.refiner {
       | Some(fn) => {
           let checks = fn(~input=val)
           checks->Js.Array2.length > 0 ? val->refine(~checks) : val
         }
       | None => val
       }
+      val.isOutput = Some(true)
+      val
     }
 
     // Used in union codegen: splice a literal child's checks into the parent
@@ -2355,10 +2361,8 @@ let rec parse = (input: val) => {
         // and expect the decoder itself to handle refinements and manage isInput/isOutput flags.
         if !(valRef.contents.isOutput->Option.getUnsafe) {
           let schema = valRef.contents.expected
-          valRef := valRef.contents->B.applyInputRefiner(~schema)
-          valRef := valRef.contents->B.applyOutputRefiner(~schema)
-          valRef.contents.isInput = Some(true)
-          valRef.contents.isOutput = Some(true)
+          valRef := valRef.contents->B.markInput(~schema)
+          valRef := valRef.contents->B.markOutput(~schema)
         }
       }
     }
@@ -3079,16 +3083,13 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     }
   }
   // Apply user-supplied refiners after field decoding: inputRefiner first
-  // (so input checks emit before output checks), then output refiner. Mark
-  // isOutput so the parse-loop primitive fallback skips this val. Async
-  // object refiners still emit on the Promise wrapper — follow-up.
-  let result =
-    result
-    ->B.applyInputRefiner(~schema=expectedSchema)
-    ->B.applyOutputRefiner(~schema=expectedSchema)
-  result.isInput = Some(true)
-  result.isOutput = Some(true)
+  // (so input checks emit before output checks), then output refiner. The
+  // mark helpers also set isInput / isOutput so the parse-loop primitive
+  // fallback skips this val. Async object refiners still emit on the
+  // Promise wrapper — follow-up.
   result
+  ->B.markInput(~schema=expectedSchema)
+  ->B.markOutput(~schema=expectedSchema)
 }
 
 let recursiveDecoder = Builder.make((~input) => {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1565,6 +1565,38 @@ module Builder = {
       }
     }
 
+    // Apply a schema's input refiner to a val. Returns the same val if no
+    // refiner / empty checks, otherwise a `refine`-cloned val carrying the
+    // checks. Advanced decoders (object, array, tuple, union, recursive)
+    // MUST call this themselves; the parse-loop fallback only fires for
+    // primitive decoders (`isOutput !== Some(true)`). Pair with
+    // `applyRefiner`; call this one first so input checks emit ahead of
+    // output checks.
+    let applyInputRefiner = (val: val, ~schema: internal) => {
+      switch schema.inputRefiner {
+      | Some(fn) => {
+          let checks = fn(~input=val)
+          checks->Js.Array2.length > 0 ? val->refine(~checks) : val
+        }
+      | None => val
+      }
+    }
+
+    // Apply a schema's output refiner to a val (the assembled output). Same
+    // ownership rule as `applyInputRefiner`. For async decoders, the check
+    // must be injected inside the `.then` callback on the resolved value,
+    // not on the Promise wrapper — current object/array decoders still emit
+    // on the wrapper for async, which is a known follow-up.
+    let applyRefiner = (val: val, ~schema: internal) => {
+      switch schema.refiner {
+      | Some(fn) => {
+          let checks = fn(~input=val)
+          checks->Js.Array2.length > 0 ? val->refine(~checks) : val
+        }
+      | None => val
+      }
+    }
+
     // Used in union codegen: splice a literal child's checks into the parent
     // as dispatch discriminants. Each cond's `inputVar` is rewritten to
     // `parent[key]`; `fail` stays shared so lifted checks fuse with the
@@ -2322,30 +2354,9 @@ let rec parse = (input: val) => {
         // Otherwise, we assume internal transformations are present,
         // and expect the decoder itself to handle refinements and manage isInput/isOutput flags.
         if !(valRef.contents.isOutput->Option.getUnsafe) {
-          let hasInputRefiner = valRef.contents.expected.inputRefiner->Obj.magic
-          let hasRefiner = valRef.contents.expected.refiner->Obj.magic
-          if hasInputRefiner || hasRefiner {
-            let checks = []
-            if hasInputRefiner {
-              let arr = (valRef.contents.expected.inputRefiner->X.Option.getUnsafe)(
-                ~input=valRef.contents,
-              )
-              for i in 0 to arr->Js.Array2.length - 1 {
-                checks->Js.Array2.push(arr->Js.Array2.unsafe_get(i))->ignore
-              }
-            }
-            if hasRefiner {
-              let arr = (valRef.contents.expected.refiner->X.Option.getUnsafe)(
-                ~input=valRef.contents,
-              )
-              for i in 0 to arr->Js.Array2.length - 1 {
-                checks->Js.Array2.push(arr->Js.Array2.unsafe_get(i))->ignore
-              }
-            }
-            if checks->Js.Array2.length > 0 {
-              valRef.contents = valRef.contents->B.refine(~checks)
-            }
-          }
+          let schema = valRef.contents.expected
+          valRef := valRef.contents->B.applyInputRefiner(~schema)
+          valRef := valRef.contents->B.applyRefiner(~schema)
           valRef.contents.isInput = Some(true)
           valRef.contents.isOutput = Some(true)
         }
@@ -2940,7 +2951,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     unknownInput->B.unsupportedDecode(~from=unknownInput.schema, ~target=expectedSchema)
   }
 
-  switch expectedSchema.additionalItems->X.Option.getUnsafe {
+  let result = switch expectedSchema.additionalItems->X.Option.getUnsafe {
   | Schema(itemSchema) => {
       let itemSchema = itemSchema->castToInternal
       if itemSchema === unknown {
@@ -3067,6 +3078,17 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
       }
     }
   }
+  // Apply user-supplied refiners after field decoding: inputRefiner first
+  // (so input checks emit before output checks), then output refiner. Mark
+  // isOutput so the parse-loop primitive fallback skips this val. Async
+  // object refiners still emit on the Promise wrapper — follow-up.
+  let result =
+    result
+    ->B.applyInputRefiner(~schema=expectedSchema)
+    ->B.applyRefiner(~schema=expectedSchema)
+  result.isInput = Some(true)
+  result.isOutput = Some(true)
+  result
 }
 
 let recursiveDecoder = Builder.make((~input) => {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1565,17 +1565,10 @@ module Builder = {
       }
     }
 
-    // Mark a val as a fully-validated Input: pushes the schema's input
-    // refiner checks (if any) onto the val's own checks array, then sets
-    // `isInput = Some(true)`. Mutates `val` in place — call sites typically
-    // pass the *input* val itself so the emitted check references the
-    // pre-transform input variable. For advanced decoders, that means
-    // calling `input->markInput` rather than `result->markInput`; the
-    // input val's slot in `merge` emits the user check right after its
-    // existing type-narrow checks, before field decoding code. Pair with
-    // `markOutput`. Advanced decoders (object, array, tuple, union,
-    // recursive) MUST call this themselves; the parse-loop fallback only
-    // fires for primitive decoders (`isOutput !== Some(true)`).
+    // Mutates `val`: pushes the schema's input refiner checks onto
+    // `val.checks` and sets `isInput = Some(true)`. Call on the *input*
+    // val so the check observes the pre-transform variable. Advanced
+    // decoders must call this themselves; parse-loop covers primitives.
     let markInput = (val: val, ~schema: internal) => {
       switch schema.inputRefiner {
       | Some(fn) => {
@@ -1590,15 +1583,10 @@ module Builder = {
       val
     }
 
-    // Mark a val as a fully-validated Output: wraps via `refine` with the
-    // schema's output refiner checks (if any) so the emitted check
-    // references the post-decode output variable (the wrapper's `prev` is
-    // the assembled output val). Then sets `isOutput = Some(true)` on the
-    // returned val. Same ownership rule as `markInput`. For async decoders,
-    // the check must be injected inside the `.then` callback on the
-    // resolved value, not on the Promise wrapper — current object/array
-    // decoders still emit on the wrapper for async, which is a known
-    // follow-up.
+    // Wraps `val` via `refine` with the schema's output refiner checks so
+    // the check observes the assembled output, and sets `isOutput =
+    // Some(true)` on the wrapper. Async paths must inject the check
+    // inside `.then` on the resolved value — TODO.
     let markOutput = (val: val, ~schema: internal) => {
       let val = switch schema.refiner {
       | Some(fn) => {
@@ -2828,7 +2816,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     unknownInput->B.unsupportedDecode(~from=unknownInput.schema, ~target=expectedSchema)
   }
 
-  switch expectedSchema.additionalItems->X.Option.getUnsafe {
+  let result = switch expectedSchema.additionalItems->X.Option.getUnsafe {
   | Schema(itemSchema) => {
       let itemSchema = itemSchema->castToInternal
       if itemSchema === unknown {
@@ -2912,6 +2900,9 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       o
     }
   }
+  // inputRefiner on input val (pre-transform); outputRefiner on result.
+  let _: val = input->B.markInput(~schema=expectedSchema)
+  result->B.markOutput(~schema=expectedSchema)
 }
 and objectDecoder: Builder.t = (~input as unknownInput) => {
   let isUnion = unknownInput.isUnion->X.Option.getUnsafe
@@ -3090,15 +3081,8 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
       }
     }
   }
-  // Apply user-supplied refiners after field decoding. `markInput` is
-  // called on the *input* val so the input refiner check is pushed onto
-  // input.checks (alongside the type-narrow) and the emitted check
-  // references the pre-transform input variable — required for inputRefiner
-  // predicates that observe input-shape fields. `markOutput` wraps the
-  // assembled result so its check references the post-decode output. Both
-  // also set isInput / isOutput so the parse-loop primitive fallback skips
-  // this val. Async object refiners still emit on the Promise wrapper —
-  // follow-up.
+  // inputRefiner on the input val so the check observes pre-transform
+  // input; outputRefiner on the assembled result. Async TODO.
   let _: val = input->B.markInput(~schema=expectedSchema)
   result->B.markOutput(~schema=expectedSchema)
 }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1565,15 +1565,13 @@ module Builder = {
       }
     }
 
-    // Pushes the schema's input refiner checks onto `val.checks` (so the
-    // check observes the pre-transform variable via `val.prev.var()`),
-    // then sets `isInput = Some(true)`. When `val.prev` is None (e.g.
-    // primitive decoder returned the operationArg val unchanged), wraps
-    // via `refine` instead so emit has a prev.var() to reference.
-    // Advanced decoders must call this themselves; parse-loop covers
-    // primitives.
-    let markInput = (val: val, ~schema: internal) => {
-      let val = switch schema.inputRefiner {
+    // Pushes the input refiner checks (from `val.expected.inputRefiner`)
+    // onto `val.checks` so emit reads them at val's slot with
+    // inputVar = val.prev.var(); sets `isInput = Some(true)`. When
+    // `val.prev` is None (primitive decoder returned the operationArg
+    // unchanged), wraps via `refine` instead so emit has a prev.var().
+    let markInput = (val: val) => {
+      let val = switch val.expected.inputRefiner {
       | Some(fn) => {
           let checks = fn(~input=val)
           if checks->Js.Array2.length > 0 {
@@ -1596,12 +1594,12 @@ module Builder = {
       val
     }
 
-    // Wraps `val` via `refine` with the schema's output refiner checks so
-    // the check observes the assembled output, and sets `isOutput =
-    // Some(true)` on the wrapper. Async paths must inject the check
-    // inside `.then` on the resolved value — TODO.
-    let markOutput = (val: val, ~schema: internal) => {
-      let val = switch schema.refiner {
+    // Wraps `val` via `refine` with the output refiner checks (from
+    // `val.expected.refiner`) so the check observes the assembled
+    // output; sets `isOutput = Some(true)` on the wrapper. Async paths
+    // must inject the check inside `.then` on the resolved value — TODO.
+    let markOutput = (val: val) => {
+      let val = switch val.expected.refiner {
       | Some(fn) => {
           let checks = fn(~input=val)
           checks->Js.Array2.length > 0 ? val->refine(~checks) : val
@@ -2369,9 +2367,8 @@ let rec parse = (input: val) => {
         // Otherwise, we assume internal transformations are present,
         // and expect the decoder itself to handle refinements and manage isInput/isOutput flags.
         if !(valRef.contents.isOutput->Option.getUnsafe) {
-          let schema = valRef.contents.expected
-          valRef := valRef.contents->B.markInput(~schema)
-          valRef := valRef.contents->B.markOutput(~schema)
+          valRef := valRef.contents->B.markInput
+          valRef := valRef.contents->B.markOutput
         }
       }
     }
@@ -2829,7 +2826,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     unknownInput->B.unsupportedDecode(~from=unknownInput.schema, ~target=expectedSchema)
   }
 
-  let result = switch expectedSchema.additionalItems->X.Option.getUnsafe {
+  let output = switch expectedSchema.additionalItems->X.Option.getUnsafe {
   | Schema(itemSchema) => {
       let itemSchema = itemSchema->castToInternal
       if itemSchema === unknown {
@@ -2913,9 +2910,9 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       o
     }
   }
-  // inputRefiner on input val (pre-transform); outputRefiner on result.
-  let _: val = input->B.markInput(~schema=expectedSchema)
-  result->B.markOutput(~schema=expectedSchema)
+  // inputRefiner on input val (pre-transform); outputRefiner on output.
+  let _: val = input->B.markInput
+  output->B.markOutput
 }
 and objectDecoder: Builder.t = (~input as unknownInput) => {
   let isUnion = unknownInput.isUnion->X.Option.getUnsafe
@@ -2967,7 +2964,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     unknownInput->B.unsupportedDecode(~from=unknownInput.schema, ~target=expectedSchema)
   }
 
-  let result = switch expectedSchema.additionalItems->X.Option.getUnsafe {
+  let output = switch expectedSchema.additionalItems->X.Option.getUnsafe {
   | Schema(itemSchema) => {
       let itemSchema = itemSchema->castToInternal
       if itemSchema === unknown {
@@ -3095,9 +3092,9 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     }
   }
   // inputRefiner on the input val so the check observes pre-transform
-  // input; outputRefiner on the assembled result. Async TODO.
-  let _: val = input->B.markInput(~schema=expectedSchema)
-  result->B.markOutput(~schema=expectedSchema)
+  // input; outputRefiner on the assembled output. Async TODO.
+  let _: val = input->B.markInput
+  output->B.markOutput
 }
 
 let recursiveDecoder = Builder.make((~input) => {
@@ -5815,9 +5812,9 @@ let compactColumnsDecoder = (~input) => {
         } else {
           input
         }
-        let _: val = input->B.markInput(~schema=selfSchema)
+        let _: val = input->B.markInput
         let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
-        output->B.markOutput(~schema=selfSchema)
+        output->B.markOutput
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         let input = if isUnknownInput {
@@ -5911,7 +5908,7 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=new Array(Math.max(${lengthCode.contents}))`)
 
-        let _: val = input->B.markInput(~schema=selfSchema)
+        let _: val = input->B.markInput
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
 
@@ -5946,12 +5943,12 @@ let compactColumnsDecoder = (~input) => {
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${outputVar}.length;++${iteratorVar}){${wrappedBody}}`
 
-        let result = if hasAsync.contents {
+        let output = if hasAsync.contents {
           output->B.asyncVal(`Promise.all(${outputVar})`)
         } else {
           output
         }
-        result->B.markOutput(~schema=selfSchema)
+        output->B.markOutput
       } else {
         // Reverse direction: rows → columnar
         // When the declared source type is unknown, field values have
@@ -6003,7 +6000,7 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
 
-        let _: val = input->B.markInput(~schema=selfSchema)
+        let _: val = input->B.markInput
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
         let loopBody = perFieldCode.contents ++ settingCode.contents
@@ -6016,7 +6013,7 @@ let compactColumnsDecoder = (~input) => {
         output.codeFromPrev =
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${inputVar}.length;++${iteratorVar}){${wrappedBody}}`
-        output->B.markOutput(~schema=selfSchema)
+        output->B.markOutput
       }
     }
   }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -761,8 +761,8 @@ function pushCheck(val, check) {
   }
 }
 
-function markInput(val, schema) {
-  let fn = schema.inputRefiner;
+function markInput(val) {
+  let fn = val.e.inputRefiner;
   let val$1;
   if (fn !== undefined) {
     let checks = fn(val);
@@ -786,8 +786,8 @@ function markInput(val, schema) {
   return val$1;
 }
 
-function markOutput(val, schema) {
-  let fn = schema.refiner;
+function markOutput(val) {
+  let fn = val.e.refiner;
   let val$1;
   if (fn !== undefined) {
     let checks = fn(val);
@@ -1355,9 +1355,8 @@ function parse$1(input) {
       } else {
         valRef = loopInput.e.decoder(loopInput);
         if (!valRef.io) {
-          let schema = valRef.e;
-          valRef = markInput(valRef, schema);
-          valRef = markOutput(valRef, schema);
+          valRef = markInput(valRef);
+          valRef = markOutput(valRef);
         }
         
       }
@@ -1697,24 +1696,24 @@ function arrayDecoder(unknownInput) {
     input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
   }
   let itemSchema = expectedSchema.additionalItems;
-  let result;
+  let output;
   let exit = 0;
   if (itemSchema === "strip" || itemSchema === "strict") {
     exit = 1;
   } else if (itemSchema === unknown) {
-    result = input;
+    output = input;
   } else {
     let inputVar = input.v();
     let iteratorVar = varWithoutAllocation(input.g);
     let itemInput = dynamicScope(input, iteratorVar);
     let itemOutput = parseDynamic(itemInput);
     let hasTransform = itemOutput.t;
-    let output = hasTransform ? next(input, "new Array(" + inputVar + ".length)", expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
-    let itemCode = mergeWithPathPrepend(itemOutput, input, iteratorVar, hasTransform ? () => addKey(output, iteratorVar, itemOutput) : undefined);
+    let output$1 = hasTransform ? next(input, "new Array(" + inputVar + ".length)", expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
+    let itemCode = mergeWithPathPrepend(itemOutput, input, iteratorVar, hasTransform ? () => addKey(output$1, iteratorVar, itemOutput) : undefined);
     if (hasTransform || itemCode !== "") {
-      output.cp = output.cp + ("for(let " + iteratorVar + "=" + expectedLength + ";" + iteratorVar + "<" + inputVar + ".length;++" + iteratorVar + "){" + itemCode + "}");
+      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=" + expectedLength + ";" + iteratorVar + "<" + inputVar + ".length;++" + iteratorVar + "){" + itemCode + "}");
     }
-    result = itemOutput.f & 1 ? asyncVal(output, "Promise.all(" + output.i + ")") : output;
+    output = itemOutput.f & 1 ? asyncVal(output$1, "Promise.all(" + output$1.i + ")") : output$1;
   }
   if (exit === 1) {
     let objectVal = makeObjectVal(input, expectedSchema);
@@ -1749,16 +1748,16 @@ function arrayDecoder(unknownInput) {
       
     }
     if (shouldRecreateInput) {
-      result = completeObjectVal(objectVal);
+      output = completeObjectVal(objectVal);
     } else {
       let o = refine(input, undefined, undefined, undefined);
       o.cp = objectVal.cp;
       o.d = objectVal.d;
-      result = o;
+      output = o;
     }
   }
-  markInput(input, expectedSchema);
-  return markOutput(result, expectedSchema);
+  markInput(input);
+  return markOutput(output);
 }
 
 function objectDecoder(unknownInput) {
@@ -1796,32 +1795,32 @@ function objectDecoder(unknownInput) {
     input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
   }
   let itemSchema = expectedSchema.additionalItems;
-  let result;
+  let output;
   let exit = 0;
   if (itemSchema === "strip" || itemSchema === "strict") {
     exit = 1;
   } else if (itemSchema === unknown) {
-    result = input;
+    output = input;
   } else {
     let inputVar = input.v();
     let keyVar = varWithoutAllocation(input.g);
     let itemInput = dynamicScope(input, keyVar);
     let itemOutput = parseDynamic(itemInput);
     let hasTransform = itemOutput.t;
-    let output = hasTransform ? next(input, "{}", expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
-    let itemCode = mergeWithPathPrepend(itemOutput, input, keyVar, hasTransform ? () => addKey(output, keyVar, itemOutput) : undefined);
+    let output$1 = hasTransform ? next(input, "{}", expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
+    let itemCode = mergeWithPathPrepend(itemOutput, input, keyVar, hasTransform ? () => addKey(output$1, keyVar, itemOutput) : undefined);
     if (hasTransform || itemCode !== "") {
-      output.cp = output.cp + ("for(let " + keyVar + " in " + inputVar + "){" + itemCode + "}");
+      output$1.cp = output$1.cp + ("for(let " + keyVar + " in " + inputVar + "){" + itemCode + "}");
     }
     if (itemOutput.f & 1) {
-      let resolveVar = varWithoutAllocation(output.g);
-      let rejectVar = varWithoutAllocation(output.g);
-      let asyncParseResultVar = varWithoutAllocation(output.g);
-      let counterVar = varWithoutAllocation(output.g);
-      let outputVar = output.v();
-      result = asyncVal(output, "new Promise((" + resolveVar + "," + rejectVar + ")=>{let " + counterVar + "=Object.keys(" + outputVar + ").length;for(let " + keyVar + " in " + outputVar + "){" + outputVar + "[" + keyVar + "].then(" + asyncParseResultVar + "=>{" + outputVar + "[" + keyVar + "]=" + asyncParseResultVar + ";if(" + counterVar + "--===1){" + resolveVar + "(" + outputVar + ")}}," + rejectVar + ")}})");
+      let resolveVar = varWithoutAllocation(output$1.g);
+      let rejectVar = varWithoutAllocation(output$1.g);
+      let asyncParseResultVar = varWithoutAllocation(output$1.g);
+      let counterVar = varWithoutAllocation(output$1.g);
+      let outputVar = output$1.v();
+      output = asyncVal(output$1, "new Promise((" + resolveVar + "," + rejectVar + ")=>{let " + counterVar + "=Object.keys(" + outputVar + ").length;for(let " + keyVar + " in " + outputVar + "){" + outputVar + "[" + keyVar + "].then(" + asyncParseResultVar + "=>{" + outputVar + "[" + keyVar + "]=" + asyncParseResultVar + ";if(" + counterVar + "--===1){" + resolveVar + "(" + outputVar + ")}}," + rejectVar + ")}})");
     } else {
-      result = output;
+      output = output$1;
     }
   }
   if (exit === 1) {
@@ -1898,16 +1897,16 @@ function objectDecoder(unknownInput) {
       }), keyVar$1) + "}}");
     }
     if (shouldRecreateInput) {
-      result = completeObjectVal(objectVal);
+      output = completeObjectVal(objectVal);
     } else {
       let o = refine(input, undefined, undefined, undefined);
       o.cp = objectVal.cp;
       o.d = objectVal.d;
-      result = o;
+      output = o;
     }
   }
-  markInput(input, expectedSchema);
-  return markOutput(result, expectedSchema);
+  markInput(input);
+  return markOutput(output);
 }
 
 function recursiveDecoder(input) {
@@ -3463,157 +3462,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3714,6 +3562,153 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = "~" + fieldName;
@@ -3789,20 +3784,18 @@ function definitionToSchema(definition) {
   });
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function shapedParser(input) {
@@ -3826,6 +3819,12 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return output;
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {
@@ -3993,9 +3992,8 @@ function compactColumnsDecoder(input) {
             c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0",
             f: failInvalidType
           }], undefined) : input;
-      markInput(input$1, selfSchema);
-      let output = next(input$1, "[]", outputSchema, outputSchema);
-      return markOutput(output, selfSchema);
+      markInput(input$1);
+      return markOutput(next(input$1, "[]", outputSchema, outputSchema));
     }
     if (forwardProps) {
       let input$2 = isUnknownInput ? refine(input, undefined, [{
@@ -4050,9 +4048,9 @@ function compactColumnsDecoder(input) {
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input$2.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
-      markInput(input$2, selfSchema);
-      let output$1 = next(input$2, outputVar, outputSchema, outputSchema);
-      output$1.v = _var;
+      markInput(input$2);
+      let output = next(input$2, outputVar, outputSchema, outputSchema);
+      output.v = _var;
       let rowAssign;
       if (hasAsync) {
         let rowResultVar = varWithoutAllocation(input$2.g);
@@ -4073,9 +4071,8 @@ function compactColumnsDecoder(input) {
         let errorVar = varWithoutAllocation(input$2.g);
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
-      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
-      let result = hasAsync ? asyncVal(output$1, "Promise.all(" + outputVar + ")") : output$1;
-      return markOutput(result, selfSchema);
+      output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
+      return markOutput(hasAsync ? asyncVal(output, "Promise.all(" + outputVar + ")") : output);
     }
     let inputVar$1 = input.v();
     let iteratorVar$1 = varWithoutAllocation(input.g);
@@ -4109,9 +4106,9 @@ function compactColumnsDecoder(input) {
       }
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
-    markInput(input, selfSchema);
-    let output$2 = next(input, outputVar$1, outputSchema, outputSchema);
-    output$2.v = _var;
+    markInput(input);
+    let output$1 = next(input, outputVar$1, outputSchema, outputSchema);
+    output$1.v = _var;
     let loopBody = perFieldCode + settingCode;
     let wrappedBody$1;
     if (needsPerFieldTransform && perFieldCode !== "") {
@@ -4120,8 +4117,8 @@ function compactColumnsDecoder(input) {
     } else {
       wrappedBody$1 = loopBody;
     }
-    output$2.cp = output$2.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
-    return markOutput(output$2, selfSchema);
+    output$1.cp = output$1.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
+    return markOutput(output$1);
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -761,6 +761,44 @@ function pushCheck(val, check) {
   }
 }
 
+function markInput(val, schema) {
+  let fn = schema.inputRefiner;
+  let val$1;
+  if (fn !== undefined) {
+    let checks = fn(val);
+    if (checks.length > 0) {
+      let match = val.prev;
+      if (match !== undefined) {
+        for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
+          pushCheck(val, checks[i]);
+        }
+        val$1 = val;
+      } else {
+        val$1 = refine(val, undefined, checks, undefined);
+      }
+    } else {
+      val$1 = val;
+    }
+  } else {
+    val$1 = val;
+  }
+  val$1.ii = true;
+  return val$1;
+}
+
+function markOutput(val, schema) {
+  let fn = schema.refiner;
+  let val$1;
+  if (fn !== undefined) {
+    let checks = fn(val);
+    val$1 = checks.length > 0 ? refine(val, undefined, checks, undefined) : val;
+  } else {
+    val$1 = val;
+  }
+  val$1.io = true;
+  return val$1;
+}
+
 function hoistChildChecks(parent, child, key) {
   if (!child.vc) {
     return;
@@ -1317,47 +1355,15 @@ function parse$1(input) {
       } else {
         valRef = loopInput.e.decoder(loopInput);
         if (!valRef.io) {
-          let hasInputRefiner = valRef.e.inputRefiner;
-          let hasRefiner = valRef.e.refiner;
-          if (hasInputRefiner || hasRefiner) {
-            let checks = [];
-            if (hasInputRefiner) {
-              let arr = valRef.e.inputRefiner(valRef);
-              for (let i = 0, i_finish = arr.length; i < i_finish; ++i) {
-                checks.push(arr[i]);
-              }
-            }
-            if (hasRefiner) {
-              let arr$1 = valRef.e.refiner(valRef);
-              for (let i$1 = 0, i_finish$1 = arr$1.length; i$1 < i_finish$1; ++i$1) {
-                checks.push(arr$1[i$1]);
-              }
-            }
-            if (checks.length > 0) {
-              valRef = refine(valRef, undefined, checks, undefined);
-            }
-            
-          }
-          valRef.ii = true;
-          valRef.io = true;
+          let schema = valRef.e;
+          valRef = markInput(valRef, schema);
+          valRef = markOutput(valRef, schema);
         }
         
       }
     }
   };
   return valRef;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function reverse(schema) {
@@ -1463,6 +1469,18 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
+}
+
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
 }
 
 function parseDynamic(input) {
@@ -1679,12 +1697,13 @@ function arrayDecoder(unknownInput) {
     input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
   }
   let itemSchema = expectedSchema.additionalItems;
+  let result;
+  let exit = 0;
   if (itemSchema === "strip" || itemSchema === "strict") {
-    itemSchema === "strip";
+    exit = 1;
+  } else if (itemSchema === unknown) {
+    result = input;
   } else {
-    if (itemSchema === unknown) {
-      return input;
-    }
     let inputVar = input.v();
     let iteratorVar = varWithoutAllocation(input.g);
     let itemInput = dynamicScope(input, iteratorVar);
@@ -1695,50 +1714,51 @@ function arrayDecoder(unknownInput) {
     if (hasTransform || itemCode !== "") {
       output.cp = output.cp + ("for(let " + iteratorVar + "=" + expectedLength + ";" + iteratorVar + "<" + inputVar + ".length;++" + iteratorVar + "){" + itemCode + "}");
     }
-    if (itemOutput.f & 1) {
-      return asyncVal(output, "Promise.all(" + output.i + ")");
+    result = itemOutput.f & 1 ? asyncVal(output, "Promise.all(" + output.i + ")") : output;
+  }
+  if (exit === 1) {
+    let objectVal = makeObjectVal(input, expectedSchema);
+    let match$2 = expectedSchema.additionalItems;
+    let shouldRecreateInput;
+    if (match$2 === "strip" || match$2 === "strict") {
+      if (match$2 === "strip") {
+        let match$3 = input.s.additionalItems;
+        shouldRecreateInput = match$3 === "strip" || match$3 === "strict" ? input.s.items.length !== expectedLength : true;
+      } else {
+        shouldRecreateInput = false;
+      }
     } else {
-      return output;
+      shouldRecreateInput = true;
     }
-  }
-  let objectVal = makeObjectVal(input, expectedSchema);
-  let match$2 = expectedSchema.additionalItems;
-  let shouldRecreateInput;
-  if (match$2 === "strip" || match$2 === "strict") {
-    if (match$2 === "strip") {
-      let match$3 = input.s.additionalItems;
-      shouldRecreateInput = match$3 === "strip" || match$3 === "strict" ? input.s.items.length !== expectedLength : true;
+    for (let idx = 0; idx < expectedLength; ++idx) {
+      let schema$1 = expectedItems[idx];
+      let key = idx.toString();
+      let itemInput$1 = get(input, key);
+      itemInput$1.e = schema$1;
+      itemInput$1.ii = false;
+      itemInput$1.io = false;
+      itemInput$1.u = isUnion;
+      let itemOutput$1 = parse$1(itemInput$1);
+      if (isUnion && constField in schema$1) {
+        hoistChildChecks(input, itemOutput$1, key);
+      }
+      add(objectVal, key, itemOutput$1);
+      if (!shouldRecreateInput) {
+        shouldRecreateInput = itemOutput$1.t;
+      }
+      
+    }
+    if (shouldRecreateInput) {
+      result = completeObjectVal(objectVal);
     } else {
-      shouldRecreateInput = false;
+      let o = refine(input, undefined, undefined, undefined);
+      o.cp = objectVal.cp;
+      o.d = objectVal.d;
+      result = o;
     }
-  } else {
-    shouldRecreateInput = true;
   }
-  for (let idx = 0; idx < expectedLength; ++idx) {
-    let schema$1 = expectedItems[idx];
-    let key = idx.toString();
-    let itemInput$1 = get(input, key);
-    itemInput$1.e = schema$1;
-    itemInput$1.ii = false;
-    itemInput$1.io = false;
-    itemInput$1.u = isUnion;
-    let itemOutput$1 = parse$1(itemInput$1);
-    if (isUnion && constField in schema$1) {
-      hoistChildChecks(input, itemOutput$1, key);
-    }
-    add(objectVal, key, itemOutput$1);
-    if (!shouldRecreateInput) {
-      shouldRecreateInput = itemOutput$1.t;
-    }
-    
-  }
-  if (shouldRecreateInput) {
-    return completeObjectVal(objectVal);
-  }
-  let o = refine(input, undefined, undefined, undefined);
-  o.cp = objectVal.cp;
-  o.d = objectVal.d;
-  return o;
+  markInput(input, expectedSchema);
+  return markOutput(result, expectedSchema);
 }
 
 function objectDecoder(unknownInput) {
@@ -1776,13 +1796,13 @@ function objectDecoder(unknownInput) {
     input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
   }
   let itemSchema = expectedSchema.additionalItems;
+  let result;
   let exit = 0;
   if (itemSchema === "strip" || itemSchema === "strict") {
     exit = 1;
+  } else if (itemSchema === unknown) {
+    result = input;
   } else {
-    if (itemSchema === unknown) {
-      return input;
-    }
     let inputVar = input.v();
     let keyVar = varWithoutAllocation(input.g);
     let itemInput = dynamicScope(input, keyVar);
@@ -1793,15 +1813,16 @@ function objectDecoder(unknownInput) {
     if (hasTransform || itemCode !== "") {
       output.cp = output.cp + ("for(let " + keyVar + " in " + inputVar + "){" + itemCode + "}");
     }
-    if (!(itemOutput.f & 1)) {
-      return output;
+    if (itemOutput.f & 1) {
+      let resolveVar = varWithoutAllocation(output.g);
+      let rejectVar = varWithoutAllocation(output.g);
+      let asyncParseResultVar = varWithoutAllocation(output.g);
+      let counterVar = varWithoutAllocation(output.g);
+      let outputVar = output.v();
+      result = asyncVal(output, "new Promise((" + resolveVar + "," + rejectVar + ")=>{let " + counterVar + "=Object.keys(" + outputVar + ").length;for(let " + keyVar + " in " + outputVar + "){" + outputVar + "[" + keyVar + "].then(" + asyncParseResultVar + "=>{" + outputVar + "[" + keyVar + "]=" + asyncParseResultVar + ";if(" + counterVar + "--===1){" + resolveVar + "(" + outputVar + ")}}," + rejectVar + ")}})");
+    } else {
+      result = output;
     }
-    let resolveVar = varWithoutAllocation(output.g);
-    let rejectVar = varWithoutAllocation(output.g);
-    let asyncParseResultVar = varWithoutAllocation(output.g);
-    let counterVar = varWithoutAllocation(output.g);
-    let outputVar = output.v();
-    return asyncVal(output, "new Promise((" + resolveVar + "," + rejectVar + ")=>{let " + counterVar + "=Object.keys(" + outputVar + ").length;for(let " + keyVar + " in " + outputVar + "){" + outputVar + "[" + keyVar + "].then(" + asyncParseResultVar + "=>{" + outputVar + "[" + keyVar + "]=" + asyncParseResultVar + ";if(" + counterVar + "--===1){" + resolveVar + "(" + outputVar + ")}}," + rejectVar + ")}})");
   }
   if (exit === 1) {
     let properties = expectedSchema.properties;
@@ -1877,14 +1898,16 @@ function objectDecoder(unknownInput) {
       }), keyVar$1) + "}}");
     }
     if (shouldRecreateInput) {
-      return completeObjectVal(objectVal);
+      result = completeObjectVal(objectVal);
+    } else {
+      let o = refine(input, undefined, undefined, undefined);
+      o.cp = objectVal.cp;
+      o.d = objectVal.d;
+      result = o;
     }
-    let o = refine(input, undefined, undefined, undefined);
-    o.cp = objectVal.cp;
-    o.d = objectVal.d;
-    return o;
   }
-  
+  markInput(input, expectedSchema);
+  return markOutput(result, expectedSchema);
 }
 
 function recursiveDecoder(input) {
@@ -3440,6 +3463,59 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== "object" || definition === null) {
     return parse(definition);
@@ -3482,67 +3558,60 @@ function traverseDefinition(definition, onNode) {
   return mut$2;
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
       }
     } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
       } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
       }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
     }
-    v = completeObjectVal(output);
+    accAtFrom.val = input;
+    return;
   }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3720,60 +3789,14 @@ function definitionToSchema(definition) {
   });
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function definitionToShapedSchema(definition) {
@@ -3970,9 +3993,9 @@ function compactColumnsDecoder(input) {
             c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0",
             f: failInvalidType
           }], undefined) : input;
+      markInput(input$1, selfSchema);
       let output = next(input$1, "[]", outputSchema, outputSchema);
-      output.io = true;
-      return output;
+      return markOutput(output, selfSchema);
     }
     if (forwardProps) {
       let input$2 = isUnknownInput ? refine(input, undefined, [{
@@ -4027,9 +4050,9 @@ function compactColumnsDecoder(input) {
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input$2.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
+      markInput(input$2, selfSchema);
       let output$1 = next(input$2, outputVar, outputSchema, outputSchema);
       output$1.v = _var;
-      output$1.io = true;
       let rowAssign;
       if (hasAsync) {
         let rowResultVar = varWithoutAllocation(input$2.g);
@@ -4051,11 +4074,8 @@ function compactColumnsDecoder(input) {
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
       output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
-      if (hasAsync) {
-        return asyncVal(output$1, "Promise.all(" + outputVar + ")");
-      } else {
-        return output$1;
-      }
+      let result = hasAsync ? asyncVal(output$1, "Promise.all(" + outputVar + ")") : output$1;
+      return markOutput(result, selfSchema);
     }
     let inputVar$1 = input.v();
     let iteratorVar$1 = varWithoutAllocation(input.g);
@@ -4089,9 +4109,9 @@ function compactColumnsDecoder(input) {
       }
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
+    markInput(input, selfSchema);
     let output$2 = next(input, outputVar$1, outputSchema, outputSchema);
     output$2.v = _var;
-    output$2.io = true;
     let loopBody = perFieldCode + settingCode;
     let wrappedBody$1;
     if (needsPerFieldTransform && perFieldCode !== "") {
@@ -4101,7 +4121,7 @@ function compactColumnsDecoder(input) {
       wrappedBody$1 = loopBody;
     }
     output$2.cp = output$2.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
-    return output$2;
+    return markOutput(output$2, selfSchema);
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -110,10 +110,13 @@ test(
   "Refiner application order: type-narrow first, then inputRefiner, then output refiner",
   t => {
     let schema =
-      S.schema({"foo": S.string})
+      S.schema(s => {"foo": s.matches(S.string)})
       ->S.refine(i => i["foo"] !== "rejectByInput", ~error="Input refine failure")
       ->S.reverse
-      ->S.refine(i => i["foo"] !== "rejectByOutput", ~error="Output refine failure")
+      ->S.refine(
+        i => (i->Obj.magic)["foo"] !== "rejectByOutput",
+        ~error="Output refine failure",
+      )
 
     // Type-narrow on `foo` runs before either refiner.
     t->U.assertThrowsMessage(
@@ -136,7 +139,7 @@ test(
     // All three pass.
     t->Assert.deepEqual(
       %raw(`{"foo": "ok"}`)->S.parseOrThrow(~to=schema),
-      {"foo": "ok"},
+      {"foo": "ok"}->Obj.magic,
     )
   },
 )
@@ -151,7 +154,7 @@ test(
 // bigint -> string transform turns foo into a string).
 test("inputRefiner observes pre-transform input on a reversed transforming schema", t => {
   let schema =
-    S.schema({"foo": S.string->S.to(S.bigint)})
+    S.schema(s => {"foo": s.matches(S.string->S.to(S.bigint))})
     ->S.refine(
       i => Js.typeof(i["foo"]) === "bigint",
       ~error="Input refine should get a correct input value",
@@ -161,12 +164,12 @@ test("inputRefiner observes pre-transform input on a reversed transforming schem
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{typeof i==="object"&&i||e[2](i);e[1](i)||e[3](i);let v0=i["foo"];typeof v0==="bigint"||e[0](v0);return {"foo":""+v0,}}`,
+    `i=>{typeof i==="object"&&i||e[2](i);e[1](i)||e[3](i);let v0=i["foo"];typeof v0==="bigint"||e[0](v0);return {"foo":""+i["foo"],}}`,
   )
 
   t->Assert.deepEqual(
     %raw(`{"foo": 123n}`)->S.parseOrThrow(~to=schema),
-    {"foo": "123"},
+    {"foo": "123"}->Obj.magic,
   )
 })
 
@@ -186,7 +189,7 @@ test("inputRefiner observes pre-transform input on a reversed transforming array
 
   t->Assert.deepEqual(
     %raw(`[1n, 2n, 3n]`)->S.parseOrThrow(~to=schema),
-    ["1", "2", "3"],
+    ["1", "2", "3"]->Obj.magic,
   )
 })
 
@@ -285,7 +288,7 @@ test("inputRefiner observes pre-transform input on a reversed transforming dict"
 
   t->Assert.deepEqual(
     %raw(`{"a": 1n, "b": 2n}`)->S.parseOrThrow(~to=schema),
-    Js.Dict.fromArray([("a", "1"), ("b", "2")]),
+    Js.Dict.fromArray([("a", "1"), ("b", "2")])->Obj.magic,
   )
 })
 
@@ -300,7 +303,7 @@ test("inputRefiner observes pre-transform input on a reversed transforming tuple
 
   t->Assert.deepEqual(
     %raw(`[1n, 5]`)->S.parseOrThrow(~to=schema),
-    ("1", 5),
+    ("1", 5)->Obj.magic,
   )
 })
 

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -408,10 +408,17 @@ test("inputRefiner runs on reversed S.compactColumns", t => {
 test("Refiner runs on S.shape", t => {
   let schema =
     S.string
-    ->S.shape(s => s)
-    ->S.refine(s => Js.String2.length(s) < 10, ~error="Shape refine fail")
+    ->S.shape(s => Ok(s))
+    ->S.refine(
+      v =>
+        switch v {
+        | Ok(s) => Js.String2.length(s) < 10
+        | _ => false
+        },
+      ~error="Shape refine fail",
+    )
 
-  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), "hello")
+  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), Ok("hello"))
   t->U.assertThrowsMessage(
     () => "hello world"->S.parseOrThrow(~to=schema),
     `Shape refine fail`,
@@ -421,13 +428,20 @@ test("Refiner runs on S.shape", t => {
 test("inputRefiner runs on reversed S.shape", t => {
   let schema =
     S.string
-    ->S.shape(s => s)
-    ->S.refine(s => Js.String2.length(s) < 10, ~error="Shape input refine fail")
+    ->S.shape(s => Ok(s))
+    ->S.refine(
+      v =>
+        switch v {
+        | Ok(s) => Js.String2.length(s) < 10
+        | _ => false
+        },
+      ~error="Shape input refine fail",
+    )
     ->S.reverse
 
-  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), "hello"->Obj.magic)
+  t->Assert.deepEqual(Ok("hello")->S.parseOrThrow(~to=schema), "hello"->Obj.magic)
   t->U.assertThrowsMessage(
-    () => "hello world"->S.parseOrThrow(~to=schema),
+    () => Ok("hello world")->S.parseOrThrow(~to=schema),
     `Shape input refine fail`,
   )
 })

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -210,3 +210,58 @@ test("Output refine on a tuple runs on the assembled tuple", t => {
     `String length must match int`,
   )
 })
+
+// Custom-decoder refiner audit: every advanced decoder must surface
+// user S.refine. Tests below pin the always-fails path so a silent drop
+// surfaces immediately.
+
+test("Refiner runs on S.dict", t => {
+  let schema = S.dict(S.int)->S.refine(_ => false, ~error="Dict refine fail")
+  t->U.assertThrowsMessage(
+    () => %raw(`{"a": 1}`)->S.parseOrThrow(~to=schema),
+    `Dict refine fail`,
+  )
+})
+
+test("Refiner runs on S.json", t => {
+  let schema = S.json->S.refine(_ => false, ~error="Json refine fail")
+  t->U.assertThrowsMessage(
+    () => %raw(`{"a": 1}`)->S.parseOrThrow(~to=schema),
+    `Json refine fail`,
+  )
+})
+
+test("Refiner runs on S.jsonString", t => {
+  let schema = S.jsonString->S.refine(_ => false, ~error="JsonString refine fail")
+  t->U.assertThrowsMessage(
+    () => `{"a":1}`->S.parseOrThrow(~to=schema),
+    `JsonString refine fail`,
+  )
+})
+
+test("Refiner runs on S.uint8Array", t => {
+  let schema = S.uint8Array->S.refine(_ => false, ~error="Uint8Array refine fail")
+  t->U.assertThrowsMessage(
+    () => %raw(`new Uint8Array([1, 2, 3])`)->S.parseOrThrow(~to=schema),
+    `Uint8Array refine fail`,
+  )
+})
+
+test("Refiner runs on S.compactColumns", t => {
+  let schema =
+    S.compactColumns(S.unknown)
+    ->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+          }
+        ),
+      ),
+    )
+    ->S.refine(_ => false, ~error="CompactColumns refine fail")
+  t->U.assertThrowsMessage(
+    () => %raw(`[["a"]]`)->S.parseOrThrow(~to=schema),
+    `CompactColumns refine fail`,
+  )
+})

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -140,3 +140,25 @@ test(
     )
   },
 )
+
+// Regression: with a transforming field, the inputRefiner must observe the
+// pre-transform input value, not the post-transform output. Here the schema's
+// foo field is string -> bigint, so after S.reverse the field decodes
+// bigint -> string and the original output refiner becomes the inputRefiner.
+// The predicate checks that foo is bigint — which is true of the Input but
+// false of the post-decode Output. If the inputRefiner runs after field
+// decoding, it sees a string and incorrectly rejects.
+test("inputRefiner observes pre-transform input on a reversed transforming schema", t => {
+  let schema =
+    S.schema({"foo": S.string->S.to(S.bigint)})
+    ->S.refine(
+      i => Js.typeof(i["foo"]) === "bigint",
+      ~error="Input refine should get a correct input value",
+    )
+    ->S.reverse
+
+  t->Assert.deepEqual(
+    %raw(`{"foo": 123n}`)->S.parseOrThrow(~to=schema),
+    {"foo": "123"},
+  )
+})

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -105,3 +105,38 @@ test("Chaining refinements", t => {
   t->U.assertThrowsMessage(() => %raw(`-2`)->S.parseOrThrow(~to=schema), `Must be positive`)
   t->U.assertThrowsMessage(() => %raw(`3`)->S.parseOrThrow(~to=schema), `Must be even`)
 })
+
+test(
+  "Refiner application order: type-narrow first, then inputRefiner, then output refiner",
+  t => {
+    let schema =
+      S.schema({"foo": S.string})
+      ->S.refine(i => i["foo"] !== "rejectByInput", ~error="Input refine failure")
+      ->S.reverse
+      ->S.refine(i => i["foo"] !== "rejectByOutput", ~error="Output refine failure")
+
+    // Type-narrow on `foo` runs before either refiner.
+    t->U.assertThrowsMessage(
+      () => %raw(`{"foo": 123}`)->S.parseOrThrow(~to=schema),
+      `Failed at ["foo"]: Expected string, received 123`,
+    )
+
+    // Type-narrow passes; inputRefiner rejects.
+    t->U.assertThrowsMessage(
+      () => %raw(`{"foo": "rejectByInput"}`)->S.parseOrThrow(~to=schema),
+      `Input refine failure`,
+    )
+
+    // Type-narrow + inputRefiner pass; output refiner rejects.
+    t->U.assertThrowsMessage(
+      () => %raw(`{"foo": "rejectByOutput"}`)->S.parseOrThrow(~to=schema),
+      `Output refine failure`,
+    )
+
+    // All three pass.
+    t->Assert.deepEqual(
+      %raw(`{"foo": "ok"}`)->S.parseOrThrow(~to=schema),
+      {"foo": "ok"},
+    )
+  },
+)

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -146,8 +146,9 @@ test(
 // foo field is string -> bigint, so after S.reverse the field decodes
 // bigint -> string and the original output refiner becomes the inputRefiner.
 // The predicate checks that foo is bigint — which is true of the Input but
-// false of the post-decode Output. If the inputRefiner runs after field
-// decoding, it sees a string and incorrectly rejects.
+// false of the post-decode Output. The check must be pushed onto the input
+// val's checks slot so it emits before field decoding code (where the
+// bigint -> string transform turns foo into a string).
 test("inputRefiner observes pre-transform input on a reversed transforming schema", t => {
   let schema =
     S.schema({"foo": S.string->S.to(S.bigint)})
@@ -156,6 +157,12 @@ test("inputRefiner observes pre-transform input on a reversed transforming schem
       ~error="Input refine should get a correct input value",
     )
     ->S.reverse
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{typeof i==="object"&&i||e[2](i);e[1](i)||e[3](i);let v0=i["foo"];typeof v0==="bigint"||e[0](v0);return {"foo":""+v0,}}`,
+  )
 
   t->Assert.deepEqual(
     %raw(`{"foo": 123n}`)->S.parseOrThrow(~to=schema),

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -169,3 +169,44 @@ test("inputRefiner observes pre-transform input on a reversed transforming schem
     {"foo": "123"},
   )
 })
+
+// arrayDecoder analog: refiners on an array schema must observe the
+// pre-transform input (for inputRefiner) and the assembled output
+// (for outputRefiner). The array element is string -> bigint, so the
+// reversed schema decodes bigint -> string; the inputRefiner predicate
+// checks bigint and would reject if it ran on the post-decode strings.
+test("inputRefiner observes pre-transform input on a reversed transforming array schema", t => {
+  let schema =
+    S.array(S.string->S.to(S.bigint))
+    ->S.refine(
+      arr => arr->Js.Array2.every(x => Js.typeof(x) === "bigint"),
+      ~error="Array input refine should see bigint elements",
+    )
+    ->S.reverse
+
+  t->Assert.deepEqual(
+    %raw(`[1n, 2n, 3n]`)->S.parseOrThrow(~to=schema),
+    ["1", "2", "3"],
+  )
+})
+
+test("Output refine on an array runs on the assembled output array", t => {
+  let schema = S.array(S.int)->S.refine(arr => arr->Js.Array2.length > 0, ~error="Empty array")
+
+  t->Assert.deepEqual(%raw(`[1, 2, 3]`)->S.parseOrThrow(~to=schema), [1, 2, 3])
+  t->U.assertThrowsMessage(() => %raw(`[]`)->S.parseOrThrow(~to=schema), `Empty array`)
+})
+
+test("Output refine on a tuple runs on the assembled tuple", t => {
+  let schema =
+    S.tuple(s => (s.item(0, S.string), s.item(1, S.int)))->S.refine(
+      ((s, i)) => Js.String2.length(s) === i,
+      ~error="String length must match int",
+    )
+
+  t->Assert.deepEqual(%raw(`["abc", 3]`)->S.parseOrThrow(~to=schema), ("abc", 3))
+  t->U.assertThrowsMessage(
+    () => %raw(`["abc", 5]`)->S.parseOrThrow(~to=schema),
+    `String length must match int`,
+  )
+})

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -156,7 +156,7 @@ test("inputRefiner observes pre-transform input on a reversed transforming schem
   let schema =
     S.schema(s => {"foo": s.matches(S.string->S.to(S.bigint))})
     ->S.refine(
-      i => Js.typeof(i["foo"]) === "bigint",
+      i => Js.typeof(i["foo"]) === "bigint" && i["foo"] >= 0n,
       ~error="Input refine should get a correct input value",
     )
     ->S.reverse
@@ -171,18 +171,19 @@ test("inputRefiner observes pre-transform input on a reversed transforming schem
     %raw(`{"foo": 123n}`)->S.parseOrThrow(~to=schema),
     {"foo": "123"}->Obj.magic,
   )
+  t->U.assertThrowsMessage(
+    () => %raw(`{"foo": -1n}`)->S.parseOrThrow(~to=schema),
+    `Input refine should get a correct input value`,
+  )
 })
 
-// arrayDecoder analog: refiners on an array schema must observe the
-// pre-transform input (for inputRefiner) and the assembled output
-// (for outputRefiner). The array element is string -> bigint, so the
-// reversed schema decodes bigint -> string; the inputRefiner predicate
-// checks bigint and would reject if it ran on the post-decode strings.
 test("inputRefiner observes pre-transform input on a reversed transforming array schema", t => {
   let schema =
     S.array(S.string->S.to(S.bigint))
     ->S.refine(
-      arr => arr->Js.Array2.every(x => Js.typeof(x) === "bigint"),
+      arr =>
+        arr->Js.Array2.every(x => Js.typeof(x) === "bigint") &&
+          arr->Js.Array2.every(x => x >= 0n),
       ~error="Array input refine should see bigint elements",
     )
     ->S.reverse
@@ -190,6 +191,10 @@ test("inputRefiner observes pre-transform input on a reversed transforming array
   t->Assert.deepEqual(
     %raw(`[1n, 2n, 3n]`)->S.parseOrThrow(~to=schema),
     ["1", "2", "3"]->Obj.magic,
+  )
+  t->U.assertThrowsMessage(
+    () => %raw(`[-1n]`)->S.parseOrThrow(~to=schema),
+    `Array input refine should see bigint elements`,
   )
 })
 
@@ -215,37 +220,51 @@ test("Output refine on a tuple runs on the assembled tuple", t => {
 })
 
 // Custom-decoder refiner audit: every advanced decoder must surface
-// user S.refine. Tests below pin the always-fails path so a silent drop
-// surfaces immediately.
+// user S.refine. Each test exercises both the passing and the failing
+// branch of a meaningful predicate.
 
 test("Refiner runs on S.dict", t => {
-  let schema = S.dict(S.int)->S.refine(_ => false, ~error="Dict refine fail")
+  let schema =
+    S.dict(S.int)->S.refine(d => !(d->Js.Dict.keys->Js.Array2.includes("fail")), ~error="Dict refine fail")
+
+  t->Assert.deepEqual(%raw(`{"a": 1}`)->S.parseOrThrow(~to=schema), Js.Dict.fromArray([("a", 1)]))
   t->U.assertThrowsMessage(
-    () => %raw(`{"a": 1}`)->S.parseOrThrow(~to=schema),
+    () => %raw(`{"fail": 1}`)->S.parseOrThrow(~to=schema),
     `Dict refine fail`,
   )
 })
 
 test("Refiner runs on S.json", t => {
-  let schema = S.json->S.refine(_ => false, ~error="Json refine fail")
-  t->U.assertThrowsMessage(
-    () => %raw(`{"a": 1}`)->S.parseOrThrow(~to=schema),
-    `Json refine fail`,
-  )
+  let schema = S.json->S.refine(v => v !== %raw(`null`), ~error="Json refine fail")
+
+  t->Assert.deepEqual(%raw(`{"a": 1}`)->S.parseOrThrow(~to=schema), %raw(`{"a": 1}`))
+  t->U.assertThrowsMessage(() => %raw(`null`)->S.parseOrThrow(~to=schema), `Json refine fail`)
 })
 
 test("Refiner runs on S.jsonString", t => {
-  let schema = S.jsonString->S.refine(_ => false, ~error="JsonString refine fail")
+  let schema =
+    S.jsonString->S.refine(s => Js.String2.length(s) < 10, ~error="JsonString refine fail")
+
+  t->Assert.deepEqual(`1`->S.parseOrThrow(~to=schema), `1`)
   t->U.assertThrowsMessage(
-    () => `{"a":1}`->S.parseOrThrow(~to=schema),
+    () => `{"a":1,"b":2}`->S.parseOrThrow(~to=schema),
     `JsonString refine fail`,
   )
 })
 
 test("Refiner runs on S.uint8Array", t => {
-  let schema = S.uint8Array->S.refine(_ => false, ~error="Uint8Array refine fail")
+  let schema =
+    S.uint8Array->S.refine(
+      arr => (arr->Obj.magic)["byteLength"] < 5,
+      ~error="Uint8Array refine fail",
+    )
+
+  t->Assert.deepEqual(
+    %raw(`new Uint8Array([1, 2, 3])`)->S.parseOrThrow(~to=schema),
+    %raw(`new Uint8Array([1, 2, 3])`),
+  )
   t->U.assertThrowsMessage(
-    () => %raw(`new Uint8Array([1, 2, 3])`)->S.parseOrThrow(~to=schema),
+    () => %raw(`new Uint8Array([1, 2, 3, 4, 5, 6])`)->S.parseOrThrow(~to=schema),
     `Uint8Array refine fail`,
   )
 })
@@ -262,17 +281,22 @@ test("Refiner runs on S.compactColumns", t => {
         ),
       ),
     )
-    ->S.refine(_ => false, ~error="CompactColumns refine fail")
+    ->S.refine(arr => arr->Js.Array2.length > 0, ~error="Empty compactColumns")
+
+  t->Assert.deepEqual(
+    %raw(`[["a"]]`)->S.parseOrThrow(~to=schema),
+    [{"foo": "a"}],
+  )
   t->U.assertThrowsMessage(
-    () => %raw(`[["a"]]`)->S.parseOrThrow(~to=schema),
-    `CompactColumns refine fail`,
+    () => %raw(`[[]]`)->S.parseOrThrow(~to=schema),
+    `Empty compactColumns`,
   )
 })
 
 // inputRefiner coverage for the custom decoders. inputRefiner is created
 // via S.refine(...)->S.reverse, which swaps refiner ↔ inputRefiner. For
 // schemas with nested-item transforms, the predicate must observe the
-// pre-transform input type — these tests pin that contract.
+// pre-transform input type.
 
 test("inputRefiner observes pre-transform input on a reversed transforming dict", t => {
   let schema =
@@ -281,7 +305,7 @@ test("inputRefiner observes pre-transform input on a reversed transforming dict"
       d =>
         d
         ->Js.Dict.values
-        ->Js.Array2.every(v => Js.typeof(v) === "bigint"),
+        ->Js.Array2.every(v => Js.typeof(v) === "bigint" && v >= 0n),
       ~error="Dict input refine should see bigint values",
     )
     ->S.reverse
@@ -290,34 +314,37 @@ test("inputRefiner observes pre-transform input on a reversed transforming dict"
     %raw(`{"a": 1n, "b": 2n}`)->S.parseOrThrow(~to=schema),
     Js.Dict.fromArray([("a", "1"), ("b", "2")])->Obj.magic,
   )
+  t->U.assertThrowsMessage(
+    () => %raw(`{"a": -1n}`)->S.parseOrThrow(~to=schema),
+    `Dict input refine should see bigint values`,
+  )
 })
 
 test("inputRefiner observes pre-transform input on a reversed transforming tuple", t => {
   let schema =
     S.tuple(s => (s.item(0, S.string->S.to(S.bigint)), s.item(1, S.int)))
     ->S.refine(
-      ((b, _)) => Js.typeof(b) === "bigint",
+      ((b, i)) => Js.typeof(b) === "bigint" && i > 0,
       ~error="Tuple input refine should see bigint at index 0",
     )
     ->S.reverse
 
-  t->Assert.deepEqual(
-    %raw(`[1n, 5]`)->S.parseOrThrow(~to=schema),
-    ("1", 5)->Obj.magic,
+  t->Assert.deepEqual(%raw(`[1n, 5]`)->S.parseOrThrow(~to=schema), ("1", 5)->Obj.magic)
+  t->U.assertThrowsMessage(
+    () => %raw(`[1n, 0]`)->S.parseOrThrow(~to=schema),
+    `Tuple input refine should see bigint at index 0`,
   )
 })
-
-// For the leaf-shaped custom decoders (no nested item transform) the
-// always-fails inputRefiner test only confirms the reversed refiner is
-// invoked at all.
 
 test("inputRefiner runs on reversed S.json", t => {
   let schema =
     S.json
-    ->S.refine(_ => false, ~error="Json input refine fail")
+    ->S.refine(v => v !== %raw(`null`), ~error="Json input refine fail")
     ->S.reverse
+
+  t->Assert.deepEqual(%raw(`{"a": 1}`)->S.parseOrThrow(~to=schema), %raw(`{"a": 1}`))
   t->U.assertThrowsMessage(
-    () => %raw(`{"a": 1}`)->S.parseOrThrow(~to=schema),
+    () => %raw(`null`)->S.parseOrThrow(~to=schema),
     `Json input refine fail`,
   )
 })
@@ -325,10 +352,12 @@ test("inputRefiner runs on reversed S.json", t => {
 test("inputRefiner runs on reversed S.jsonString", t => {
   let schema =
     S.jsonString
-    ->S.refine(_ => false, ~error="JsonString input refine fail")
+    ->S.refine(s => Js.String2.length(s) < 10, ~error="JsonString input refine fail")
     ->S.reverse
+
+  t->Assert.deepEqual(`1`->S.parseOrThrow(~to=schema), `1`->Obj.magic)
   t->U.assertThrowsMessage(
-    () => `{"a":1}`->S.parseOrThrow(~to=schema),
+    () => `{"a":1,"b":2}`->S.parseOrThrow(~to=schema),
     `JsonString input refine fail`,
   )
 })
@@ -336,10 +365,15 @@ test("inputRefiner runs on reversed S.jsonString", t => {
 test("inputRefiner runs on reversed S.uint8Array", t => {
   let schema =
     S.uint8Array
-    ->S.refine(_ => false, ~error="Uint8Array input refine fail")
+    ->S.refine(arr => (arr->Obj.magic)["byteLength"] < 5, ~error="Uint8Array input refine fail")
     ->S.reverse
+
+  t->Assert.deepEqual(
+    %raw(`new Uint8Array([1, 2, 3])`)->S.parseOrThrow(~to=schema),
+    %raw(`new Uint8Array([1, 2, 3])`)->Obj.magic,
+  )
   t->U.assertThrowsMessage(
-    () => %raw(`new Uint8Array([1, 2, 3])`)->S.parseOrThrow(~to=schema),
+    () => %raw(`new Uint8Array([1, 2, 3, 4, 5, 6])`)->S.parseOrThrow(~to=schema),
     `Uint8Array input refine fail`,
   )
 })
@@ -356,26 +390,30 @@ test("inputRefiner runs on reversed S.compactColumns", t => {
         ),
       ),
     )
-    ->S.refine(_ => false, ~error="CompactColumns input refine fail")
+    ->S.refine(arr => arr->Js.Array2.length > 0, ~error="Empty compactColumns input")
     ->S.reverse
+
+  t->Assert.deepEqual(
+    %raw(`[{"foo": "a"}]`)->S.parseOrThrow(~to=schema),
+    %raw(`[["a"]]`)->Obj.magic,
+  )
   t->U.assertThrowsMessage(
-    () => %raw(`[{"foo": "a"}]`)->S.parseOrThrow(~to=schema),
-    `CompactColumns input refine fail`,
+    () => %raw(`[]`)->S.parseOrThrow(~to=schema),
+    `Empty compactColumns input`,
   )
 })
 
-// shape, recursive, union: gap cases. Output and input refiner tests for
-// each. shape's shapedParser sets isOutput without applying refiners and
-// will silently drop these — added to the failing baseline as regressions
-// to fix in follow-up.
+// shape, recursive, union: gap cases.
 
 test("Refiner runs on S.shape", t => {
   let schema =
     S.string
-    ->S.shape(s => Ok(s))
-    ->S.refine(_ => false, ~error="Shape refine fail")
+    ->S.shape(s => s)
+    ->S.refine(s => Js.String2.length(s) < 10, ~error="Shape refine fail")
+
+  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), "hello")
   t->U.assertThrowsMessage(
-    () => "hello"->S.parseOrThrow(~to=schema),
+    () => "hello world"->S.parseOrThrow(~to=schema),
     `Shape refine fail`,
   )
 })
@@ -383,19 +421,27 @@ test("Refiner runs on S.shape", t => {
 test("inputRefiner runs on reversed S.shape", t => {
   let schema =
     S.string
-    ->S.shape(s => Ok(s))
-    ->S.refine(_ => false, ~error="Shape input refine fail")
+    ->S.shape(s => s)
+    ->S.refine(s => Js.String2.length(s) < 10, ~error="Shape input refine fail")
     ->S.reverse
+
+  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), "hello"->Obj.magic)
   t->U.assertThrowsMessage(
-    () => Ok("hello")->S.parseOrThrow(~to=schema),
+    () => "hello world"->S.parseOrThrow(~to=schema),
     `Shape input refine fail`,
   )
 })
 
 test("Refiner runs on S.recursive", t => {
-  let schema = S.recursive("R", _ => S.string)->S.refine(_ => false, ~error="Recursive refine fail")
+  let schema =
+    S.recursive("R", _ => S.string)->S.refine(
+      s => Js.String2.length(s) < 10,
+      ~error="Recursive refine fail",
+    )
+
+  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), "hello")
   t->U.assertThrowsMessage(
-    () => "hello"->S.parseOrThrow(~to=schema),
+    () => "hello world"->S.parseOrThrow(~to=schema),
     `Recursive refine fail`,
   )
 })
@@ -403,10 +449,12 @@ test("Refiner runs on S.recursive", t => {
 test("inputRefiner runs on reversed S.recursive", t => {
   let schema =
     S.recursive("R", _ => S.string)
-    ->S.refine(_ => false, ~error="Recursive input refine fail")
+    ->S.refine(s => Js.String2.length(s) < 10, ~error="Recursive input refine fail")
     ->S.reverse
+
+  t->Assert.deepEqual("hello"->S.parseOrThrow(~to=schema), "hello"->Obj.magic)
   t->U.assertThrowsMessage(
-    () => "hello"->S.parseOrThrow(~to=schema),
+    () => "hello world"->S.parseOrThrow(~to=schema),
     `Recursive input refine fail`,
   )
 })
@@ -414,11 +462,13 @@ test("inputRefiner runs on reversed S.recursive", t => {
 test("Refiner runs on S.union", t => {
   let schema =
     S.union([S.string->S.castToUnknown, S.int->S.castToUnknown])->S.refine(
-      _ => false,
+      v => v !== ("fail"->Obj.magic),
       ~error="Union refine fail",
     )
+
+  t->Assert.deepEqual("ok"->Obj.magic->S.parseOrThrow(~to=schema), "ok"->Obj.magic)
   t->U.assertThrowsMessage(
-    () => "hello"->S.parseOrThrow(~to=schema),
+    () => "fail"->Obj.magic->S.parseOrThrow(~to=schema),
     `Union refine fail`,
   )
 })
@@ -426,10 +476,12 @@ test("Refiner runs on S.union", t => {
 test("inputRefiner runs on reversed S.union", t => {
   let schema =
     S.union([S.string->S.castToUnknown, S.int->S.castToUnknown])
-    ->S.refine(_ => false, ~error="Union input refine fail")
+    ->S.refine(v => v !== ("fail"->Obj.magic), ~error="Union input refine fail")
     ->S.reverse
+
+  t->Assert.deepEqual("ok"->Obj.magic->S.parseOrThrow(~to=schema), "ok"->Obj.magic)
   t->U.assertThrowsMessage(
-    () => "hello"->S.parseOrThrow(~to=schema),
+    () => "fail"->Obj.magic->S.parseOrThrow(~to=schema),
     `Union input refine fail`,
   )
 })

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -265,3 +265,168 @@ test("Refiner runs on S.compactColumns", t => {
     `CompactColumns refine fail`,
   )
 })
+
+// inputRefiner coverage for the custom decoders. inputRefiner is created
+// via S.refine(...)->S.reverse, which swaps refiner ↔ inputRefiner. For
+// schemas with nested-item transforms, the predicate must observe the
+// pre-transform input type — these tests pin that contract.
+
+test("inputRefiner observes pre-transform input on a reversed transforming dict", t => {
+  let schema =
+    S.dict(S.string->S.to(S.bigint))
+    ->S.refine(
+      d =>
+        d
+        ->Js.Dict.values
+        ->Js.Array2.every(v => Js.typeof(v) === "bigint"),
+      ~error="Dict input refine should see bigint values",
+    )
+    ->S.reverse
+
+  t->Assert.deepEqual(
+    %raw(`{"a": 1n, "b": 2n}`)->S.parseOrThrow(~to=schema),
+    Js.Dict.fromArray([("a", "1"), ("b", "2")]),
+  )
+})
+
+test("inputRefiner observes pre-transform input on a reversed transforming tuple", t => {
+  let schema =
+    S.tuple(s => (s.item(0, S.string->S.to(S.bigint)), s.item(1, S.int)))
+    ->S.refine(
+      ((b, _)) => Js.typeof(b) === "bigint",
+      ~error="Tuple input refine should see bigint at index 0",
+    )
+    ->S.reverse
+
+  t->Assert.deepEqual(
+    %raw(`[1n, 5]`)->S.parseOrThrow(~to=schema),
+    ("1", 5),
+  )
+})
+
+// For the leaf-shaped custom decoders (no nested item transform) the
+// always-fails inputRefiner test only confirms the reversed refiner is
+// invoked at all.
+
+test("inputRefiner runs on reversed S.json", t => {
+  let schema =
+    S.json
+    ->S.refine(_ => false, ~error="Json input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => %raw(`{"a": 1}`)->S.parseOrThrow(~to=schema),
+    `Json input refine fail`,
+  )
+})
+
+test("inputRefiner runs on reversed S.jsonString", t => {
+  let schema =
+    S.jsonString
+    ->S.refine(_ => false, ~error="JsonString input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => `{"a":1}`->S.parseOrThrow(~to=schema),
+    `JsonString input refine fail`,
+  )
+})
+
+test("inputRefiner runs on reversed S.uint8Array", t => {
+  let schema =
+    S.uint8Array
+    ->S.refine(_ => false, ~error="Uint8Array input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => %raw(`new Uint8Array([1, 2, 3])`)->S.parseOrThrow(~to=schema),
+    `Uint8Array input refine fail`,
+  )
+})
+
+test("inputRefiner runs on reversed S.compactColumns", t => {
+  let schema =
+    S.compactColumns(S.unknown)
+    ->S.to(
+      S.array(
+        S.schema(s =>
+          {
+            "foo": s.matches(S.string),
+          }
+        ),
+      ),
+    )
+    ->S.refine(_ => false, ~error="CompactColumns input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => %raw(`[{"foo": "a"}]`)->S.parseOrThrow(~to=schema),
+    `CompactColumns input refine fail`,
+  )
+})
+
+// shape, recursive, union: gap cases. Output and input refiner tests for
+// each. shape's shapedParser sets isOutput without applying refiners and
+// will silently drop these — added to the failing baseline as regressions
+// to fix in follow-up.
+
+test("Refiner runs on S.shape", t => {
+  let schema =
+    S.string
+    ->S.shape(s => Ok(s))
+    ->S.refine(_ => false, ~error="Shape refine fail")
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Shape refine fail`,
+  )
+})
+
+test("inputRefiner runs on reversed S.shape", t => {
+  let schema =
+    S.string
+    ->S.shape(s => Ok(s))
+    ->S.refine(_ => false, ~error="Shape input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => Ok("hello")->S.parseOrThrow(~to=schema),
+    `Shape input refine fail`,
+  )
+})
+
+test("Refiner runs on S.recursive", t => {
+  let schema = S.recursive("R", _ => S.string)->S.refine(_ => false, ~error="Recursive refine fail")
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Recursive refine fail`,
+  )
+})
+
+test("inputRefiner runs on reversed S.recursive", t => {
+  let schema =
+    S.recursive("R", _ => S.string)
+    ->S.refine(_ => false, ~error="Recursive input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Recursive input refine fail`,
+  )
+})
+
+test("Refiner runs on S.union", t => {
+  let schema =
+    S.union([S.string->S.castToUnknown, S.int->S.castToUnknown])->S.refine(
+      _ => false,
+      ~error="Union refine fail",
+    )
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Union refine fail`,
+  )
+})
+
+test("inputRefiner runs on reversed S.union", t => {
+  let schema =
+    S.union([S.string->S.castToUnknown, S.int->S.castToUnknown])
+    ->S.refine(_ => false, ~error="Union input refine fail")
+    ->S.reverse
+  t->U.assertThrowsMessage(
+    () => "hello"->S.parseOrThrow(~to=schema),
+    `Union input refine fail`,
+  )
+})


### PR DESCRIPTION
## Summary

Extracted the logic for applying `inputRefiner` and `refiner` into two reusable helper functions (`markInput` and `markOutput`) to reduce code duplication and ensure consistent refiner handling across all decoders.

## Key Changes

- **Added `markInput` helper** — Applies the input refiner by either pushing checks onto the input val's checks array (if a previous val exists) or wrapping via `refine` (if not). Sets `isInput = Some(true)`.

- **Added `markOutput` helper** — Applies the output refiner by wrapping the val via `refine` with the refiner checks. Sets `isOutput = Some(true)`.

- **Refactored primitive decoder path** — Replaced inline refiner application logic in the main `parse` loop with calls to `markInput` and `markOutput`.

- **Updated advanced decoders** — Modified `arrayDecoder`, `objectDecoder`, and `compactColumnsDecoder` to use the new helpers instead of duplicating refiner logic. This ensures consistent behavior across all decoder types.

- **Reorganized function definitions** — Moved helper functions and related utilities to improve code organization and readability (e.g., `getOutputSchema`, `traverseDefinition`, `shapedSerializer`, etc.).

- **Expanded test coverage** — Added comprehensive tests for refiner application order, inputRefiner behavior on reversed transforming schemas, and refiner execution on all custom decoders (dict, json, jsonString, uint8Array, compactColumns, shape, recursive, union).

## Implementation Details

- `markInput` handles the distinction between primitive decoders (which may return the input unchanged) and advanced decoders by checking `val.prev`. When `prev` is `None`, it wraps via `refine` to ensure emit has a valid previous var.

- `markOutput` always wraps via `refine` since the output refiner must observe the final assembled value.

- The refactoring maintains the execution order: type-narrowing → inputRefiner → transformation → refiner.

- Tests verify that inputRefiners on reversed transforming schemas observe the pre-transform input type, not the post-transform output.

https://claude.ai/code/session_018DmNVSxrpz2WHTcyLCWf22