### PR TITLE
Refactor refiner application: merge markInput/markOutput into single function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 1. **DX** — intuitive public API and error messages.
 2. **Performance** — generated code is the hot path; avoid extra vars, allocations, double validation; inline over indirect.
-3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.markInput`, `B.markOutput`) over duplicated codegen.
+3. **Bundle size** — `Sury.res.mjs` ships to browsers. Reuse helpers (`B.refine`, `B.markOutput`) over duplicated codegen.
 
 Tiebreaker: shortest *generated* code wins over shortest *library* code (runtime ships per-schema, library ships once).
 
@@ -35,17 +35,15 @@ Per-schema execution order:
 
 ## Refiner ownership
 
-The parse loop (around `expected.decoder(~input)`) applies `inputRefiner`/`refiner` **only for primitive decoders** — ones whose result has `isOutput !== Some(true)`. It pushes them as checks via `B.refine`.
+The parse loop applies refiners **only for primitive decoders** (result has `isOutput !== Some(true)`). **Advanced decoders** (object, array, tuple, union, recursive — anything that sets `isOutput = Some(true)`) own refiner application themselves, so input checks land on the pre-transform val and output checks on the assembled output.
 
-**Advanced decoders** (`objectDecoder`, `arrayDecoder`, tuple, union, recursive — anything that sets `isOutput = Some(true)`) own refiner application themselves, because:
-- They know the optimal injection points: `inputRefiner` is pushed onto the *input* val's checks so its predicate observes the pre-transform input; `refiner` wraps the assembled output so its predicate observes the final shape.
-- The generic fallback would force materializing an output val even when nothing else needs it.
+Use `B.markOutput(val, ~valInput)`:
+- Pushes input-refiner checks onto `valInput.checks` (emits at pre-transform slot).
+- Wraps `val` via `B.refine` with output-refiner checks (observes assembled output).
+- Sets `isOutput = Some(true)` on the result.
+- When `valInput.prev` is None, input checks fold into the output wrap so emit has a `prev.var()`.
 
-Use the two shared helpers:
-- `B.markInput(~val, ~schema)` — mutates `val.checks` (pushes the input refiner) and sets `isInput = Some(true)`. Call it on the *input* val (e.g. `input->B.markInput`).
-- `B.markOutput(~val, ~schema)` — wraps `val` via `B.refine` with the output refiner and sets `isOutput = Some(true)` on the wrapper. Call it on the *result* val.
-
-Two fns (not `~which`) so the bundler DCEs whichever is unused. **A new advanced decoder that skips either silently drops user `S.refine`s.**
+For primitives, `val === valInput`. For advanced decoders, `valInput` is the pre-transform input and `val` is the assembled output. **Skipping this call silently drops user `S.refine`s.**
 
 Async output refiner must run inside `.then()` on the resolved value, never on the Promise wrapper.
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -608,10 +608,6 @@ and val = {
   // The schema of the value that is being parsed
   @as("s")
   mutable schema: internal,
-  // Whether the val is at input part of expected schema
-  // This means that when decoding we need to do it from input to output instead of unknown to output
-  @as("ii")
-  mutable isInput?: bool,
   // Whether the val is at output part of expected schema
   // Needed for schemas like S.array(S.nullAsOption) where child schemas might be transformed
   @as("io")
@@ -1567,11 +1563,11 @@ module Builder = {
 
     // Pushes the input refiner checks (from `val.expected.inputRefiner`)
     // onto `val.checks` so emit reads them at val's slot with
-    // inputVar = val.prev.var(); sets `isInput = Some(true)`. When
-    // `val.prev` is None (primitive decoder returned the operationArg
-    // unchanged), wraps via `refine` instead so emit has a prev.var().
+    // inputVar = val.prev.var(). When `val.prev` is None (primitive
+    // decoder returned the operationArg unchanged), wraps via `refine`
+    // instead so emit has a prev.var().
     let markInput = (val: val) => {
-      let val = switch val.expected.inputRefiner {
+      switch val.expected.inputRefiner {
       | Some(fn) => {
           let checks = fn(~input=val)
           if checks->Js.Array2.length > 0 {
@@ -1590,8 +1586,6 @@ module Builder = {
         }
       | None => val
       }
-      val.isInput = Some(true)
-      val
     }
 
     // Wraps `val` via `refine` with the output refiner checks (from
@@ -1720,7 +1714,6 @@ module Builder = {
           varsAllocation: "",
           hasTransform: false,
           allocate: initialAllocate,
-          isInput: ?val.isInput,
           isOutput: ?val.isOutput,
           vals: ?val.vals, // TODO: Is this correct?
         }
@@ -2346,7 +2339,6 @@ let rec parse = (input: val) => {
     } else {
       let maybeEncoder = loopInput.schema.encoder
       if (
-        !(loopInput.isInput->Option.getUnsafe) &&
         maybeEncoder->Obj.magic &&
         maybeEncoder->Obj.magic !== appliedEncoder &&
         loopInput.schema !== loopInput.expected &&
@@ -2365,7 +2357,7 @@ let rec parse = (input: val) => {
         // If the decoder's return value is not marked as isOutput,
         // we treat it as a primitive decoder with no internal transformations.
         // Otherwise, we assume internal transformations are present,
-        // and expect the decoder itself to handle refinements and manage isInput/isOutput flags.
+        // and expect the decoder itself to handle refinements and manage the isOutput flag.
         if !(valRef.contents.isOutput->Option.getUnsafe) {
           valRef := valRef.contents->B.markInput
           valRef := valRef.contents->B.markOutput
@@ -2884,7 +2876,6 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       let key = idx->Js.Int.toString
       let itemInput = input->B.Val.get(key)
       itemInput.expected = schema
-      itemInput.isInput = Some(false)
       itemInput.isOutput = Some(false)
       itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
       let itemOutput = itemInput->parse
@@ -3034,7 +3025,6 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
 
         let itemInput = input->B.Val.get(key)
         itemInput.expected = schema
-        itemInput.isInput = Some(false)
         itemInput.isOutput = Some(false)
         itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
         let itemOutput = itemInput->parse
@@ -3762,7 +3752,6 @@ module Union = {
           let input = typeValidationOutput->B.Val.scope
           input.isUnion = Some(true)
           input.hasTransform = typeValidationOutput.hasTransform
-          input.isInput = Some(false)
           input.isOutput = Some(false)
           input.expected =
             arr->Stdlib.Array.getUnsafe(itemIdx.contents)->(Obj.magic: unknown => internal)
@@ -4518,7 +4507,6 @@ let rec jsonEncoderFn = (~input, ~target) => {
     let output = input->B.refine(~schema=unknown, ~expected=jsonExpected)->parse
     output.schema.additionalItems = Some(Schema(json()->castToPublic))
     output.expected = target
-    output.isInput = Some(false)
     output.isOutput = Some(false)
     output
   } else if toTagFlag->Flag.unsafeHas(TagFlag.object) {
@@ -4528,7 +4516,6 @@ let rec jsonEncoderFn = (~input, ~target) => {
     let output = input->B.refine(~schema=unknown, ~expected=jsonExpected)->parse
     output.schema.additionalItems = Some(Schema(json()->castToPublic))
     output.expected = target
-    output.isInput = Some(false)
     output.isOutput = Some(false)
     output
   } else if toTagFlag->Flag.unsafeHas(TagFlag.union->Flag.with(TagFlag.ref)) {
@@ -4612,7 +4599,6 @@ and jsonDecoderFn = (~input) => {
         for idx in 0 to keys->Js.Array2.length - 1 {
           let key = keys->Js.Array2.unsafe_get(idx)
           let itemVal = input->B.Val.get(key)
-          itemVal.isInput = Some(false)
           itemVal.isOutput = Some(false)
 
           if (
@@ -4749,7 +4735,6 @@ let jsonString = {
         nextSchema.to = Some(target)
 
         let output = input->B.next(outputVar, ~schema=nextSchema, ~expected=nextSchema)
-        output.isInput = Some(true)
         output.isOutput = Some(true)
         output.var = B._var
 
@@ -5462,7 +5447,6 @@ module Schema = {
         let flattenedInput = input->B.Val.scope
         flattenedInput.expected = flattenedSchema
         flattenedInput.isOutput = Some(false)
-        flattenedInput.isInput = Some(false)
         let flattenedVal = flattenedInput->parse
         flattenedVals->Js.Array2.push(flattenedVal)->ignore
         input.codeFromPrev = input.codeFromPrev ++ flattenedVal->B.merge
@@ -5888,7 +5872,6 @@ let compactColumnsDecoder = (~input) => {
           itemInput.schema = runtimeItemSchema
           itemInput.expected = itemExpected
           itemInput.var = B._notVarBeforeValidation
-          itemInput.isInput = Some(false)
           itemInput.isOutput = Some(false)
           // Path like ["bar"] so validation errors carry the field location.
           itemInput.path = Path.fromInlinedLocation(input.global->B.inlineLocation(key))
@@ -5982,7 +5965,6 @@ let compactColumnsDecoder = (~input) => {
             itemInput.schema = fieldSchema
             itemInput.expected = declaredItemSchema
             itemInput.var = B._notVarBeforeValidation
-            itemInput.isInput = Some(false)
             itemInput.isOutput = Some(false)
             itemInput.path = Path.fromInlinedLocation(input.global->B.inlineLocation(key))
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1561,44 +1561,51 @@ module Builder = {
       }
     }
 
-    // Pushes the input refiner checks (from `val.expected.inputRefiner`)
-    // onto `val.checks` so emit reads them at val's slot with
-    // inputVar = val.prev.var(). When `val.prev` is None (primitive
-    // decoder returned the operationArg unchanged), wraps via `refine`
-    // instead so emit has a prev.var().
-    let markInput = (val: val) => {
-      switch val.expected.inputRefiner {
+    // Applies both refiners for one decoder seam. `valInput` is the
+    // pre-transform input val; `val` is the assembled output val (may
+    // equal `valInput` for primitive decoders). Input-refiner checks
+    // (from `valInput.expected.inputRefiner`) are pushed onto
+    // `valInput.checks` so they emit at the input slot, before any
+    // transform code. Output-refiner checks (from `val.expected.refiner`)
+    // wrap `val` via `refine` so they observe the assembled output.
+    // When `valInput.prev` is None (primitive decoder returned the
+    // operationArg unchanged) the input-refiner checks are folded into
+    // the output wrap instead, so emit has a prev.var() to read from.
+    // Sets `isOutput = Some(true)` on the result. Async paths must
+    // inject the output check inside `.then` on the resolved value — TODO.
+    let markOutput = (val: val, ~valInput: val) => {
+      let deferredInputChecks = switch valInput.expected.inputRefiner {
       | Some(fn) => {
-          let checks = fn(~input=val)
+          let checks = fn(~input=valInput)
           if checks->Js.Array2.length > 0 {
-            switch val.prev {
+            switch valInput.prev {
             | Some(_) => {
                 for i in 0 to checks->Js.Array2.length - 1 {
-                  val->pushCheck(checks->Js.Array2.unsafe_get(i))
+                  valInput->pushCheck(checks->Js.Array2.unsafe_get(i))
                 }
-                val
+                None
               }
-            | None => val->refine(~checks)
+            | None => Some(checks)
             }
           } else {
-            val
+            None
           }
         }
-      | None => val
+      | None => None
       }
-    }
 
-    // Wraps `val` via `refine` with the output refiner checks (from
-    // `val.expected.refiner`) so the check observes the assembled
-    // output; sets `isOutput = Some(true)` on the wrapper. Async paths
-    // must inject the check inside `.then` on the resolved value — TODO.
-    let markOutput = (val: val) => {
-      let val = switch val.expected.refiner {
+      let outputChecks = switch val.expected.refiner {
       | Some(fn) => {
           let checks = fn(~input=val)
-          checks->Js.Array2.length > 0 ? val->refine(~checks) : val
+          checks->Js.Array2.length > 0 ? Some(checks) : None
         }
-      | None => val
+      | None => None
+      }
+
+      let val = switch (deferredInputChecks, outputChecks) {
+      | (Some(ic), Some(oc)) => val->refine(~checks=ic->Js.Array2.concat(oc))
+      | (Some(checks), None) | (None, Some(checks)) => val->refine(~checks)
+      | (None, None) => val
       }
       val.isOutput = Some(true)
       val
@@ -2359,8 +2366,7 @@ let rec parse = (input: val) => {
         // Otherwise, we assume internal transformations are present,
         // and expect the decoder itself to handle refinements and manage the isOutput flag.
         if !(valRef.contents.isOutput->Option.getUnsafe) {
-          valRef := valRef.contents->B.markInput
-          valRef := valRef.contents->B.markOutput
+          valRef := valRef.contents->B.markOutput(~valInput=valRef.contents)
         }
       }
     }
@@ -2902,8 +2908,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     }
   }
   // inputRefiner on input val (pre-transform); outputRefiner on output.
-  let _: val = input->B.markInput
-  output->B.markOutput
+  output->B.markOutput(~valInput=input)
 }
 and objectDecoder: Builder.t = (~input as unknownInput) => {
   let isUnion = unknownInput.isUnion->X.Option.getUnsafe
@@ -3083,8 +3088,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
   }
   // inputRefiner on the input val so the check observes pre-transform
   // input; outputRefiner on the assembled output. Async TODO.
-  let _: val = input->B.markInput
-  output->B.markOutput
+  output->B.markOutput(~valInput=input)
 }
 
 let recursiveDecoder = Builder.make((~input) => {
@@ -5796,9 +5800,8 @@ let compactColumnsDecoder = (~input) => {
         } else {
           input
         }
-        let _: val = input->B.markInput
         let output = input->B.next("[]", ~schema=outputSchema, ~expected=outputSchema)
-        output->B.markOutput
+        output->B.markOutput(~valInput=input)
       } else if isForwardDirection {
         // Forward direction: columnar → rows
         let input = if isUnknownInput {
@@ -5891,7 +5894,6 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=new Array(Math.max(${lengthCode.contents}))`)
 
-        let _: val = input->B.markInput
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
 
@@ -5931,7 +5933,7 @@ let compactColumnsDecoder = (~input) => {
         } else {
           output
         }
-        output->B.markOutput
+        output->B.markOutput(~valInput=input)
       } else {
         // Reverse direction: rows → columnar
         // When the declared source type is unknown, field values have
@@ -5982,7 +5984,6 @@ let compactColumnsDecoder = (~input) => {
 
         input.allocate(`${outputVar}=[${initialArraysCode.contents}]`)
 
-        let _: val = input->B.markInput
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
         let loopBody = perFieldCode.contents ++ settingCode.contents
@@ -5995,7 +5996,7 @@ let compactColumnsDecoder = (~input) => {
         output.codeFromPrev =
           output.codeFromPrev ++
           `for(let ${iteratorVar}=0;${iteratorVar}<${inputVar}.length;++${iteratorVar}){${wrappedBody}}`
-        output->B.markOutput
+        output->B.markOutput(~valInput=input)
       }
     }
   }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1561,18 +1561,11 @@ module Builder = {
       }
     }
 
-    // Applies both refiners for one decoder seam. `valInput` is the
-    // pre-transform input val; `val` is the assembled output val (may
-    // equal `valInput` for primitive decoders). Input-refiner checks
-    // (from `valInput.expected.inputRefiner`) are pushed onto
-    // `valInput.checks` so they emit at the input slot, before any
-    // transform code. Output-refiner checks (from `val.expected.refiner`)
-    // wrap `val` via `refine` so they observe the assembled output.
-    // When `valInput.prev` is None (primitive decoder returned the
-    // operationArg unchanged) the input-refiner checks are folded into
-    // the output wrap instead, so emit has a prev.var() to read from.
-    // Sets `isOutput = Some(true)` on the result. Async paths must
-    // inject the output check inside `.then` on the resolved value — TODO.
+    // Applies both refiners. Input checks push onto valInput.checks
+    // (emit at pre-transform slot); output checks wrap val via refine.
+    // When valInput.prev is None, input checks fold into the output
+    // wrap so emit has a prev.var(). Sets isOutput on the result.
+    // TODO: async output refiner must run inside .then(), not on the Promise.
     let markOutput = (val: val, ~valInput: val) => {
       let deferredInputChecks = switch valInput.expected.inputRefiner {
       | Some(fn) => {
@@ -2361,10 +2354,8 @@ let rec parse = (input: val) => {
       } else {
         valRef := loopInput.expected.decoder(~input=loopInput)
 
-        // If the decoder's return value is not marked as isOutput,
-        // we treat it as a primitive decoder with no internal transformations.
-        // Otherwise, we assume internal transformations are present,
-        // and expect the decoder itself to handle refinements and manage the isOutput flag.
+        // Primitive decoder (no internal transforms): apply refiners here.
+        // Advanced decoders set isOutput themselves and own refiner application.
         if !(valRef.contents.isOutput->Option.getUnsafe) {
           valRef := valRef.contents->B.markOutput(~valInput=valRef.contents)
         }
@@ -2907,7 +2898,6 @@ and arrayDecoder: builder = (~input as unknownInput) => {
       o
     }
   }
-  // inputRefiner on input val (pre-transform); outputRefiner on output.
   output->B.markOutput(~valInput=input)
 }
 and objectDecoder: Builder.t = (~input as unknownInput) => {
@@ -3086,8 +3076,6 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
       }
     }
   }
-  // inputRefiner on the input val so the check observes pre-transform
-  // input; outputRefiner on the assembled output. Async TODO.
   output->B.markOutput(~valInput=input)
 }
 

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -761,34 +761,40 @@ function pushCheck(val, check) {
   }
 }
 
-function markInput(val) {
-  let fn = val.e.inputRefiner;
-  if (fn === undefined) {
-    return val;
-  }
-  let checks = fn(val);
-  if (checks.length <= 0) {
-    return val;
-  }
-  let match = val.prev;
-  if (match === undefined) {
-    return refine(val, undefined, checks, undefined);
-  }
-  for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
-    pushCheck(val, checks[i]);
-  }
-  return val;
-}
-
-function markOutput(val) {
-  let fn = val.e.refiner;
-  let val$1;
+function markOutput(val, valInput) {
+  let fn = valInput.e.inputRefiner;
+  let deferredInputChecks;
   if (fn !== undefined) {
-    let checks = fn(val);
-    val$1 = checks.length > 0 ? refine(val, undefined, checks, undefined) : val;
+    let checks = fn(valInput);
+    if (checks.length > 0) {
+      let match = valInput.prev;
+      if (match !== undefined) {
+        for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
+          pushCheck(valInput, checks[i]);
+        }
+        deferredInputChecks = undefined;
+      } else {
+        deferredInputChecks = checks;
+      }
+    } else {
+      deferredInputChecks = undefined;
+    }
   } else {
-    val$1 = val;
+    deferredInputChecks = undefined;
   }
+  let fn$1 = val.e.refiner;
+  let outputChecks;
+  if (fn$1 !== undefined) {
+    let checks$1 = fn$1(val);
+    outputChecks = checks$1.length > 0 ? checks$1 : undefined;
+  } else {
+    outputChecks = undefined;
+  }
+  let val$1 = deferredInputChecks !== undefined ? (
+      outputChecks !== undefined ? refine(val, undefined, deferredInputChecks.concat(outputChecks), undefined) : refine(val, undefined, deferredInputChecks, undefined)
+    ) : (
+      outputChecks !== undefined ? refine(val, undefined, outputChecks, undefined) : val
+    );
   val$1.io = true;
   return val$1;
 }
@@ -1348,26 +1354,13 @@ function parse$1(input) {
       } else {
         valRef = loopInput.e.decoder(loopInput);
         if (!valRef.io) {
-          valRef = markInput(valRef);
-          valRef = markOutput(valRef);
+          valRef = markOutput(valRef, valRef);
         }
         
       }
     }
   };
   return valRef;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function reverse(schema) {
@@ -1473,6 +1466,18 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
+}
+
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
 }
 
 function parseDynamic(input) {
@@ -1748,8 +1753,7 @@ function arrayDecoder(unknownInput) {
       output = o;
     }
   }
-  markInput(input);
-  return markOutput(output);
+  return markOutput(output, input);
 }
 
 function objectDecoder(unknownInput) {
@@ -1896,8 +1900,7 @@ function objectDecoder(unknownInput) {
       output = o;
     }
   }
-  markInput(input);
-  return markOutput(output);
+  return markOutput(output, input);
 }
 
 function recursiveDecoder(input) {
@@ -3448,6 +3451,115 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
+        throw new Error("[Sury] " + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== "object" || definition === null) {
     return parse(definition);
@@ -3488,30 +3600,6 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3614,110 +3702,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = "Don't know where the value is coming from: " + toExpression(targetSchema);
-        throw new Error("[Sury] " + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = "~" + fieldName;
@@ -3782,6 +3766,25 @@ function nested(fieldName) {
   };
   parentCtx[cacheId] = ctx$1;
   return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+    
+  });
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input) {
@@ -3977,8 +3980,8 @@ function compactColumnsDecoder(input) {
             c: inputVar => "Array.isArray(" + inputVar + ")&&" + inputVar + ".length===0",
             f: failInvalidType
           }], undefined) : input;
-      markInput(input$1);
-      return markOutput(next(input$1, "[]", outputSchema, outputSchema));
+      let output = next(input$1, "[]", outputSchema, outputSchema);
+      return markOutput(output, input$1);
     }
     if (forwardProps) {
       let input$2 = isUnknownInput ? refine(input, undefined, [{
@@ -4032,9 +4035,8 @@ function compactColumnsDecoder(input) {
         itemBuildCode = itemBuildCode + (fromString(key) + ":" + itemOutput.i + ",");
       }
       input$2.a(outputVar + "=new Array(Math.max(" + lengthCode + "))");
-      markInput(input$2);
-      let output = next(input$2, outputVar, outputSchema, outputSchema);
-      output.v = _var;
+      let output$1 = next(input$2, outputVar, outputSchema, outputSchema);
+      output$1.v = _var;
       let rowAssign;
       if (hasAsync) {
         let rowResultVar = varWithoutAllocation(input$2.g);
@@ -4055,8 +4057,9 @@ function compactColumnsDecoder(input) {
         let errorVar = varWithoutAllocation(input$2.g);
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
-      output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
-      return markOutput(hasAsync ? asyncVal(output, "Promise.all(" + outputVar + ")") : output);
+      output$1.cp = output$1.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
+      let output$2 = hasAsync ? asyncVal(output$1, "Promise.all(" + outputVar + ")") : output$1;
+      return markOutput(output$2, input$2);
     }
     let inputVar$1 = input.v();
     let iteratorVar$1 = varWithoutAllocation(input.g);
@@ -4089,9 +4092,8 @@ function compactColumnsDecoder(input) {
       }
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
-    markInput(input);
-    let output$1 = next(input, outputVar$1, outputSchema, outputSchema);
-    output$1.v = _var;
+    let output$3 = next(input, outputVar$1, outputSchema, outputSchema);
+    output$3.v = _var;
     let loopBody = perFieldCode + settingCode;
     let wrappedBody$1;
     if (needsPerFieldTransform && perFieldCode !== "") {
@@ -4100,8 +4102,8 @@ function compactColumnsDecoder(input) {
     } else {
       wrappedBody$1 = loopBody;
     }
-    output$1.cp = output$1.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
-    return markOutput(output$1);
+    output$3.cp = output$3.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
+    return markOutput(output$3, input);
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -763,27 +763,21 @@ function pushCheck(val, check) {
 
 function markInput(val) {
   let fn = val.e.inputRefiner;
-  let val$1;
-  if (fn !== undefined) {
-    let checks = fn(val);
-    if (checks.length > 0) {
-      let match = val.prev;
-      if (match !== undefined) {
-        for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
-          pushCheck(val, checks[i]);
-        }
-        val$1 = val;
-      } else {
-        val$1 = refine(val, undefined, checks, undefined);
-      }
-    } else {
-      val$1 = val;
-    }
-  } else {
-    val$1 = val;
+  if (fn === undefined) {
+    return val;
   }
-  val$1.ii = true;
-  return val$1;
+  let checks = fn(val);
+  if (checks.length <= 0) {
+    return val;
+  }
+  let match = val.prev;
+  if (match === undefined) {
+    return refine(val, undefined, checks, undefined);
+  }
+  for (let i = 0, i_finish = checks.length; i < i_finish; ++i) {
+    pushCheck(val, checks[i]);
+  }
+  return val;
 }
 
 function markOutput(val) {
@@ -865,7 +859,6 @@ function scope(val) {
     v: shouldLink ? _bondVar : _var,
     i: val.i,
     s: val.s,
-    ii: val.ii,
     io: val.io,
     e: val.e,
     f: 0,
@@ -1347,7 +1340,7 @@ function parse$1(input) {
       valRef = parser !== undefined ? parser(loopInput) : refine(valRef, undefined, undefined, to);
     } else {
       let maybeEncoder = loopInput.s.encoder;
-      if (!loopInput.ii && maybeEncoder && maybeEncoder !== appliedEncoder && loopInput.s !== loopInput.e && loopInput.e.type !== unknownTag) {
+      if (maybeEncoder && maybeEncoder !== appliedEncoder && loopInput.s !== loopInput.e && loopInput.e.type !== unknownTag) {
         valRef = maybeEncoder(loopInput, loopInput.e);
       }
       if (loopInput !== valRef) {
@@ -1363,6 +1356,18 @@ function parse$1(input) {
     }
   };
   return valRef;
+}
+
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
 }
 
 function reverse(schema) {
@@ -1468,18 +1473,6 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function parseDynamic(input) {
@@ -1734,7 +1727,6 @@ function arrayDecoder(unknownInput) {
       let key = idx.toString();
       let itemInput$1 = get(input, key);
       itemInput$1.e = schema$1;
-      itemInput$1.ii = false;
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
       let itemOutput$1 = parse$1(itemInput$1);
@@ -1854,7 +1846,6 @@ function objectDecoder(unknownInput) {
       let schema$1 = properties[key];
       let itemInput$1 = get(input, key);
       itemInput$1.e = schema$1;
-      itemInput$1.ii = false;
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
       let itemOutput$1 = parse$1(itemInput$1);
@@ -2402,7 +2393,6 @@ function unionDecoder(input) {
       let input = scope(typeValidationOutput);
       input.u = true;
       input.t = typeValidationOutput.t;
-      input.ii = false;
       input.io = false;
       input.e = arr[itemIdx];
       let isLast = itemIdx === lastIdx;
@@ -2941,7 +2931,6 @@ function jsonEncoderFn(input, target) {
     let output = parse$1(refine(input, unknown, undefined, jsonExpected$1));
     output.s.additionalItems = json();
     output.e = target;
-    output.ii = false;
     output.io = false;
     return output;
   }
@@ -2950,7 +2939,6 @@ function jsonEncoderFn(input, target) {
     let output$1 = parse$1(refine(input, unknown, undefined, jsonExpected$2));
     output$1.s.additionalItems = json();
     output$1.e = target;
-    output$1.ii = false;
     output$1.io = false;
     return output$1;
   }
@@ -3034,7 +3022,6 @@ function jsonDecoderFn(input) {
     for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
       let key = keys[idx];
       let itemVal = get(input, key);
-      itemVal.ii = false;
       itemVal.io = false;
       if (itemVal.s.type === unionTag && itemVal.s.has[undefinedTag]) {
         itemVal.e = factory$1([
@@ -3160,7 +3147,6 @@ function jsonStringEncoder(input, target) {
   let nextSchema = copySchema(json());
   nextSchema.to = target;
   let output = next(input, outputVar, nextSchema, nextSchema);
-  output.ii = true;
   output.io = true;
   output.v = _var;
   let inputVar = input.v();
@@ -3462,6 +3448,72 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== "object" || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3657,56 +3709,13 @@ function prepareShapedSerializerAcc(acc, input) {
   }
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== "object" || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
     }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+    
+  });
 }
 
 function nested(fieldName) {
@@ -3775,29 +3784,6 @@ function nested(fieldName) {
   return ctx$1;
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-    
-  });
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
 function shapedParser(input) {
   let flattened = input.e.flattened;
   if (flattened !== undefined) {
@@ -3807,7 +3793,6 @@ function shapedParser(input) {
       let flattenedInput = scope(input);
       flattenedInput.e = flattenedSchema;
       flattenedInput.io = false;
-      flattenedInput.ii = false;
       let flattenedVal = parse$1(flattenedInput);
       flattenedVals.push(flattenedVal);
       input.cp = input.cp + merge(flattenedVal, undefined);
@@ -4034,7 +4019,6 @@ function compactColumnsDecoder(input) {
         itemInput.s = runtimeItemSchema;
         itemInput.e = itemExpected;
         itemInput.v = _notVarBeforeValidation;
-        itemInput.ii = false;
         itemInput.io = false;
         let inlinedLocation = inlineLocation(input$2.g, key);
         itemInput.path = "[" + inlinedLocation + "]";
@@ -4094,7 +4078,6 @@ function compactColumnsDecoder(input) {
         itemInput$1.s = fieldSchema$1;
         itemInput$1.e = declaredItemSchema$1;
         itemInput$1.v = _notVarBeforeValidation;
-        itemInput$1.ii = false;
         itemInput$1.io = false;
         let inlinedLocation$1 = inlineLocation(input.g, key$2);
         itemInput$1.path = "[" + inlinedLocation$1 + "]";


### PR DESCRIPTION
## Summary

Consolidates input and output refiner application into a single `markOutput` function that handles both refiners together. This eliminates the separate `markInput` function and the `isInput` field from the val type, simplifying the refiner ownership model while maintaining correct semantics.

## Key Changes

- **Merged refiner logic**: Combined `markInput` and `markOutput` into a single `markOutput(val, ~valInput)` function that:
  - Pushes input-refiner checks onto `valInput.checks` (emits at pre-transform slot)
  - Wraps `val` with output-refiner checks via `refine` (observes assembled output)
  - Defers input checks into the output wrap when `valInput.prev` is None
  - Sets `isOutput = Some(true)` on the result

- **Removed `isInput` field**: Deleted the `isInput` property from the val record type, as it's no longer needed with the unified refiner application

- **Updated call sites**: Changed all refiner application from two separate calls to a single `markOutput(output, ~valInput=input)` call in:
  - `arrayDecoder`
  - `objectDecoder`
  - `compactColumnsDecoder`
  - `parse` loop (for primitive decoders)

- **Removed redundant assignments**: Eliminated scattered `isInput = Some(false)` assignments throughout decoders since the field no longer exists

- **Updated documentation**: Modified CLAUDE.md to reflect the new unified refiner ownership model

## Implementation Details

The refactored `markOutput` function uses a switch expression to handle four cases:
1. Both input and output checks present: concatenate and wrap
2. Only input checks: wrap with input checks
3. Only output checks: wrap with output checks  
4. No checks: return val unchanged

This approach maintains the same validation semantics while reducing code duplication and simplifying the mental model for refiner application across the codebase.

https://claude.ai/code/session_01MZBV6kRNJLbyA9o9bgULDm