### PR TITLE
Fix refiner application in shaped parsers and compact columns

### DIFF
--- a/packages/sury/failing-tests.snapshot.txt
+++ b/packages/sury/failing-tests.snapshot.txt
@@ -3,15 +3,9 @@
 # To reproduce this list after making changes, run:
 #   cd packages/sury && npx ava 2>&1 | grep "✘ \[fail\]" | sed 's/lib › bs › //' | sed 's/tests › //' | sed 's/ Error thrown in test//' | sort -u
 #
-# Total: 13 failing tests
+# Total: 9 failing tests
 
   ✘ [fail]: S_object_discriminant_test.res › Fails to serialize object with discriminant that we don't know how to serialize "true | null"
-  ✘ [fail]: S_object_test.res › Compiled code snapshot for refined nested object
-  ✘ [fail]: S_refine_test.res › Compiled parse code snapshot for simple object with refine
-  ✘ [fail]: S_refine_test.res › Output refine on a tuple runs on the assembled tuple
-  ✘ [fail]: S_refine_test.res › Refiner runs on S.compactColumns
-  ✘ [fail]: S_refine_test.res › Refiner runs on S.shape
-  ✘ [fail]: S_refine_test.res › Successfully parses
   ✘ [fail]: S_toExpression_test.res › Expression of renamed schema
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union
   ✘ [fail]: S_to_test.res › Coerce from union to bigint with refinement on union (with an item transformed to) Should apply refinement after the item transformation

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5451,7 +5451,7 @@ module Schema = {
     let output = getShapedParserOutput(~input, ~targetSchema)
     output.hasTransform = Some(true)
     output.prev = Some(input)
-    output->B.markOutput
+    output->B.markOutput(~valInput=input)
   }
 
   and prepareShapedSerializerAcc = (~acc: shapedSerializerAcc, ~input: val) => {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5787,16 +5787,11 @@ let compactColumnsDecoder = (~input) => {
       let keys = properties->Js.Dict.keys
       let keysLen = keys->Js.Array2.length
 
-      // Common output schema setup shared by all branches below. In the
-      // forward direction the output already matches selfSchema.to's shape,
-      // so use it directly — that way markOutput sees the user-declared
-      // output refiner and the loop terminates on selfSchema.to.to (None).
-      // selfSchema.to is guaranteed Some here: isForwardDirection only
-      // becomes true when the match at the top of this decoder reads
-      // properties through selfSchema.to.additionalItems.
-      // In reverse direction the runtime type is a different shape
-      // (array of arrays of unknown), but we still propagate .to so
-      // subsequent steps (e.g. json validation) continue to run.
+      // Forward: output already matches selfSchema.to, reuse it so
+      // markOutput picks up its refiner. selfSchema.to is Some here —
+      // isForwardDirection reads through it above.
+      // Reverse: runtime shape differs (array of arrays of unknown),
+      // so build fresh and propagate .to for downstream steps.
       let outputSchema = if isForwardDirection {
         selfSchema.to->X.Option.getUnsafe
       } else {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5787,11 +5787,15 @@ let compactColumnsDecoder = (~input) => {
       let keys = properties->Js.Dict.keys
       let keysLen = keys->Js.Array2.length
 
-      // Common output schema setup shared by all branches below.
-      // In reverse direction we propagate the original chain's .to so that
+      // Common output schema setup shared by all branches below. In the
+      // forward direction the output already matches selfSchema.to's shape,
+      // so use it directly — that way markOutput sees the user-declared
+      // output refiner and the loop terminates on selfSchema.to.to (None).
+      // In reverse direction the runtime type is a different shape
+      // (array of arrays of unknown), but we still propagate .to so
       // subsequent steps (e.g. json validation) continue to run.
       let outputSchema = if isForwardDirection {
-        base(arrayTag, ~selfReverse=false)
+        selfSchema.to->Stdlib.Option.getOr(base(arrayTag, ~selfReverse=false))
       } else {
         let s = array(array(unknown->castToPublic))->castToInternal
         s.to = selfSchema.to
@@ -5947,13 +5951,6 @@ let compactColumnsDecoder = (~input) => {
           output->B.asyncVal(`Promise.all(${outputVar})`)
         } else {
           output
-        }
-        // Use selfSchema.to (when set) so markOutput sees the user-declared
-        // output schema's refiner. The freshly built outputSchema has no
-        // refiner, so without this the output refine on .to is dropped.
-        switch selfSchema.to {
-        | Some(to) => output.expected = to
-        | None => ()
         }
         output->B.markOutput
       } else {

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5791,11 +5791,14 @@ let compactColumnsDecoder = (~input) => {
       // forward direction the output already matches selfSchema.to's shape,
       // so use it directly — that way markOutput sees the user-declared
       // output refiner and the loop terminates on selfSchema.to.to (None).
+      // selfSchema.to is guaranteed Some here: isForwardDirection only
+      // becomes true when the match at the top of this decoder reads
+      // properties through selfSchema.to.additionalItems.
       // In reverse direction the runtime type is a different shape
       // (array of arrays of unknown), but we still propagate .to so
       // subsequent steps (e.g. json validation) continue to run.
       let outputSchema = if isForwardDirection {
-        selfSchema.to->Stdlib.Option.getOr(base(arrayTag, ~selfReverse=false))
+        selfSchema.to->X.Option.getUnsafe
       } else {
         let s = array(array(unknown->castToPublic))->castToInternal
         s.to = selfSchema.to

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5475,7 +5475,7 @@ module Schema = {
     let output = getShapedParserOutput(~input, ~targetSchema)
     output.hasTransform = Some(true)
     output.prev = Some(input)
-    output
+    output->B.markOutput
   }
 
   and prepareShapedSerializerAcc = (~acc: shapedSerializerAcc, ~input: val) => {
@@ -5947,6 +5947,13 @@ let compactColumnsDecoder = (~input) => {
           output->B.asyncVal(`Promise.all(${outputVar})`)
         } else {
           output
+        }
+        // Use selfSchema.to (when set) so markOutput sees the user-declared
+        // output schema's refiner. The freshly built outputSchema has no
+        // refiner, so without this the output refine on .to is dropped.
+        switch selfSchema.to {
+        | Some(to) => output.expected = to
+        | None => ()
         }
         output->B.markOutput
       } else {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3818,7 +3818,7 @@ function shapedParser(input) {
   let output = getShapedParserOutput(input, targetSchema);
   output.t = true;
   output.prev = input;
-  return output;
+  return markOutput(output);
 }
 
 function definitionToShapedSchema(definition) {
@@ -4072,7 +4072,12 @@ function compactColumnsDecoder(input) {
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
       output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
-      return markOutput(hasAsync ? asyncVal(output, "Promise.all(" + outputVar + ")") : output);
+      let output$1 = hasAsync ? asyncVal(output, "Promise.all(" + outputVar + ")") : output;
+      let to = selfSchema.to;
+      if (to !== undefined) {
+        output$1.e = to;
+      }
+      return markOutput(output$1);
     }
     let inputVar$1 = input.v();
     let iteratorVar$1 = varWithoutAllocation(input.g);
@@ -4107,8 +4112,8 @@ function compactColumnsDecoder(input) {
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
     markInput(input);
-    let output$1 = next(input, outputVar$1, outputSchema, outputSchema);
-    output$1.v = _var;
+    let output$2 = next(input, outputVar$1, outputSchema, outputSchema);
+    output$2.v = _var;
     let loopBody = perFieldCode + settingCode;
     let wrappedBody$1;
     if (needsPerFieldTransform && perFieldCode !== "") {
@@ -4117,8 +4122,8 @@ function compactColumnsDecoder(input) {
     } else {
       wrappedBody$1 = loopBody;
     }
-    output$1.cp = output$1.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
-    return markOutput(output$1);
+    output$2.cp = output$2.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
+    return markOutput(output$2);
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3981,7 +3981,7 @@ function compactColumnsDecoder(input) {
     let keysLen = keys.length;
     let outputSchema;
     if (forwardProps) {
-      outputSchema = Stdlib_Option.getOr(selfSchema.to, base(arrayTag, false));
+      outputSchema = selfSchema.to;
     } else {
       let s = array(array(unknown));
       s.to = selfSchema.to;

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3981,7 +3981,7 @@ function compactColumnsDecoder(input) {
     let keysLen = keys.length;
     let outputSchema;
     if (forwardProps) {
-      outputSchema = base(arrayTag, false);
+      outputSchema = Stdlib_Option.getOr(selfSchema.to, base(arrayTag, false));
     } else {
       let s = array(array(unknown));
       s.to = selfSchema.to;
@@ -4072,12 +4072,7 @@ function compactColumnsDecoder(input) {
         wrappedBody = "try{" + rowBody + "}catch(" + errorVar + "){" + errorVar + ".path='[\"'+" + iteratorVar + "+'\"]'+" + errorVar + ".path;throw " + errorVar + "}";
       }
       output.cp = output.cp + ("for(let " + iteratorVar + "=0;" + iteratorVar + "<" + outputVar + ".length;++" + iteratorVar + "){" + wrappedBody + "}");
-      let output$1 = hasAsync ? asyncVal(output, "Promise.all(" + outputVar + ")") : output;
-      let to = selfSchema.to;
-      if (to !== undefined) {
-        output$1.e = to;
-      }
-      return markOutput(output$1);
+      return markOutput(hasAsync ? asyncVal(output, "Promise.all(" + outputVar + ")") : output);
     }
     let inputVar$1 = input.v();
     let iteratorVar$1 = varWithoutAllocation(input.g);
@@ -4112,8 +4107,8 @@ function compactColumnsDecoder(input) {
     }
     input.a(outputVar$1 + "=[" + initialArraysCode + "]");
     markInput(input);
-    let output$2 = next(input, outputVar$1, outputSchema, outputSchema);
-    output$2.v = _var;
+    let output$1 = next(input, outputVar$1, outputSchema, outputSchema);
+    output$1.v = _var;
     let loopBody = perFieldCode + settingCode;
     let wrappedBody$1;
     if (needsPerFieldTransform && perFieldCode !== "") {
@@ -4122,8 +4117,8 @@ function compactColumnsDecoder(input) {
     } else {
       wrappedBody$1 = loopBody;
     }
-    output$2.cp = output$2.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
-    return markOutput(output$2);
+    output$1.cp = output$1.cp + ("for(let " + iteratorVar$1 + "=0;" + iteratorVar$1 + "<" + inputVar$1 + ".length;++" + iteratorVar$1 + "){" + wrappedBody$1 + "}");
+    return markOutput(output$1);
   }
   throw new Error("[Sury] S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).");
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3806,7 +3806,7 @@ function shapedParser(input) {
   let output = getShapedParserOutput(input, targetSchema);
   output.t = true;
   output.prev = input;
-  return markOutput(output);
+  return markOutput(output, input);
 }
 
 function definitionToShapedSchema(definition) {

--- a/packages/sury/tests/S_object_test.res
+++ b/packages/sury/tests/S_object_test.res
@@ -1053,12 +1053,12 @@ module Compiled = {
     t->U.assertCompiledCode(
       ~schema,
       ~op=#Parse,
-      `i=>{if(typeof i!=="object"||!i){e[4](i)}let v0=i["foo"],v1=i["bar"];if(v0!==12){e[0](v0)}if(typeof v1!=="object"||!v1){e[3](v1)}let v2=v1["baz"],v3={"baz":v2,};if(typeof v2!=="string"){e[1](v2)}if(!e[2](v3)){e[5]()}return {"foo":v0,"bar":v3,}}`,
+      `i=>{typeof i==="object"&&i||e[5](i);let v0=i["foo"],v1=i["bar"];v0===12||e[0](v0);typeof v1==="object"&&v1||e[4](v1);let v2=v1["baz"];typeof v2==="string"||e[1](v2);let v3={"baz":v2,};e[2](v3)||e[3](v3);return {"foo":v0,"bar":v3,}}`,
     )
     t->U.assertCompiledCode(
       ~schema,
       ~op=#ReverseConvert,
-      `i=>{let v0=i["bar"];if(!e[0](v0)){e[1]()}return i}`,
+      `i=>{let v0=i["bar"];e[0](v0)||e[1](v0);return {"foo":12,"bar":{"baz":v0["baz"],},}}`,
     )
   })
 

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -65,7 +65,7 @@ test("Compiled parse code snapshot for simple object with refine", t => {
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(typeof i!=="object"||!i){e[3](i)}let v0=i["foo"],v1=i["bar"],v2={"foo":v0,"bar":v1,};if(typeof v0!=="string"){e[0](v0)}if(typeof v1!=="boolean"){e[1](v1)}if(!e[2](v2)){e[4]()}return v2}`,
+    `i=>{typeof i==="object"&&i||e[4](i);let v0=i["foo"],v1=i["bar"];typeof v0==="string"||e[0](v0);typeof v1==="boolean"||e[1](v1);let v2={"foo":v0,"bar":v1,};e[2](v2)||e[3](v2);return v2}`,
   )
 })
 
@@ -88,9 +88,9 @@ module Issue79 = {
     t->U.assertCompiledCode(
       ~schema,
       ~op=#Parse,
-      `i=>{if(typeof i!=="object"||!i){e[0](i)}let v0=i["myField"];if(!(typeof v0==="string"||v0===void 0||v0===null)){e[1](v0)}if(!e[2](v0)){e[3]()}return v0}`,
+      `i=>{typeof i==="object"&&i||e[3](i);let v0=i["myField"];if(!(typeof v0==="string"||v0===void 0||v0===null)){e[0](v0)}e[1](v0)||e[2](v0);return v0}`,
     )
-    t->U.assertCompiledCode(~schema, ~op=#Convert, `i=>{let v0=i["myField"];if(!e[0](v0)){e[1]()}return v0}`)
+    t->U.assertCompiledCode(~schema, ~op=#Convert, `i=>{let v0=i["myField"];e[0](v0)||e[1](v0);return i["myField"]}`)
 
     t->Assert.deepEqual(%raw(`{"myField": "test"}`)->S.parseOrThrow(~to=schema), Value("test"))
   })


### PR DESCRIPTION
## Summary
This PR fixes the application of refiners in shaped parsers and the `compactColumns` decoder by ensuring that output schemas properly track their refiners through the `markOutput` function.

## Key Changes

- **Shaped Parser Output**: Modified `shapedParser` to call `markOutput` on the output, ensuring that refiners attached to the target schema are properly applied to the parsed result.

- **Compact Columns Decoder**: Changed the forward direction path to reuse `selfSchema.to` instead of creating a fresh base schema. This allows `markOutput` to pick up the refiner from the schema's `.to` property, which is guaranteed to exist in the forward direction.

- **Test Updates**: Updated compiled code snapshots in `S_refine_test.res` and `S_object_test.res` to reflect the corrected refiner application order and error handler indices. The generated code now properly applies refiners after value assembly rather than before.

## Implementation Details

The fix leverages the existing `markOutput` function which handles the propagation of refiners from a schema's `.to` property to the output. By ensuring this function is called in both shaped parsers and the compact columns decoder, refiners are now consistently applied at the correct point in the parsing pipeline.

This resolves 6 failing tests related to refiner execution in various schema configurations.

https://claude.ai/code/session_01RBMV1NLKSmrd69AoQJPGui