### PR TITLE
Remove S.enableUrl() calls from e2e tests

### DIFF
--- a/packages/e2e/src/ppx/Ppx_Example_test.res
+++ b/packages/e2e/src/ppx/Ppx_Example_test.res
@@ -1,8 +1,6 @@
 open Ava
 open U
 
-S.enableUrl()
-
 @schema
 type rating =
   | @as("G") GeneralAudiences

--- a/packages/e2e/src/ppx/Ppx_Example_test.res.mjs
+++ b/packages/e2e/src/ppx/Ppx_Example_test.res.mjs
@@ -4,8 +4,6 @@ import * as S from "sury/src/S.res.mjs";
 import * as U from "../utils/U.res.mjs";
 import Ava from "ava";
 
-S.enableUrl();
-
 let ratingSchema = S.union([
   S.literal("G"),
   S.literal("PG"),

--- a/packages/e2e/src/ppx/Ppx_General_test.res
+++ b/packages/e2e/src/ppx/Ppx_General_test.res
@@ -1,8 +1,6 @@
 open Ava
 open U
 
-S.enableUrl()
-
 @schema
 type t = string
 test("Creates schema with the name schema from t type", t => {

--- a/packages/e2e/src/ppx/Ppx_General_test.res.mjs
+++ b/packages/e2e/src/ppx/Ppx_General_test.res.mjs
@@ -4,8 +4,6 @@ import * as S from "sury/src/S.res.mjs";
 import * as U from "../utils/U.res.mjs";
 import Ava from "ava";
 
-S.enableUrl();
-
 Ava("Creates schema with the name schema from t type", t => U.assertEqualSchemas(t, S.string, S.string, undefined));
 
 Ava("Creates schema with the type name and schema at the for non t types", t => U.assertEqualSchemas(t, S.int, S.int, undefined));


### PR DESCRIPTION
## Summary
- `S.enableUrl()` was removed when all schemas were converted to `/*#__PURE__*/` factory functions. `S.url` is now a standalone schema constant, so the runtime opt-in is no longer needed.
- Drop the two stale `S.enableUrl()` calls in `Ppx_Example_test.res` and `Ppx_General_test.res` (and their compiled `.res.mjs` outputs) so the e2e ReScript build compiles again.

## Test plan
- [x] Local: ran the two affected suites via `ava` — all 17 tests pass.
- [ ] CI: e2e job builds with `pnpm rescript && pnpm test`.

https://claude.ai/code/session_01XGvSn7FVha97oLp1JydzRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGvSn7FVha97oLp1JydzRK)_