### PR TITLE
Alpha.5: Pipeline-based operations and union matching overhaul

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -6,6 +6,45 @@ Alpha.5 is the biggest release on the road to v11. It introduces a redesigned op
 
 > **TL;DR** — Parse, decode, encode and assert with one consistent family of functions. Coerce between any two unions with predictable, identity-preserving rules. Validate dates, ISO datetimes, Uint8Arrays, ports, emails, UUIDs, CUIDs and URLs out of the box. And get more readable errors while you're at it.
 
+### 🧠 The mental model shift: schemas all the way down
+
+The biggest idea in Alpha.5 isn't a single new function — it's a **change in how you think about operations**.
+
+In every other validation library — and in earlier Sury — moving between data shapes meant reaching for a different function: `parseOrThrow`, `parseJsonOrThrow`, `parseJsonStringOrThrow`, `convertToJsonOrThrow`, `convertToJsonStringOrThrow`, `reverseConvertToJsonOrThrow`… one operation per supported target.
+
+**Sury Alpha.5 collapses all of that into two ideas:**
+
+1. **`Json`, `JsonString`, `Unknown`, `Date`, `Uint8Array`, … are just schemas.** There is nothing special about JSON. If you can describe it as a schema, it can be a stage in a pipeline.
+2. **`S.decoder` and `S.encoder` accept any sequence of schemas** and compile them into a single, ultra-optimized function via `new Function`. No per-target operations, no special casing — you build the exact pipeline you want.
+
+```ts
+// Old mental model: pick the right function for the job.
+S.parseOrThrow(data, schema);
+S.parseJsonStringOrThrow(rawString, schema);
+S.reverseConvertToJsonOrThrow(value, schema);
+
+// New mental model: name the stages, Sury compiles the path.
+S.parser(schema)(data);
+S.decoder(S.jsonString, schema)(rawString);   // string → JSON.parse → validate → output
+S.encoder(schema, S.json)(value);              // output → input → JSON-shaped value
+S.encoder(schema, S.jsonString)(value);        // …or all the way to a JSON string
+S.decoder(S.jsonString, schema, S.json)(raw);  // parse, then re-emit as plain JSON
+```
+
+The same idea scales beyond JSON:
+
+```ts
+// Decode a Uint8Array of UTF-8 bytes, parse the JSON payload, validate, done.
+S.decoder(S.uint8Array, S.jsonString, schema);
+
+// Take a domain object, encode it to a URL-safe string via a custom pipeline.
+S.encoder(schema, S.string, S.uint8Array);
+```
+
+Each pipeline is fused into a single generated function with no intermediate allocations, so chaining stages doesn't cost you performance — in many cases it's **faster** than the equivalent hand-written code, because Sury can inline the whole path. You go from a fixed menu of operations to an open set: any schema can be an input, any schema can be an output, and the library handles the plumbing.
+
+This is what unlocks most of the other changes in this release — and what makes the [migration cheat sheet](#typescript--javascript) below mostly a story of *deletions*.
+
 ### 🆕 New built-in schemas
 
 A bigger toolbox for everyday data:

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -41,6 +41,23 @@ S.encoder(schema, S.jsonString, S.uint8Array);
 
 Each pipeline is fused into a single generated function with no intermediate allocations, so chaining stages doesn't cost you performance — in many cases it's **faster** than the equivalent hand-written code, because Sury can inline the whole path. You go from a fixed menu of operations to an open set: any schema can be an input, any schema can be an output, and the library handles the plumbing.
 
+**The same pipeline idea works inside schemas too — via `S.to`.** A field, an array element, a tuple slot, or any nested schema can be its own multi-stage chain:
+
+```ts
+const apiUser = S.schema({
+  // Field arrives as a string, parsed as JSON, validated as the addresses array.
+  addresses: S.string.with(S.to, S.jsonString).with(S.to, S.array(addressSchema)),
+
+  // Field arrives as bytes, decoded as UTF-8, validated as an ISO datetime, mapped to Date.
+  createdAt: S.uint8Array.with(S.to, S.string).with(S.to, S.isoDateTime).with(S.to, S.date),
+
+  // Element-level transforms work the same way.
+  ids: S.array(S.string.with(S.to, S.number)),
+});
+```
+
+`S.to` is the same compiler as `S.decoder` / `S.encoder`, just used at a single point in a larger schema. The whole tree — top-level operation plus every nested `S.to` — still folds into one generated function, so deep pipelines stay free of runtime overhead.
+
 `S.parser` and `S.assert` aren't even separate primitives — they're just **specializations of `S.decoder`** with `S.unknown` on the input side:
 
 - `S.parser(schema)` ≡ `S.decoder(S.unknown, schema)` — accept anything, validate against the schema, produce its output type.

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -45,14 +45,14 @@ Each pipeline is fused into a single generated function with no intermediate all
 
 ```ts
 const apiUser = S.schema({
-  // Field arrives as a string, parsed as JSON, validated as the addresses array.
-  addresses: S.string.with(S.to, S.jsonString).with(S.to, S.array(addressSchema)),
+  // Field arrives as a JSON string, which is parsed and validated as an array of addresses.
+  addresses: S.jsonString.with(S.to, S.array(addressSchema)),
 
-  // Field arrives as bytes, decoded as UTF-8, validated as an ISO datetime, mapped to Date.
-  createdAt: S.uint8Array.with(S.to, S.string).with(S.to, S.isoDateTime).with(S.to, S.date),
+  // Field arrives as bytes, decoded as UTF-8, mapped to Date.
+  createdAt: S.uint8Array.with(S.to, S.string).with(S.to, S.date),
 
   // Element-level transforms work the same way.
-  ids: S.array(S.string.with(S.to, S.number)),
+  ids: S.array(S.string.with(S.to, S.bigint)),
 });
 ```
 
@@ -151,12 +151,44 @@ let passwordsMatch =
 
 ### 🧹 Sharper, friendlier errors
 
-- `InvalidType` errors now include the received schema, so you can pattern-match on the concrete type that came in.
-- Dropped the noisy `Failed parsing/converting/asserting` prefix when the error is at the root.
-- Renamed `Failed parsing/converting/asserting at path` → **`Failed at path`** — short, neutral, and applies uniformly to every operation.
-- Every error thrown from `transform`/`refine` is wrapped in `SuryError`, so you never lose stack context.
+Error **messages** are shorter and operation-agnostic. The `Failed parsing/converting/asserting at path` prefix is gone — root errors have no prefix at all, and nested errors share one neutral `Failed at <path>` form regardless of which operation produced them:
+
+```diff
+- Failed parsing at root: Expected boolean, received "yes"
++ Expected boolean, received "yes"
+
+- Failed parsing at ["user"]["age"]: Expected number, received "twenty"
++ Failed at ["user"]["age"]: Expected number, received "twenty"
+
+- Failed converting at root: Can't convert boolean | undefined to JSON
++ Can't decode boolean | undefined to JSON. Use S.to to define a custom decoder
+```
+
+The error **object** is now a properly discriminated variant — `code` is a literal type, each branch carries the fields relevant to it, and `InvalidInput` (formerly `InvalidType`) gained a `received` schema so you can pattern-match on the concrete type that came in:
+
+```diff
+- // Before — flat shape, untyped `code`, no `received`.
+- {
+-   code: "InvalidType",
+-   flag: 1,
+-   path: ["age"],
+-   message: "Failed parsing at [\"age\"]: Expected number, received \"twenty\"",
+-   reason: "Expected number, received \"twenty\"",
+- }
++ // After — discriminated variant, no `flag`, `received` is a schema.
++ {
++   code: "invalid_input",
++   path: ["age"],
++   message: "Failed at [\"age\"]: Expected number, received \"twenty\"",
++   reason: "Expected number, received \"twenty\"",
++   expected: S.number,
++   received: S.string,
++   input: "twenty",
++ }
+```
+
 - Renamed error code `unsupported_conversion` → **`unsupported_decode`** (variant `UnsupportedConversion` → `UnsupportedDecode`). The new message reads: `Can't decode X to Y. Use S.to to define a custom decoder` — a direct hint at the fix.
-- TS: `S.Error` is now a discriminated variant instead of a `code` string property — full type-safe pattern matching.
+- Every error thrown from `transform`/`refine` is wrapped in `SuryError`, so you never lose stack context.
 - ReScript: `S.ErrorClass.constructor` → **`S.Error.make`** (accepts full error details, no more `flag` parameter); `S.ErrorClass.t` and `S.ErrorClass.value` → **`S.Error.class`**; new **`S.Error.classify`** turns an error into a variant of every possible error code.
 
 ### 🎯 Customizable error messages
@@ -184,7 +216,7 @@ schema.with(S.meta, { errorMessage: {} });
 
 ### 🛠️ Internal refactors (worth knowing about)
 
-- Object schemas no longer carry an `items` field, and tuple schemas store `items` as an array of schemas instead of an array of items. The dedicated `item` type is removed.
+- Object schemas no longer carry an `items` field — they now expose `properties` (a dict of field schemas) plus a new **`required`** array listing the non-optional keys, making schema introspection a straight match to the JSON Schema shape. Tuple schemas store `items` as an array of schemas instead of an array of items, and the dedicated `item` type is removed.
 - ReScript: `S.null` is renamed to **`S.nullAsOption`** to reflect what it actually does (decode `null` into `option`).
 
 ### 🚚 Migration cheat sheet

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -2,9 +2,7 @@
 
 ## Alpha.5
 
-Alpha.5 is the biggest release on the road to v11. It introduces a redesigned operation API, a brand-new union dispatch engine, a richer set of built-in schemas, sharper error messages, and a wave of API polish across both the TS/JS and ReScript surfaces.
-
-> **TL;DR** — Parse, decode, encode and assert with one consistent family of functions. Coerce between any two unions with predictable, identity-preserving rules. Validate dates, ISO datetimes, Uint8Arrays, ports, emails, UUIDs, CUIDs and URLs out of the box. And get more readable errors while you're at it.
+Alpha.5 is the biggest release on the road to v11. It introduces a redesigned operation API, a brand-new union match engine, a richer set of built-in schemas, sharper and customizable error messages, and a wave of API polish across both the TS/JS and ReScript surfaces.
 
 ### 🧠 The mental model shift: schemas all the way down
 
@@ -14,8 +12,8 @@ In every other validation library — and in earlier Sury — moving between dat
 
 **Sury Alpha.5 collapses all of that into two ideas:**
 
-1. **`Json`, `JsonString`, `Unknown`, `Date`, `Uint8Array`, … are just schemas.** There is nothing special about JSON. If you can describe it as a schema, it can be a stage in a pipeline.
-2. **`S.decoder` and `S.encoder` accept any sequence of schemas** and compile them into a single, ultra-optimized function via `new Function`. No per-target operations, no special casing — you build the exact pipeline you want.
+1. **`S.json`, `S.jsonString`, `S.unknown`, `S.date`, `S.uint8Array`, … are just schemas.** There is nothing special about JSON. If you can describe it as a schema, it can be a stage in a pipeline.
+2. **`S.parser`, `S.decoder` and `S.encoder` accept any sequence of schemas** and compile them into a single, ultra-optimized function via `new Function`. No per-target operations, no special casing — you build the exact pipeline you want.
 
 ```ts
 // Old mental model: pick the right function for the job.
@@ -37,8 +35,8 @@ The same idea scales beyond JSON:
 // Decode a Uint8Array of UTF-8 bytes, parse the JSON payload, validate, done.
 S.decoder(S.uint8Array, S.jsonString, schema);
 
-// Take a domain object, encode it to a URL-safe string via a custom pipeline.
-S.encoder(schema, S.string, S.uint8Array);
+// Take a domain object, encode it to a JSON string, then to a Uint8Array of UTF-8 bytes.
+S.encoder(schema, S.jsonString, S.uint8Array);
 ```
 
 Each pipeline is fused into a single generated function with no intermediate allocations, so chaining stages doesn't cost you performance — in many cases it's **faster** than the equivalent hand-written code, because Sury can inline the whole path. You go from a fixed menu of operations to an open set: any schema can be an input, any schema can be an output, and the library handles the plumbing.
@@ -48,7 +46,7 @@ Each pipeline is fused into a single generated function with no intermediate all
 - `S.parser(schema)` ≡ `S.decoder(S.unknown, schema)` — accept anything, validate against the schema, produce its output type.
 - `S.assert(schema, data)` ≡ a `S.decoder` from `S.unknown` *through* the schema *to* `S.literal(true).with(S.noValidation, true)` — the target is a no-op constant with validation disabled, so the compiler runs the schema's validation but emits no output-construction code at all. That's why `assert` is 2–3× faster than `parser`.
 
-This is what unlocks most of the other changes in this release — and what makes the [migration cheat sheet](#typescript--javascript) below mostly a story of *deletions*.
+See the [migration cheat sheet](#typescript--javascript) below for the full mapping of the old per-target operations to the new pipeline form.
 
 ### 🆕 New built-in schemas
 
@@ -60,9 +58,11 @@ A bigger toolbox for everyday data:
 - **`S.compactColumns`** — transforms columnar data (`[[a1, a2], [b1, b2]]`) to and from row objects (`[{foo: a1, bar: b1}, {foo: a2, bar: b2}]`). Typed as `Schema<Output[][], Input[][]>`, and `S.toExpression` renders it as the concrete element type (e.g. `"string[][]"`) without needing an explicit `S.to`.
 - **Standalone format schemas** — `S.port`, `S.email`, `S.uuid`, `S.cuid`, `S.url` are now standalone schemas instead of refinement helpers. `Email`, `Uuid`, `Cuid`, `Url` are exposed on the `StringFormat` type for type-level reuse.
 
-### 🪄 Smarter unions: three-tier decoding
+### 🪄 Smarter unions: three-tier matching
 
-When compiling `source -> targetUnion` (via `S.to` or reversal), Sury now uses a three-tier dispatch based on the source's **derived tag** — the tag at compile time, which may be narrower than the original (upstream transformations can refine it). When the source is itself a union, the algorithm runs independently for each source variant.
+When compiling `source -> targetUnion` (via `S.to` or reversal), Sury now uses a three-tier match based on the source's **derived tag** — the tag at compile time, which may be narrower than the original (upstream transformations can refine it).
+
+> 🚧 **Work in progress.** When the source is itself a union, the algorithm runs independently for each source variant. This per-variant fan-out is still being polished and may change before the stable release.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are attempted directly in target-union order at runtime.
 
@@ -93,13 +93,42 @@ Reverse:
 
 To opt into `string → float` when a `string` target also exists, write the transform into a variant explicitly: `S.union([S.string->S.to(S.float), S.string])` as the target. The transform variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-Beyond dispatch, union conversion now always performs **exhaustive validation** — every variant is checked instead of bailing on the first match — so transformed unions stay consistent across encode and decode.
+Beyond matching, union conversion now always performs **exhaustive validation** — every variant is checked instead of bailing on the first match — so transformed unions stay consistent across encode and decode.
 
 ### ⚡ Cleaner refinements
 
-- `S.refine` is now **boolean-returning** instead of callback-based — return `true` for valid, `false` for invalid.
-  - TS/JS: `(value) => boolean` with optional `{ error?: string, path?: string[] }`.
-  - ReScript: `'value => bool` with optional `~error: string=?` and `~path: array<string>=?`.
+`S.refine` is now **boolean-returning** instead of callback-based — return `true` for valid, `false` for invalid:
+
+```ts
+// TS/JS
+const positive = S.number.with(S.refine, (n) => n > 0);
+
+const passwordsMatch = S.schema({
+  password: S.string,
+  confirm: S.string,
+}).with(S.refine, (data) => data.password === data.confirm, {
+  error: "Passwords don't match",
+  path: ["confirm"],
+});
+```
+
+```rescript
+// ReScript
+let positive = S.float->S.refine(n => n > 0.)
+
+let passwordsMatch =
+  S.schema(s =>
+    {
+      "password": s.field("password", S.string),
+      "confirm": s.field("confirm", S.string),
+    }
+  )->S.refine(
+    data => data["password"] == data["confirm"],
+    ~error="Passwords don't match",
+    ~path=["confirm"],
+  )
+```
+
 - Renamed `S.asyncParserRefine` → **`S.asyncDecoderAssert`** (TS/JS). The `EffectCtx` (`s`) parameter is gone — throw directly to signal failure instead of calling `s.fail()`.
 - ReScript: `schema` is no longer passed to the `S.transform` and `S.refine` context — they receive only the value.
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -43,6 +43,11 @@ S.encoder(schema, S.string, S.uint8Array);
 
 Each pipeline is fused into a single generated function with no intermediate allocations, so chaining stages doesn't cost you performance — in many cases it's **faster** than the equivalent hand-written code, because Sury can inline the whole path. You go from a fixed menu of operations to an open set: any schema can be an input, any schema can be an output, and the library handles the plumbing.
 
+`S.parser` and `S.assert` aren't even separate primitives — they're just **specializations of `S.decoder`** with `S.unknown` on the input side:
+
+- `S.parser(schema)` ≡ `S.decoder(S.unknown, schema)` — accept anything, validate against the schema, produce its output type.
+- `S.assert(schema, data)` ≡ a `S.decoder` from `S.unknown` *through* the schema *to* `S.literal(true).with(S.noValidation, true)` — the target is a no-op constant with validation disabled, so the compiler runs the schema's validation but emits no output-construction code at all. That's why `assert` is 2–3× faster than `parser`.
+
 This is what unlocks most of the other changes in this release — and what makes the [migration cheat sheet](#typescript--javascript) below mostly a story of *deletions*.
 
 ### 🆕 New built-in schemas

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -2,52 +2,31 @@
 
 ## Alpha.5
 
-- Add `S.date` — standalone Date instance schema. Validates `instanceof Date` and rejects Invalid Date. Unlike `S.isoDateTime` (which validates ISO 8601 UTC strings) and `S.string->S.to(S.date)` (which decodes ISO strings into Date objects), `S.date` directly validates existing Date instances.
-- Add `S.isoDateTime` — standalone string schema that validates ISO 8601 UTC datetime strings (no timezone offsets, arbitrary sub-second precision). Replaces the removed `S.datetime` for the "validate an ISO string" use case — for string↔Date conversion use `S.string->S.to(S.date)`.
-- Added `S.compactColumns` - transforms columnar data (`[[a1,a2], [b1,b2]]`) to/from row objects (`[{foo:a1,bar:b1}, {foo:a2,bar:b2}]`)
-- TypeScript: Use `S.encoder(schema)` for encoding (replaces internal `reverseConvertOrThrow`)
-- `S.compactColumns` type is `Schema<Output[][], Input[][]>`
-- `S.toExpression` now shows proper type for `S.compactColumns` without `S.to` (e.g., `"string[][]"`)
-- Changed `S.refine` from callback-based to boolean-returning. TS/JS: `(value) => boolean` with optional `{ error?: string, path?: string[] }` options. ReScript: `'value => bool` with optional `~error: string=?` and `~path: array<string>=?` labeled arguments. The check returns `true` when valid, `false` when invalid.
-- TS/JS API: Renamed `S.asyncParserRefine` to `S.asyncDecoderAssert`. Removed `EffectCtx` (`s`) parameter — throw directly to signal failure instead of calling `s.fail()`
-- TS API: Removed `S.transform` in favor of `S.to`
-- Add `S.uint8Array`
-- Updated `InvalidType` error code to include the received schema
-- Updated internal representation of object schema - removed `items` fields. Updated internalt representation of tuple schema - `items` field is now an array of schemas instead of array of items. The `item` type is removed.
-- Removed `Failed parsing/converting/asserting` when the error is at root
-- Renamed `Failed parsing/converting/asserting at path` to `Failed at path`
-- ReScript: Removed `schema` from `S.transform` and `S.refine` context
-- ReScript:
-  - `S.ErrorClass.constructor` -> `S.Error.make` - now accepts full error details and doesn't require `flag` parameter
-  - `S.ErrorClass.t` -> `S.Error.class`
-  - `S.ErrorClass.value` -> `S.Error.class`
-  - Reworked error code and added `S.Error.classify` to turn error into a variant of all possible error codes
-- All errors thrown in transform/refine are wrapped in `SuryError`
-- TS: Updated `S.Error` type to use variants instead of code property
-- ReScript: `S.null` -> `S.nullAsOption`
-- Updated union conversion logic - it now always performs exhaustive validation
-- Encoding to JSON now strips undefined fields
-- JSON decoder now automatically decodes non-JSON types (e.g. `S.date`, `S.bigint`) to string via their encoder, instead of special-casing each type. Schemas with a string encoder (like `S.date` → `toISOString()`) work with `S.json`/`S.jsonString` out of the box.
-- Renamed error code `unsupported_conversion` → `unsupported_decode` and variant `UnsupportedConversion` → `UnsupportedDecode`
-- Error message for unsupported decode now reads: `"Can't decode X to Y. Use S.to to define a custom decoder"`
-- `S.port`, `S.email`, `S.uuid`, `S.cuid`, `S.url` are now standalone schemas.
-- Added `Email`, `Uuid`, `Cuid`, `Url` to `StringFormat` type.
-- Removed `S.String.Refinement` module and `S.String.refinements` accessor. Use schema `pattern`/`format`/`errorMessage` fields directly.
-- Added `errorMessage` field to `S.meta` for overriding validation messages per-use: `S.email.with(S.meta, { errorMessage: { format: "Custom" } })`. Supports `_` as a catch-all key. Empty `{}` deletes the field.
-- Added typed `SchemaErrorMessage` type with fields for each constraint key (`format`, `type`, `minimum`, `maximum`, `minLength`, `maxLength`, `minItems`, `maxItems`, `pattern`, `_`).
-- Renamed `errorMessages` → `errorMessage` (singular) on schema types.
+Alpha.5 is the biggest release on the road to v11. It introduces a redesigned operation API, a brand-new union dispatch engine, a richer set of built-in schemas, sharper error messages, and a wave of API polish across both the TS/JS and ReScript surfaces.
 
-### Union coercion
+> **TL;DR** — Parse, decode, encode and assert with one consistent family of functions. Coerce between any two unions with predictable, identity-preserving rules. Validate dates, ISO datetimes, Uint8Arrays, ports, emails, UUIDs, CUIDs and URLs out of the box. And get more readable errors while you're at it.
 
-When compiling `source -> targetUnion` (via `S.to` or reversal), matching uses a three-tier algorithm based on the source's derived tag. The derived tag is the tag at compile time, which may be narrower than the tag set at schema creation (upstream transformations can narrow it). When the source is itself a union, the algorithm is applied independently for each source variant.
+### 🆕 New built-in schemas
 
-When the source is `unknown` (no derived tag), the matching logic is ignored: the tag-based tiers do not apply, and target variants are attempted directly in target-union order at runtime.
+A bigger toolbox for everyday data:
 
-1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: target variants with a matching `const`/`format` (string literals, `Int32`, etc.) are attempted first in target-union order, then remaining catch-all same-tag variants in target-union order. Variants with a different tag are never tried from here — if all branches in the group fail, the match errors.
-2. **Nullish bridge.** Applied only when tier 1's group is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant if present, exclusively.
-3. **Fallback.** Applied only when tiers 1 and 2 are both empty. Attempt to build a decoder for every target variant in target-union order. This is where cross-type coercions live: `number`/`bigint` → `string` via `""+i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-const matches like `"null" → null`, etc.
+- **`S.date`** — standalone `Date` instance schema. Validates `instanceof Date` and rejects Invalid Date. Unlike `S.isoDateTime` (which validates ISO 8601 UTC strings) and `S.string->S.to(S.date)` (which decodes ISO strings into Date objects), `S.date` validates existing Date instances directly.
+- **`S.isoDateTime`** — standalone string schema for ISO 8601 UTC datetime strings: no timezone offsets, arbitrary sub-second precision. Replaces the removed `S.datetime` for the "validate an ISO string" use case. For string ↔ Date conversion use `S.string->S.to(S.date)`.
+- **`S.uint8Array`** — first-class `Uint8Array` schema. Combine with `S.to(S.string)` for binary ↔ text encoding/decoding.
+- **`S.compactColumns`** — transforms columnar data (`[[a1, a2], [b1, b2]]`) to and from row objects (`[{foo: a1, bar: b1}, {foo: a2, bar: b2}]`). Typed as `Schema<Output[][], Input[][]>`, and `S.toExpression` renders it as the concrete element type (e.g. `"string[][]"`) without needing an explicit `S.to`.
+- **Standalone format schemas** — `S.port`, `S.email`, `S.uuid`, `S.cuid`, `S.url` are now standalone schemas instead of refinement helpers. `Email`, `Uuid`, `Cuid`, `Url` are exposed on the `StringFormat` type for type-level reuse.
 
-Worked example — `S.union([S.bigint, S.float, S.nullLiteral])->S.to(S.union([S.string, S.unit]))`:
+### 🪄 Smarter unions: three-tier decoding
+
+When compiling `source -> targetUnion` (via `S.to` or reversal), Sury now uses a three-tier dispatch based on the source's **derived tag** — the tag at compile time, which may be narrower than the original (upstream transformations can refine it). When the source is itself a union, the algorithm runs independently for each source variant.
+
+If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are attempted directly in target-union order at runtime.
+
+1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then remaining catch-all same-tag variants. Variants with a different tag are never tried — if every branch in the group fails, the match errors.
+2. **Nullish bridge.** Only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
+3. **Fallback.** Only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `number`/`bigint` → `string` via `"" + i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-const matches like `"null" → null`, and more.
+
+**Worked example** — `S.union([S.bigint, S.float, S.nullLiteral])->S.to(S.union([S.string, S.unit]))`:
 
 Forward:
 
@@ -63,29 +42,86 @@ Reverse:
 - `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to float)
 - `"abc"` → error (tier 3: no variant's decoder succeeds)
 
-Identity is strictly preferred over available coercion. For `S.union([S.string, S.bigint])->S.to(S.union([S.float, S.string]))`:
+**Identity beats coercion.** For `S.union([S.string, S.bigint])->S.to(S.union([S.float, S.string]))`:
 
 - `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `float` even though a `float` target exists)
-- `123n` → `"123"` (tier 3: no `bigint` target, falls through to the `string` variant via `""+i`)
+- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" + i`)
 
-To opt into `string → float` when a `string` target also exists, the user writes the transform into a variant explicitly: `S.union([S.string->S.to(S.float), S.string])` as the target. The transform variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+To opt into `string → float` when a `string` target also exists, write the transform into a variant explicitly: `S.union([S.string->S.to(S.float), S.string])` as the target. The transform variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-### TS
+Beyond dispatch, union conversion now always performs **exhaustive validation** — every variant is checked instead of bailing on the first match — so transformed unions stay consistent across encode and decode.
 
-- `S.parseOrThrow` -> `S.parser(schema)(data)`
-- `S.parseJsonOrThrow` -> `S.decoder(S.json, schema)(data)`
-- `S.parseJsonStringOrThrow` -> `S.decoder(S.jsonString, schema)(data)`
-- `S.parseAsyncOrThrow` -> `S.asyncParser(schema)(data)`
-- `S.convertOrThrow` -> `S.decoder(schema)(data)`
-- `S.convertToJsonOrThrow` -> `S.decoder(schema, S.json)(data)`
-- `S.convertToJsonStringOrThrow` -> `S.decoder(schema, S.jsonString)(data)`
-- `S.reverseConvertOrThrow` -> `S.encoder(schema)(data)`
-- `S.reverseConvertToJsonOrThrow` -> `S.encoder(schema, S.json)(data)`
-- `S.reverseConvertToJsonStringOrThrow` -> `S.encoder(schema, S.jsonString)(data)`
-- `S.assertOrThrow` -> `S.assert(schema, data)`
-- `S.compile` -> `S.decoder` or `S.encoder` or `S.parser`
+### ⚡ Cleaner refinements
 
-### ReScript
+- `S.refine` is now **boolean-returning** instead of callback-based — return `true` for valid, `false` for invalid.
+  - TS/JS: `(value) => boolean` with optional `{ error?: string, path?: string[] }`.
+  - ReScript: `'value => bool` with optional `~error: string=?` and `~path: array<string>=?`.
+- Renamed `S.asyncParserRefine` → **`S.asyncDecoderAssert`** (TS/JS). The `EffectCtx` (`s`) parameter is gone — throw directly to signal failure instead of calling `s.fail()`.
+- ReScript: `schema` is no longer passed to the `S.transform` and `S.refine` context — they receive only the value.
+
+### 🧹 Sharper, friendlier errors
+
+- `InvalidType` errors now include the received schema, so you can pattern-match on the concrete type that came in.
+- Dropped the noisy `Failed parsing/converting/asserting` prefix when the error is at the root.
+- Renamed `Failed parsing/converting/asserting at path` → **`Failed at path`** — short, neutral, and applies uniformly to every operation.
+- Every error thrown from `transform`/`refine` is wrapped in `SuryError`, so you never lose stack context.
+- Renamed error code `unsupported_conversion` → **`unsupported_decode`** (variant `UnsupportedConversion` → `UnsupportedDecode`). The new message reads: `Can't decode X to Y. Use S.to to define a custom decoder` — a direct hint at the fix.
+- TS: `S.Error` is now a discriminated variant instead of a `code` string property — full type-safe pattern matching.
+- ReScript: `S.ErrorClass.constructor` → **`S.Error.make`** (accepts full error details, no more `flag` parameter); `S.ErrorClass.t` and `S.ErrorClass.value` → **`S.Error.class`**; new **`S.Error.classify`** turns an error into a variant of every possible error code.
+
+### 🎯 Customizable error messages
+
+Override validation messages per-use without forking a schema:
+
+```ts
+S.email.with(S.meta, { errorMessage: { format: "Must be a valid email" } });
+
+// `_` is a catch-all for any constraint
+S.email.with(S.meta, { errorMessage: { _: "Invalid input" } });
+
+// Empty {} resets all overrides
+schema.with(S.meta, { errorMessage: {} });
+```
+
+- Added `errorMessage` (singular) on schema types — renamed from the plural `errorMessages`.
+- New typed **`SchemaErrorMessage`** with fields for every constraint key: `format`, `type`, `minimum`, `maximum`, `minLength`, `maxLength`, `minItems`, `maxItems`, `pattern`, `_`.
+- The `S.String.Refinement` module and `S.String.refinements` accessor are removed — read `pattern`/`format`/`errorMessage` from the schema directly.
+
+### 📦 JSON pipeline improvements
+
+- **Strips `undefined` on encode.** Encoding to JSON now drops `undefined` fields by default — no more accidentally serializing keys with `undefined` values.
+- **Automatic string encoders.** The JSON decoder no longer special-cases each non-JSON type. Any schema with a string encoder (`S.date` → `toISOString()`, `S.bigint`, etc.) now plays nicely with `S.json` and `S.jsonString` out of the box.
+
+### 🛠️ Internal refactors (worth knowing about)
+
+- Object schemas no longer carry an `items` field, and tuple schemas store `items` as an array of schemas instead of an array of items. The dedicated `item` type is removed.
+- ReScript: `S.null` is renamed to **`S.nullAsOption`** to reflect what it actually does (decode `null` into `option`).
+
+### 🚚 Migration cheat sheet
+
+#### TypeScript / JavaScript
+
+A consistent family of functions replaces the OrThrow zoo:
+
+| Before | After |
+|---|---|
+| `S.parseOrThrow(data, schema)` | `S.parser(schema)(data)` |
+| `S.parseAsyncOrThrow(data, schema)` | `S.asyncParser(schema)(data)` |
+| `S.parseJsonOrThrow(data, schema)` | `S.decoder(S.json, schema)(data)` |
+| `S.parseJsonStringOrThrow(data, schema)` | `S.decoder(S.jsonString, schema)(data)` |
+| `S.convertOrThrow(data, schema)` | `S.decoder(schema)(data)` |
+| `S.convertToJsonOrThrow(data, schema)` | `S.decoder(schema, S.json)(data)` |
+| `S.convertToJsonStringOrThrow(data, schema)` | `S.decoder(schema, S.jsonString)(data)` |
+| `S.reverseConvertOrThrow(data, schema)` | `S.encoder(schema)(data)` |
+| `S.reverseConvertToJsonOrThrow(data, schema)` | `S.encoder(schema, S.json)(data)` |
+| `S.reverseConvertToJsonStringOrThrow(data, schema)` | `S.encoder(schema, S.jsonString)(data)` |
+| `S.assertOrThrow(data, schema)` | `S.assert(schema, data)` |
+| `S.compile(...)` | `S.parser` / `S.decoder` / `S.encoder` |
+| `S.transform` | `S.to` |
+
+#### ReScript
+
+The labeled-argument operation API is now the single entry point:
 
 | Before | After |
 |---|---|
@@ -94,7 +130,7 @@ To opt into `string → float` when a `string` target also exists, the user writ
 | `S.parseJsonOrThrow(data, schema)` | `S.decodeOrThrow(data, ~from=S.json, ~to=schema)` |
 | `S.parseJsonStringOrThrow(data, schema)` | `S.decodeOrThrow(data, ~from=S.jsonString, ~to=schema)` |
 | `S.assertOrThrow(data, schema)` | `S.assertOrThrow(data, ~to=schema)` |
-| — | `S.assertAsyncOrThrow(data, ~to=schema)` |
+| — | `S.assertAsyncOrThrow(data, ~to=schema)` *(new)* |
 | `S.reverseConvertOrThrow(data, schema)` | `S.decodeOrThrow(data, ~from=schema, ~to=S.unknown)` |
 | `S.reverseConvertToJsonOrThrow(data, schema)` | `S.decodeOrThrow(data, ~from=schema, ~to=S.json)` |
 | `S.reverseConvertToJsonStringOrThrow(data, schema)` | `S.decodeOrThrow(data, ~from=schema, ~to=S.jsonString)` |

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -1190,6 +1190,23 @@ S.decoder(S.uint8Array, S.jsonString, userSchema)(bytes);
 
 You're no longer picking from a fixed menu of operations — you're describing the shape of the data at each stage and letting Sury compile the path.
 
+The **same pipeline idea works inside schemas** via [`S.to`](#to). A field, an array element, a tuple slot — any nested schema can be its own multi-stage chain:
+
+```ts
+const apiUser = S.schema({
+  // Arrives as a string, parsed as JSON, validated as the addresses array.
+  addresses: S.string.with(S.to, S.jsonString).with(S.to, S.array(addressSchema)),
+
+  // Arrives as bytes, decoded as UTF-8, validated as an ISO datetime, mapped to a Date.
+  createdAt: S.uint8Array.with(S.to, S.string).with(S.to, S.isoDateTime).with(S.to, S.date),
+
+  // Element-level transforms work the same way.
+  ids: S.array(S.string.with(S.to, S.number)),
+});
+```
+
+`S.to` is the same compiler as `S.decoder` / `S.encoder`, just used at a single point in a larger schema. The whole tree — top-level operation plus every nested `S.to` — still folds into one generated function, so deep pipelines stay free of runtime overhead.
+
 > 🧠 `S.parser` and `S.assert` aren't separate primitives — they're just specializations of `S.decoder` with `S.unknown` on the input side. `S.parser(schema)` is `S.decoder(S.unknown, schema)`. `S.assert(schema, data)` runs a decoder from `S.unknown` *through* the schema *to* `S.literal(true).with(S.noValidation, true)` — the target is a no-op constant with validation disabled, so the compiler emits the schema's validation but no output-construction code at all. That's why `assert` is 2–3× faster than `parser`.
 
 ### Built-in operations

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -50,6 +50,7 @@
   - [`transform`](#transforms)
   - [`shape`](#shape)
 - [Functions on schema](#functions-on-schema)
+  - [The mental model: pipelines, not operations](#the-mental-model-pipelines-not-operations)
   - [Built-in operations](#built-in-operations)
   - [Chaining operations](#chaining-operations)
   - [`reverse`](#reverse)
@@ -1161,6 +1162,33 @@ S.encoder(circleSchema)({ kind: "circle", radius: 1 }); //? 1
 ```
 
 ## Functions on schema
+
+### The mental model: pipelines, not operations
+
+If you've used other validation libraries, you're used to a separate function for every input/output pair: `parseJson`, `parseJsonString`, `convertToJson`, `convertToJsonString`, and so on. **Sury treats those targets as schemas instead.** `S.json`, `S.jsonString`, `S.unknown`, `S.date`, `S.uint8Array` — none of them are special, they're just schemas like any other.
+
+The two operation functions you need are:
+
+- **`S.decoder(from, …intermediate, to)`** — compile a forward pipeline from one schema to another.
+- **`S.encoder(from, …intermediate, to)`** — compile the reverse pipeline.
+
+Every call fuses the whole chain into a single ultra-optimized function generated via `new Function`, so adding stages costs you nothing at runtime.
+
+```ts
+// Validate unknown input.
+S.parser(userSchema)(data);
+
+// Parse a JSON string, then validate.
+S.decoder(S.jsonString, userSchema)(rawString);
+
+// Encode a domain value all the way out to a JSON string.
+S.encoder(userSchema, S.jsonString)(user);
+
+// Decode a binary payload of UTF-8 JSON, then validate.
+S.decoder(S.uint8Array, S.jsonString, userSchema)(bytes);
+```
+
+You're no longer picking from a fixed menu of operations — you're describing the shape of the data at each stage and letting Sury compile the path.
 
 ### Built-in operations
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -1190,6 +1190,8 @@ S.decoder(S.uint8Array, S.jsonString, userSchema)(bytes);
 
 You're no longer picking from a fixed menu of operations — you're describing the shape of the data at each stage and letting Sury compile the path.
 
+> 🧠 `S.parser` and `S.assert` aren't separate primitives — they're just specializations of `S.decoder` with `S.unknown` on the input side. `S.parser(schema)` is `S.decoder(S.unknown, schema)`. `S.assert(schema, data)` runs a decoder from `S.unknown` *through* the schema *to* `S.literal(true).with(S.noValidation, true)` — the target is a no-op constant with validation disabled, so the compiler emits the schema's validation but no output-construction code at all. That's why `assert` is 2–3× faster than `parser`.
+
 ### Built-in operations
 
 The library provides a bunch of built-in operations that can be used to parse, convert, and assert values.

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -1194,14 +1194,14 @@ The **same pipeline idea works inside schemas** via [`S.to`](#to). A field, an a
 
 ```ts
 const apiUser = S.schema({
-  // Arrives as a string, parsed as JSON, validated as the addresses array.
-  addresses: S.string.with(S.to, S.jsonString).with(S.to, S.array(addressSchema)),
+  // Arrives as a JSON string, which is parsed and validated as an array of addresses.
+  addresses: S.jsonString.with(S.to, S.array(addressSchema)),
 
-  // Arrives as bytes, decoded as UTF-8, validated as an ISO datetime, mapped to a Date.
-  createdAt: S.uint8Array.with(S.to, S.string).with(S.to, S.isoDateTime).with(S.to, S.date),
+  // Arrives as bytes, decoded as UTF-8, mapped to a Date.
+  createdAt: S.uint8Array.with(S.to, S.string).with(S.to, S.date),
 
   // Element-level transforms work the same way.
-  ids: S.array(S.string.with(S.to, S.number)),
+  ids: S.array(S.string.with(S.to, S.bigint)),
 });
 ```
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -35,6 +35,7 @@
 - [Unions](#unions)
   - [Discriminated unions](#discriminated-unions)
   - [Enums](#enums)
+  - [Decoding into / out of a union](#decoding-into--out-of-a-union)
 - [Records](#records)
 - [JSON](#json)
 - [JSON string](#json-string)
@@ -50,7 +51,7 @@
   - [`shape`](#shape)
 - [Functions on schema](#functions-on-schema)
   - [Built-in operations](#built-in-operations)
-  - [`compile`](#compile)
+  - [Chaining operations](#chaining-operations)
   - [`reverse`](#reverse)
   - [`to`](#to)
   - [`standard`](#standard)
@@ -122,7 +123,7 @@ if (!result.success) {
 }
 ```
 
-> 🧠 Besides `parser` there are also built-in operations to transform the data without validation, assert without allocating output, serialize back to the initial format and more. If somebody is missing in built-in operations, you can use `S.compile` to create a custom one.
+> 🧠 Besides `parser` there are also built-in operations to transform the data without validation, assert without allocating output, serialize back to the initial format and more. For more advanced pipelines, chain schemas with `S.decoder(input, …intermediate, output)` or `S.encoder(output, …intermediate, input)`.
 
 ### Inferred types
 
@@ -853,6 +854,47 @@ const schema = S.union(["Win", "Draw", "Loss"]);
 type Schema = S.Infer<typeof schema>; // "Win" | "Draw" | "Loss"
 ```
 
+### Decoding into / out of a union
+
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant.
+
+If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
+
+1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then any remaining catch-all same-tag variants. Variants with a different tag are never tried from here — if every branch in the group fails, the match errors.
+2. **Nullish bridge.** Used only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
+3. **Fallback.** Used only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `number`/`bigint` → `string` via `"" + i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-const matches like `"null" → null`, and more.
+
+**Worked example** — `S.union([S.bigint, S.number, null]).with(S.to, S.union([S.string, undefined]))`:
+
+Forward:
+
+- `123n` → `"123"` (tier 3: bigint → string)
+- `123.12` → `"123.12"` (tier 3: number → string)
+- `null` → `undefined` (tier 2: nullish bridge)
+
+Reverse (via `S.encoder`):
+
+- `"null"` → `null` (tier 3: stringified-const literal match)
+- `undefined` → `null` (tier 2: nullish bridge)
+- `"123"` → `123n` (tier 3: bigint attempted first by target order; parse succeeds)
+- `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to number)
+- `"abc"` → error (tier 3: no variant's decoder succeeds)
+
+**Identity wins over coercion.** For `S.union([S.string, S.bigint]).with(S.to, S.union([S.number, S.string]))`:
+
+- `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `number` even though a `number` target exists)
+- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" + i`)
+
+To opt into `string → number` when a `string` target also exists, write the transform into a variant explicitly:
+
+```ts
+S.union([S.string.with(S.to, S.number), S.string]);
+```
+
+The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+
+> 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
+
 ## Records
 
 Record schema is used to validate types such as `{ [k: string]: number }`.
@@ -1163,44 +1205,21 @@ All operations either return the output value or throw an error. For convinient 
 const result = S.safe(() => S.parser(S.string)(123));
 ```
 
-### **`compile`**
+### Chaining operations
 
-If you want to have the most possible performance, or the built-in operations doesn't cover your specific use case, you can use `compile` to create fine-tuned operation functions.
+`S.decoder` and `S.encoder` accept multiple schemas to build a single fused pipeline. The first schema is the input side and the last is the output side; intermediate schemas act as stages.
 
 ```ts
-const operation = S.compile(S.string, "Any", "Assert", "Async");
-typeof operation; // => (input: unknown) => Promise<void>
-await operation("Hello world!");
-// ()
+// Decode a JSON string into your domain type in one pass
+const parseJsonString = S.decoder(S.jsonString, userSchema);
+parseJsonString('{"id":"1","name":"John"}');
+
+// Encode your domain type to a JSON string in one pass
+const stringifyUser = S.encoder(userSchema, S.jsonString);
+stringifyUser({ id: "1", name: "John" });
 ```
 
-For example, in the example above we've created an async assert operation, which is not available by default.
-
-You can configure compiled function `input` with the following options:
-
-- `Output` - accepts `Output` of `Schema<Output, Input>` and reverses the operation
-- `Input` - accepts `Input` of `Schema<Output, Input>` which only affects the operation function argument type
-- `Any` - accepts `unknown`
-- `Json` - accepts `Json`
-- `JsonString` - accepts `string` and applies `JSON.parse` before parsing
-
-You can configure compiled function `output` with the following options:
-
-- `Output` - returns `Output` of `Schema<Output, Input>`
-- `Input` - returns `Input` of `Schema<Output, Input>`
-- `Assert` - returns `void` with `asserts data is T` guard
-- `Json` - validates that the schema is JSON compatible and returns `Js.Json.t`
-- `JsonString` - validates that the schema is JSON compatible and converts output to JSON string
-
-You can configure compiled function `mode` with the following options:
-
-- `Sync` - for sync operations
-- `Async` - for async operations - will wrap return value in a promise
-
-And you can configure compiled function `typeValidation` with the following options:
-
-- `true (default)` - performs type validation
-- `false` - doesn't perform type validation and only converts data to the output format. Note that refines are still applied.
+This covers the use cases that previously needed `S.compile` — see the [migration cheat sheet](/IDEAS.md#typescript--javascript) for the full mapping.
 
 ### **`reverse`**
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1429,6 +1429,27 @@ await "1"->S.parseAsyncOrThrow(~to=userSchema)
 
 ## Functions on schema
 
+### The mental model: pipelines, not operations
+
+If you're coming from earlier Sury releases (or from any other validation library), you're used to a separate function for every input/output pair: `parseJsonOrThrow`, `parseJsonStringOrThrow`, `reverseConvertToJsonOrThrow`, and so on. **Sury treats those targets as schemas instead.** `S.json`, `S.jsonString`, `S.unknown`, `S.date`, `S.uint8Array` — none of them are special, they're just schemas like any other.
+
+So instead of a fixed menu of operations, you describe the shape of the data at each stage with `~from` and `~to`, and Sury compiles the whole pipeline into a single ultra-optimized function via `new Function`. Adding stages costs you nothing at runtime.
+
+```rescript
+// Validate any input value.
+data->S.parseOrThrow(~to=userSchema)
+
+// Parse a JSON string, then validate.
+rawString->S.decodeOrThrow(~from=S.jsonString, ~to=userSchema)
+
+// Encode a domain value all the way out to a JSON string.
+user->S.decodeOrThrow(~from=userSchema, ~to=S.jsonString)
+
+// Pre-compile pipelines once, call them many times.
+let parseJsonUser = S.decoder(~from=S.jsonString, ~to=userSchema)
+let stringifyUser = S.decoder(~from=userSchema, ~to=S.jsonString)
+```
+
 ### Built-in operations
 
 The library provides a bunch of built-in operations that can be used to parse, decode, and assert values.

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1450,6 +1450,25 @@ let parseJsonUser = S.decoder(~from=S.jsonString, ~to=userSchema)
 let stringifyUser = S.decoder(~from=userSchema, ~to=S.jsonString)
 ```
 
+The **same pipeline idea works inside schemas** via [`S.to`](#to). A field, an array element, a tuple slot — any nested schema can be its own multi-stage chain:
+
+```rescript
+let apiUserSchema = S.schema(s =>
+  {
+    // Arrives as a string, parsed as JSON, validated as the addresses array.
+    "addresses": s.field("addresses", S.string->S.to(S.jsonString)->S.to(S.array(addressSchema))),
+
+    // Arrives as bytes, decoded as UTF-8, validated as an ISO datetime, mapped to a Date.
+    "createdAt": s.field("createdAt", S.uint8Array->S.to(S.string)->S.to(S.isoDateTime)->S.to(S.date)),
+
+    // Element-level transforms work the same way.
+    "ids": s.field("ids", S.array(S.string->S.to(S.float))),
+  }
+)
+```
+
+`S.to` is the same compiler as `S.decoder` and `S.decodeOrThrow`, just used at a single point in a larger schema. The whole tree — top-level operation plus every nested `S.to` — still folds into one generated function, so deep pipelines stay free of runtime overhead.
+
 > 🧠 `S.parseOrThrow` and `S.assertOrThrow` aren't separate primitives — they're just specializations of `S.decodeOrThrow` with `S.unknown` on the input side. `data->S.parseOrThrow(~to=schema)` is `data->S.decodeOrThrow(~from=S.unknown, ~to=schema)`. `data->S.assertOrThrow(~to=schema)` runs a decoder from `S.unknown` through the schema to `S.literal(true)->S.noValidation(true)` — the target is a no-op constant with validation disabled, so the compiler emits the schema's validation but no output-construction code at all. That's why `assertOrThrow` is 2–3× faster than `parseOrThrow`.
 
 ### Built-in operations

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -920,6 +920,47 @@ Also, you can use `S.enum` as a shorthand for the use case above.
 let schema = S.enum([Win, Draw, Loss])
 ```
 
+#### Decoding into / out of a union
+
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant.
+
+If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
+
+1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then any remaining catch-all same-tag variants. Variants with a different tag are never tried from here — if every branch in the group fails, the match errors.
+2. **Nullish bridge.** Used only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
+3. **Fallback.** Used only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `int`/`bigint` → `string` via `"" ++ i`, `string` → `float` via `Float.fromString`, `string` → `bigint` via `BigInt.fromString`, stringified-const matches like `"null" → null`, and more.
+
+**Worked example** — `S.union([S.bigint, S.float, S.nullLiteral])->S.to(S.union([S.string, S.unit]))`:
+
+Forward:
+
+- `123n` → `"123"` (tier 3: bigint → string)
+- `123.12` → `"123.12"` (tier 3: float → string)
+- `null` → `undefined` (tier 2: nullish bridge)
+
+Reverse (via `S.decodeOrThrow(~from=schema, ~to=S.unknown)`):
+
+- `"null"` → `null` (tier 3: stringified-const literal match)
+- `undefined` → `null` (tier 2: nullish bridge)
+- `"123"` → `123n` (tier 3: bigint attempted first by target order; parse succeeds)
+- `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to float)
+- `"abc"` → error (tier 3: no variant's decoder succeeds)
+
+**Identity wins over coercion.** For `S.union([S.string, S.bigint])->S.to(S.union([S.float, S.string]))`:
+
+- `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `float` even though a `float` target exists)
+- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" ++ i`)
+
+To opt into `string → float` when a `string` target also exists, write the transform into a variant explicitly:
+
+```rescript
+S.union([S.string->S.to(S.float), S.string])
+```
+
+The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+
+> 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
+
 ### **`array`**
 
 `S.t<'value> => S.t<array<'value>>`

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1450,6 +1450,8 @@ let parseJsonUser = S.decoder(~from=S.jsonString, ~to=userSchema)
 let stringifyUser = S.decoder(~from=userSchema, ~to=S.jsonString)
 ```
 
+> 🧠 `S.parseOrThrow` and `S.assertOrThrow` aren't separate primitives — they're just specializations of `S.decodeOrThrow` with `S.unknown` on the input side. `data->S.parseOrThrow(~to=schema)` is `data->S.decodeOrThrow(~from=S.unknown, ~to=schema)`. `data->S.assertOrThrow(~to=schema)` runs a decoder from `S.unknown` through the schema to `S.literal(true)->S.noValidation(true)` — the target is a no-op constant with validation disabled, so the compiler emits the schema's validation but no output-construction code at all. That's why `assertOrThrow` is 2–3× faster than `parseOrThrow`.
+
 ### Built-in operations
 
 The library provides a bunch of built-in operations that can be used to parse, decode, and assert values.

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1455,14 +1455,14 @@ The **same pipeline idea works inside schemas** via [`S.to`](#to). A field, an a
 ```rescript
 let apiUserSchema = S.schema(s =>
   {
-    // Arrives as a string, parsed as JSON, validated as the addresses array.
-    "addresses": s.field("addresses", S.string->S.to(S.jsonString)->S.to(S.array(addressSchema))),
+    // Arrives as a JSON string, which is parsed and validated as an array of addresses.
+    "addresses": s.field("addresses", S.jsonString->S.to(S.array(addressSchema))),
 
-    // Arrives as bytes, decoded as UTF-8, validated as an ISO datetime, mapped to a Date.
-    "createdAt": s.field("createdAt", S.uint8Array->S.to(S.string)->S.to(S.isoDateTime)->S.to(S.date)),
+    // Arrives as bytes, decoded as UTF-8, mapped to a Date.
+    "createdAt": s.field("createdAt", S.uint8Array->S.to(S.string)->S.to(S.date)),
 
     // Element-level transforms work the same way.
-    "ids": s.field("ids", S.array(S.string->S.to(S.float))),
+    "ids": s.field("ids", S.array(S.string->S.to(S.bigint))),
   }
 )
 ```

--- a/packages/sury-ppx/jsr.json
+++ b/packages/sury-ppx/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/ppx",
-  "version": "11.0.0-alpha.2",
+  "version": "11.0.0-alpha.5",
   "license": "MIT",
   "exports": "./index.ts"
 }

--- a/packages/sury-ppx/package.json
+++ b/packages/sury-ppx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury-ppx",
-  "version": "11.0.0-alpha.2",
+  "version": "11.0.0-alpha.5",
   "description": "⚙️ ReScript PPX to generate Sury schema from types",
   "keywords": [
     "Sury",
@@ -34,6 +34,6 @@
     "postinstall": "node ./install.cjs"
   },
   "peerDependencies": {
-    "sury": "^11.0.0-alpha.2"
+    "sury": "^11.0.0-alpha.5"
   }
 }

--- a/packages/sury/jsr.json
+++ b/packages/sury/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/sury",
-  "version": "11.0.0-alpha.3",
+  "version": "11.0.0-alpha.5",
   "license": "MIT",
   "exclude": ["!src", "!rescript.json", "!README.md", "!package.json", "!docs"],
   "exports": "./src/S.mjs"

--- a/packages/sury/package.json
+++ b/packages/sury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury",
-  "version": "11.0.0-alpha.3",
+  "version": "11.0.0-alpha.5",
   "private": true,
   "description": "🧬 The fastest schema with next-gen DX",
   "keywords": [
@@ -33,6 +33,18 @@
   "main": "./src/S.js",
   "module": "./src/S.mjs",
   "types": "./src/S.d.ts",
+  "exports": {
+    ".": {
+      "import": "./src/S.mjs",
+      "require": "./src/S.js",
+      "types": "./src/S.d.ts"
+    },
+    "./src/*": "./src/*",
+    "./S.gen.js": {
+      "types": "./src/S.gen.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "src",
     "rescript.json"


### PR DESCRIPTION
## Summary

This is a major release introducing a fundamental shift in how Sury handles data transformations. Instead of separate functions for each input/output pair (`parseJson`, `convertToJson`, etc.), operations are now built by composing schemas as pipeline stages. The release also includes a new three-tier union matching algorithm, cleaner refinement APIs, improved error messages, and a richer set of built-in schemas.

## Key Changes

### Mental Model Shift: Schemas as Pipelines
- Replaced per-target operation functions with a unified pipeline approach using `S.decoder()` and `S.encoder()`
- `S.parser(schema)` is now `S.decoder(S.unknown, schema)`
- `S.assert(schema, data)` is now a specialized decoder with validation but no output construction
- All old `OrThrow` functions (`parseOrThrow`, `convertToJsonOrThrow`, etc.) map to pipeline compositions
- Pipelines are fused into single generated functions with no intermediate allocations

### New Built-in Schemas
- `S.date` — validates `instanceof Date` instances directly
- `S.isoDateTime` — validates ISO 8601 UTC datetime strings
- `S.uint8Array` — first-class Uint8Array schema for binary data
- `S.compactColumns` — transforms between columnar and row-based data formats
- Standalone format schemas: `S.port`, `S.email`, `S.uuid`, `S.cuid`, `S.url` (previously refinement helpers)

### Union Matching Algorithm
- Implemented three-tier matching based on source's **derived tag** (compile-time narrowed type):
  1. **Same-tag group** — match within variants sharing the source's tag, prioritizing const/format matches
  2. **Nullish bridge** — convert between `null` and `undefined` when no same-tag match exists
  3. **Fallback** — attempt cross-type coercions (number→string, string→bigint, etc.)
- Identity matches are strictly preferred over coercions
- Union conversion now always performs exhaustive validation

### Refinement API Improvements
- `S.refine` now uses boolean-returning callbacks instead of callback-based approach
- Returns `true` for valid, `false` for invalid
- Optional `{ error?: string, path?: string[] }` options for custom messages and error location
- Renamed `S.asyncParserRefine` → `S.asyncDecoderAssert`
- Removed `EffectCtx` parameter — throw directly to signal failure

### Error Message and Object Improvements
- Removed `Failed parsing/converting/asserting` prefix from root errors
- Unified nested error prefix to `Failed at <path>` (operation-agnostic)
- Error object is now a properly discriminated variant with literal `code` type
- `InvalidType` renamed to `InvalidInput` with new `received` schema field
- `unsupported_conversion` → `unsupported_decode` with improved message
- All errors from transform/refine wrapped in `SuryError`
- ReScript: `S.ErrorClass` → `S.Error` with new `S.Error.make` and `S.Error.classify`

### Customizable Error Messages
- Added `errorMessage` field to `S.meta` for per-use message overrides
- Supports `_` as catch-all key for any constraint
- New typed `SchemaErrorMessage` with fields for each constraint
- Removed `S.String.Refinement` module and `S.String.refinements` accessor

### JSON Pipeline Improvements
- Encoding to JSON now strips `undefined` fields by default
- JSON decoder automatically encodes non-JSON types via their string encoder
- Schemas with string encoders (e.g., `S.date` → `toISOString()`) work with `S.json`/`S.jsonString` out of the box

### Internal Refactors
- Object schemas: removed `items` field, added `properties` dict and `required` array
- Tuple schemas: `items` is now array of schemas instead of array of items; removed `item` type
- ReScript: `S.null` → `S.nullAsOption` to reflect actual behavior

https://claude.ai/code/session_01UzDJKGMj4f7BtFtskCrrUD