### PR TITLE
Use glob pattern for sury-ppx artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sury-ppx
-          path: packages/sury-ppx/sury-ppx-11.0.0-alpha.2.tgz
+          path: packages/sury-ppx/sury-ppx-*.tgz
 
   e2e:
     name: E2E Test


### PR DESCRIPTION
## Summary
Updated the CI workflow to use a glob pattern when uploading the sury-ppx build artifact, making the workflow more maintainable and version-agnostic.

## Changes
- Changed the artifact upload path from a hardcoded version string (`sury-ppx-11.0.0-alpha.2.tgz`) to a glob pattern (`sury-ppx-*.tgz`)

## Details
This change eliminates the need to manually update the CI configuration whenever the package version changes. The glob pattern will automatically match the built artifact regardless of its version suffix, reducing maintenance burden and preventing CI failures due to version mismatches.

https://claude.ai/code/session_01FsrmvXd8k84864yfJgPB8V