### PR TITLE
Test union schema error reporting with string-shape fallback

### DIFF
--- a/packages/sury/tests/S_union_test.res
+++ b/packages/sury/tests/S_union_test.res
@@ -194,6 +194,13 @@ test("Reports the named union schema when a string-shape fallback rejects a non-
     () => %raw(`42`)->S.parseOrThrow(~to=schema),
     `Expected indexer plan, received 42`,
   )
+
+  t->Assert.deepEqual(#hyper->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"hyper"`))
+  t->U.assertThrowsMessage(
+    () => #unknown->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    `Expected indexer plan, received "unknown"
+- Missing input for string`,
+  )
 })
 
 test("Serializes when second struct misses serializer", t => {

--- a/packages/sury/tests/S_union_test.res
+++ b/packages/sury/tests/S_union_test.res
@@ -175,6 +175,27 @@ test("Parses with string catch all", t => {
   t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{if(!(typeof i==="string")){e[0](i)}return i}`)
 })
 
+// https://github.com/DZakh/sury/issues/115
+test("Reports the named union schema when a string-shape fallback rejects a non-string input", t => {
+  let schema =
+    S.union([
+      S.literal(#hyper),
+      S.literal(#development),
+      S.literal(#small),
+      S.literal(#medium),
+      S.literal(#large),
+      S.literal(#dedicated),
+      S.string->S.shape(_ => #unknown),
+    ])->S.meta({name: "indexer plan"})
+
+  t->Assert.deepEqual(%raw(`"hyper"`)->S.parseOrThrow(~to=schema), #hyper)
+  t->Assert.deepEqual(%raw(`"anything-else"`)->S.parseOrThrow(~to=schema), #unknown)
+  t->U.assertThrowsMessage(
+    () => %raw(`42`)->S.parseOrThrow(~to=schema),
+    `Expected indexer plan, received 42`,
+  )
+})
+
 test("Serializes when second struct misses serializer", t => {
   let schema = S.union([S.literal(#apple), S.string->S.transform(_ => {parser: _ => #apple})])
 


### PR DESCRIPTION
Add test case for issue #115 to verify that union schemas with a string-shape fallback correctly report the named union schema in error messages when rejecting non-string inputs.

## Summary
This test ensures that when a union contains literal variants and a string-shape fallback (which transforms strings to a variant), the error messages properly attribute failures to the union schema itself rather than the fallback handler.

## Key changes
- Added comprehensive test case covering both parse and decode paths
- Verifies that valid string inputs are correctly transformed through the fallback
- Confirms that non-string inputs report the union schema name ("indexer plan") in error messages
- Tests decode path error reporting includes context about the missing string input

## Test coverage
- Parse path: non-string input (42) correctly reports "Expected indexer plan"
- Decode path: invalid variant (#unknown) reports both the schema name and the missing string input context

https://claude.ai/code/session_01NR9esry3TDXiMW1aZcw7K5