### PR TITLE
Remove disabled compiler warnings 50 and 102

### DIFF
--- a/packages/e2e/rescript.json
+++ b/packages/e2e/rescript.json
@@ -13,7 +13,7 @@
   },
   "suffix": ".res.mjs",
   "warnings": {
-    "number": "+a-4-9-20-41-50-102",
+    "number": "+a-4-9-20-41",
     "error": "+a"
   },
   "dependencies": ["sury"],

--- a/packages/sury/rescript.json
+++ b/packages/sury/rescript.json
@@ -22,7 +22,7 @@
     }
   ],
   "warnings": {
-    "number": "+a-4-9-20-41-50-102",
+    "number": "+a-4-9-20-41",
     "error": "+a"
   },
   "dev-dependencies": ["@dzakh/rescript-ava", "rescript-nodejs"]


### PR DESCRIPTION
Removes compiler warnings 50 and 102 from the ReScript compiler configuration in both the e2e and sury packages.

These warnings were previously disabled but are no longer needed. The change simplifies the warning configuration by removing them from the `warnings.number` field in both `rescript.json` files.

**Changes:**
- Updated `packages/e2e/rescript.json`: removed `-50-102` from warnings configuration
- Updated `packages/sury/rescript.json`: removed `-50-102` from warnings configuration

Both packages now use the same, simplified warning configuration: `+a-4-9-20-41`

https://claude.ai/code/session_01YPusVj5u156YqHrLPpBSdW