### PR TITLE
Add type performance benchmarks to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
       - run: pnpm build
         working-directory: packages/sury
 
+      - name: Type performance benchmarks
+        run: pnpm bench:types
+        working-directory: packages/sury
+
       - run: pnpm coverage
         working-directory: packages/sury
 


### PR DESCRIPTION
Adds a type performance benchmarking step to the CI workflow to track TypeScript compilation performance across builds.

**Changes:**
- Integrated `pnpm bench:types` into the CI pipeline for the `packages/sury` workspace
- Runs after the build step and before coverage collection
- Enables continuous monitoring of type-checking performance as part of standard CI checks

This aligns with the project's performance goals by establishing a baseline and tracking regressions in type performance, which is critical for maintaining good DX with fast IDE feedback.

https://claude.ai/code/session_018xEu11NnspSgDEtGV81CwY