### PR TITLE
Fix union dispatch hoisting over coercion vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,15 +58,21 @@ A `val` is the compile-time view of a runtime value at one point in the generate
 Core fields:
 - `schema` — actual type at this point
 - `expected` — schema to build decoder for
-- `var()` — variable name in generated code
+- `var()` — variable name in generated code (allocates lazily; reuse when the value is referenced more than once)
 - `inline` — inline expression form
 - `path` — location in input (for errors)
+- `isOutput` — `Some(true)` once refiners have been applied (see Refiner ownership)
 
 Transformation chain (relative to `.prev`):
 - `prev` — previous val in the chain
-- `code` — codegen from `.prev` to this val
-- `validation` — type-check condition from `.prev` (distinct from user refiners)
+- `codeFromPrev` — statements that produce this val from `.prev`
+- `varsAllocation` — `let` declarations for vars introduced by codegen, populated via the `allocate` side-channel (which mutates whichever val it's called on — frequently `.prev`, not this val). `merge` emits them in the owning val's slot.
+- `checks` — `array<check>`; both type-narrows and user refiners live here. A check whose `fail === B.failInvalidType` is a type-narrow and **doubles as a union dispatch discriminant**.
 
 Helpers:
-- `B.refine` — clones a val to attach checks, keeping the var-allocation link.
-- `skipTo` — abort parse after current decoder. Prefer `val.expected`; aim to remove `skipTo`.
+- `B.next` — new val one step down the transform chain (sets `hasTransform`).
+- `B.refine` — clones a val to attach `checks`, keeping the var-allocation link.
+- `B.markOutput` — applies `inputRefiner`/`refiner` and sets `isOutput` (see Refiner ownership).
+- `B.merge` — walks the `.prev` chain into a code string. With `~hoistCond` (union codegen) it lifts type-narrow checks into a dispatch condition.
+
+> **Hoisting invariant (currently fragile):** a hoisted `check.cond(~inputVar)` must depend only on `inputVar` (= `prev.var()`), which is in scope at the dispatch site. A decoder that allocates an intermediate var (e.g. `v0 = +i`) and references it in a type-narrow check breaks this — `merge(~hoistCond)` lifts the discriminant above the var's `varsAllocation` declaration, producing `v0 is not defined`. Trips on `str->to(option(int))` and similar conversion-into-union cases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,4 +75,3 @@ Helpers:
 - `B.markOutput` — applies `inputRefiner`/`refiner` and sets `isOutput` (see Refiner ownership).
 - `B.merge` — walks the `.prev` chain into a code string. With `~hoistCond` (union codegen) it lifts type-narrow checks into a dispatch condition.
 
-> **Hoisting invariant (currently fragile):** a hoisted `check.cond(~inputVar)` must depend only on `inputVar` (= `prev.var()`), which is in scope at the dispatch site. A decoder that allocates an intermediate var (e.g. `v0 = +i`) and references it in a type-narrow check breaks this — `merge(~hoistCond)` lifts the discriminant above the var's `varsAllocation` declaration, producing `v0 is not defined`. Trips on `str->to(option(int))` and similar conversion-into-union cases.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,8 @@ The internal representation of a type schema, containing:
 - `encoder`: Builder function for converting from different schema types
 - `parser`: Builder function for transformations after decoding (used by `S.shape`, `S.to`)
 - `serializer`: Builder function for reverse transformations
+- `inputRefiner`: User validations run on the typed input, before the decoder
+- `refiner`: User validations run on the assembled output, after the decoder (`S.reverse` swaps `inputRefiner` ↔ `refiner`)
 - `to`: Target schema for transformations (set by `S.shape`, `S.to`)
 - `from`: Path array indicating where this value comes from in shaped schemas
 - `properties`: For object schemas, a dict of field name to schema
@@ -39,14 +41,19 @@ The internal representation of a type schema, containing:
 
 #### Builder
 
-A builder is a function with signature `(~input: val, ~selfSchema: internal) => val`. Builders generate JavaScript code at compile time by manipulating `val` objects. They are created using `Builder.make`:
+A builder is a function with signature `(~input: val) => val`. The schema being built is available as `input.expected` (there is no `~selfSchema` parameter). Builders generate JavaScript code at compile time by manipulating `val` objects. They are created using `Builder.make`:
 
 ```rescript
-let myBuilder = Builder.make((~input, ~selfSchema) => {
-  // Generate code and return output val
-  let output = input->B.val(`someTransform(${input.var()})`, ~schema=selfSchema)
-  output
+let myBuilder = Builder.make((~input) => {
+  // `input.expected` is this schema; return the output val
+  input->B.next(`someTransform(${input.var()})`, ~schema=input.expected)
 })
+```
+
+Encoders take an extra `~target` (the schema being coerced into) and are created with `Builder.encoder`:
+
+```rescript
+let myEncoder = Builder.encoder((~input, ~target) => { ... })
 ```
 
 #### Val (Value)
@@ -57,77 +64,80 @@ A compilation-time representation of a value being processed. Key fields:
 - `var()`: Function to allocate/retrieve a variable name (use when value is referenced multiple times)
 - `schema`: The schema of the current value
 - `expected`: The schema we're trying to parse/convert into
-- `from`: Link to the input val (for code merging)
-- `code`: Generated code statements
-- `validation`: Optional validation function to generate type checks
-- `skipTo`: When `Some(true)`, prevents `parse` from following the `.to` chain
+- `prev`: Link to the previous val in the transform chain (walked by `merge`)
+- `codeFromPrev`: Generated statements that produce this val from `prev`
+- `varsAllocation`: `let` declarations, populated via the `allocate` side-channel and emitted by `merge`
+- `checks`: `array<check>` of type-narrows and user refiners. A check whose `fail === B.failInvalidType` is a type-narrow that doubles as a union dispatch discriminant. (Invariant: absent iff no checks — never stored as `Some([])`.)
+- `isOutput`: `Some(true)` once refiners have run; advanced decoders (object/array/tuple/union/recursive) set it themselves
 - `global`: Shared compilation context containing:
   - `embeded`: Array of embedded values (functions, constants) accessible as `e[n]`
   - `varCounter`: Counter for generating unique variable names
 
 ### Compilation Flow
 
-When a schema operation is compiled (e.g., `parseOrThrow`), the following happens:
+When a schema operation is compiled (e.g., `parseOrThrow`), `parse(val)` runs a
+loop until the val is fully decoded (`isOutput` is `Some(true)` and there is no
+further `.to`). Each iteration:
 
 ```
 Input Schema
      │
      ▼
-┌─────────────────────────────────────────────────────────┐
-│  parse(val) function                                    │
-│                                                         │
-│  1. Encoder (if input.schema !== expected)              │
-│     - Converts between different schema types           │
-│                                                         │
-│  2. Decoder (always runs)                               │
-│     - Validates input type (e.g., typeof === "string")  │
-│     - Generates validation code                         │
-│                                                         │
-│  3. Parser (if expected.parser exists)                  │
-│     - Applies transformations (S.transform, S.shape)    │
-│                                                         │
-│  4. Recursive parse (if expected.to exists)             │
-│     - Follows transformation chain                      │
-│     - Skipped if val.skipTo === Some(true)              │
-└─────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│  parse(val) loop — one iteration                             │
+│                                                              │
+│  if async flag:                                              │
+│     - continue the chain inside `.then(...)`                 │
+│                                                              │
+│  else if val.isOutput (decoded, may still have `.to`):       │
+│     - follow `.to`: run `expected.parser` (custom decoder)   │
+│       or `refine` onto `.to` (default encoder coercion)      │
+│                                                              │
+│  else (not yet decoded):                                     │
+│     1. Encoder — if `schema !== expected` and an encoder     │
+│        exists, coerce between schema types                   │
+│     2. Decoder — otherwise narrow to the schema type         │
+│        (e.g. `typeof === "string"`) and push `checks`        │
+│     3. markOutput — for primitive decoders, apply            │
+│        `inputRefiner`/`refiner` and set `isOutput`           │
+│        (advanced decoders own this themselves)               │
+└──────────────────────────────────────────────────────────────┘
      │
      ▼
-Output Val with merged code
+Output Val (chain of `.prev` links)
      │
      ▼
-B.merge() → JavaScript function string
+B.merge(output) → JavaScript code string → wrapped into the operation function
 ```
 
 ### Code Generation Example
 
-For `S.object(s => s.field("foo", S.string))`:
+For `S.object(s => s.field("foo", S.string))` the generated parse function is:
 
 ```javascript
-// Generated parse function:
-(i) => {
-  if (typeof i !== "object" || !i) {
-    e[0](i);
-  } // Object validation
-  let v0 = i["foo"]; // Field access
-  if (typeof v0 !== "string") {
-    e[1](v0);
-  } // String validation
-  return v0; // Return parsed value
+i => {
+  typeof i === "object" && i || e[1](i); // object validation
+  let v0 = i["foo"];                     // field access
+  typeof v0 === "string" || e[0](v0);    // string validation
+  return v0;                             // return parsed value
 };
 ```
 
-Where:
+Checks emit as `cond || e[n](x);` (throw when the condition is false), not as
+`if (!cond) {...}`. Where:
 
 - `i` is the input argument
-- `e` is the embedded values array (error throwers, transformers)
+- `e` is the embedded values array (error throwers, transformers), accessed as `e[n]`
 - `v0`, `v1`, etc. are allocated variables
 
 ### Key Functions
 
-- `parse(val)`: Main compilation function that walks through encoder → decoder → parser → to chain
-- `B.merge(val)`: Collects all generated code from the val chain into a single string
-- `B.Val.cleanValFrom(val)`: Creates a clean copy of val for new code generation while preserving variable binding
-- `B.embed(val, value)`: Embeds a runtime value (function, object) and returns reference like `e[0]`
+- `parse(val)`: Main compilation loop — encoder → decoder → markOutput → follow `.to`, until the val is fully decoded
+- `B.merge(val, ~hoistCond=?)`: Walks the `.prev` chain into a code string. With `~hoistCond` (union codegen) it lifts type-narrow checks into a dispatch condition
+- `B.next(prev, code, ~schema, ~expected=?)`: Creates the next val one step down the transform chain
+- `B.refine(val, ~checks=?, ~schema=?, ~expected=?)`: Clones a val to attach `checks` while preserving the var-allocation link
+- `B.markOutput(val, ~valInput)`: Applies `inputRefiner`/`refiner` and marks the val as output
+- `B.embed(val, value)`: Embeds a runtime value (function, object) and returns a reference like `e[0]`
 
 ### Shaped Schemas (S.shape, S.object with definer)
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1951,10 +1951,17 @@ let numberDecoder = Builder.make((~input) => {
     input->B.refine(~schema=input.expected, ~checks)
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.string) {
     let outputVar = input.global->B.varWithoutAllocation
-    input.allocate(`${outputVar}=+${input.var()}`)
 
     let output = input->B.next(outputVar, ~schema=input.expected)
     output.var = B._var
+    // Emit the `+input` coercion as codeFromPrev (a self-contained unit that
+    // declares its own var) instead of parking it in varsAllocation via the
+    // `allocate` side-channel. This keeps the conversion glued to the val that
+    // owns the type-narrow check below: a non-empty codeFromPrev makes the val
+    // non-hoistable in `merge`, so when this decoder feeds a union dispatch
+    // (e.g. `str->to(option(int))`) the discriminant is not lifted above its
+    // `let v0=+i` declaration. Mirrors how the string->bool decoder works.
+    output.codeFromPrev = `let ${outputVar}=+${input.var()};`
 
     output.checks = Some([
       {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1059,9 +1059,9 @@ function numberDecoder(input) {
     }
   }
   let outputVar = varWithoutAllocation(input.g);
-  input.a(outputVar + `=+` + input.v());
   let output = next(input, outputVar, input.e, undefined);
   output.v = _var;
+  output.cp = `let ` + outputVar + `=+` + input.v() + `;`;
   output.vc = [{
       c: param => {
         let match = input.e.format;

--- a/packages/sury/tests/S_Option_getOr_test.res
+++ b/packages/sury/tests/S_Option_getOr_test.res
@@ -314,12 +314,12 @@ test("Appending S.to(S.jsonString) after getOr extends the output chain", t => {
   )
 })
 
-// FIXME: parse codegen for a multi-member transforming union + getOr puts
-// each branch's input refiner BEFORE its `let v0 = +i` / `let v1 = BigInt(i)`
-// declaration, so parsing a string throws ReferenceError. Encoder side and
-// non-string parse paths are fine — the bug lives in the outer union's
-// per-branch decoder emission, not in getWithDefault.
-test("Multi-member union with transformed members + getOr — current (broken) behavior", t => {
+// A multi-member transforming union + getOr. Each string-coercing branch
+// declares its conversion var (`let v0 = +i` / `let v1 = BigInt(i)`) inside the
+// try block that owns the branch's type check, so a string input dispatches
+// per-branch without ever reading a var before its declaration (the previous
+// codegen emitted `if(!Number.isNaN(v0))` above `let v0 = +i`).
+test("Multi-member union with transformed members + getOr", t => {
   let schema =
     S.union([
       S.string->S.to(S.float)->S.castToUnknown,
@@ -332,29 +332,23 @@ test("Multi-member union with transformed members + getOr — current (broken) b
   t->Assert.deepEqual(%raw(`undefined`)->S.parseOrThrow(~to=schema), %raw(`true`))
   t->Assert.deepEqual(%raw(`true`)->S.parseOrThrow(~to=schema), %raw(`true`))
   t->Assert.deepEqual(%raw(`false`)->S.parseOrThrow(~to=schema), %raw(`false`))
+  // Parsing a string used to throw ReferenceError (v0 read before declaration).
+  t->Assert.deepEqual("42"->S.parseOrThrow(~to=schema), %raw(`42`))
 
   t->Assert.deepEqual(%raw(`42`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"42"`))
   t->Assert.deepEqual(%raw(`1n`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"1"`))
   t->Assert.deepEqual(%raw(`true`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`true`))
 
-  // FIXME: `if(!Number.isNaN(v0))` reads v0 before `let v0 = +i`.
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(typeof i==="string"){if(!Number.isNaN(v0)){let v0=+i;i=v0}else{try{let v1;try{v1=BigInt(i)}catch(_){e[0](i)}i=v1}catch(e1){e[1](i,e1)}}}else if(!(typeof i==="boolean"||i===void 0)){e[2](i)}return i===void 0?true:i}`,
+    `i=>{if(typeof i==="string"){try{let v0=+i;!Number.isNaN(v0)||e[0](i);i=v0}catch(e0){try{let v1;try{v1=BigInt(i)}catch(_){e[1](i)}i=v1}catch(e1){e[2](i,e0,e1)}}}else if(!(typeof i==="boolean"||i===void 0)){e[3](i)}return i===void 0?true:i}`,
   )
 
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Encode,
     `i=>{if(typeof i==="number"&&!Number.isNaN(i)){i=""+i}else if(typeof i==="bigint"){i=""+i}else if(!(typeof i==="boolean")){e[0](i)}return i}`,
-  )
-
-  t->Assert.throws(
-    () => {
-      let _ = "42"->S.parseOrThrow(~to=schema)
-    },
-    ~expectations={message: "v0 is not defined"},
   )
 })
 

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -29,6 +29,36 @@ test("Coerce from string to bool", t => {
   t->U.assertCompiledCode(~schema, ~op=#Encode, `i=>{return ""+i}`)
 })
 
+test("Coerce from string to option of int (union dispatch over a converted value)", t => {
+  let schema = S.string->S.to(S.option(S.int))
+
+  t->Assert.deepEqual("123"->S.parseOrThrow(~to=schema), Some(123))
+  t->Assert.deepEqual("undefined"->S.parseOrThrow(~to=schema), None)
+  t->U.assertThrowsMessage(
+    () => "1.5"->S.parseOrThrow(~to=schema),
+    `Expected int32 | undefined, received "1.5"
+- Expected int32, received 1.5`,
+  )
+
+  // Regression (v0 is not defined): the union discriminant must not be hoisted
+  // above the `let v0 = +i` conversion it reads. The string->number coercion is
+  // a self-contained codeFromPrev unit, so the int branch dispatches via
+  // try/catch with its declaration intact.
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{typeof i==="string"||e[3](i);try{let v0=+i;!Number.isNaN(v0)||e[1](i);v0<=2147483647&&v0>=-2147483648&&v0%1===0||e[0](v0);i=v0}catch(e0){if(i==="undefined"){i=void 0}else{e[2](i,e0)}}return i}`,
+  )
+
+  t->Assert.deepEqual(Some(123)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"123"`))
+  t->Assert.deepEqual(None->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"undefined"`))
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Encode,
+    `i=>{if(typeof i==="number"&&!Number.isNaN(i)){if(i<=2147483647&&i>=-2147483648&&i%1===0){i=""+i}}else if(i===void 0){i="undefined"}else{e[0](i)}return i}`,
+  )
+})
+
 test("Coerce from bool to string", t => {
   let schema = S.bool->S.to(S.string)
 
@@ -393,7 +423,7 @@ test("Coerce string to unboxed union (each item separately)", t => {
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{typeof i==="string"||e[3](i);try{let v0=+i;!Number.isNaN(v0)||e[1](i);i=v0}catch(e1){try{let v1;(v1=i==="true")||i==="false"||e[0](i);i=v1}catch(e2){e[2](i,e1,e2)}}return i}`,
+    `i=>{typeof i==="string"||e[3](i);try{let v0=+i;!Number.isNaN(v0)||e[0](i);i=v0}catch(e0){try{let v1;(v1=i==="true")||i==="false"||e[1](i);i=v1}catch(e1){e[2](i,e0,e1)}}return i}`,
   )
 
   t->Assert.deepEqual(Number(10.)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"10"`))


### PR DESCRIPTION
## Summary

Fixes a regression where union discriminant checks were hoisted above variable declarations they depend on, causing `ReferenceError` when parsing strings through transforming unions (e.g., `S.string->S.to(S.option(S.int))`).

## Changes

- **numberDecoder**: Changed how the string-to-number coercion (`+input`) is emitted. Instead of parking it in `varsAllocation` via the `allocate` side-channel, it now emits as `codeFromPrev` on the output val. This keeps the conversion glued to the val that owns the type-narrow check, preventing the discriminant from being hoisted above the `let v0 = +i` declaration in union dispatch codegen.

- **Documentation**: Updated CONTRIBUTING.md and CLAUDE.md to reflect the current architecture:
  - Clarified that builders receive `input.expected` instead of a separate `~selfSchema` parameter
  - Documented the new `inputRefiner` and `refiner` fields and their interaction with `S.reverse`
  - Explained the `checks` array structure (type-narrows double as union dispatch discriminants)
  - Described the compilation loop flow and the role of `isOutput`
  - Updated val field descriptions (`codeFromPrev`, `varsAllocation`, `checks`, `prev`)
  - Added examples of the new builder and encoder signatures

- **Tests**: 
  - Added comprehensive test for `S.string->S.to(S.option(S.int))` covering parse, encode, and error cases
  - Fixed test name and removed `Assert.throws` from "Multi-member union with transformed members + getOr" (now passes instead of throwing `ReferenceError`)
  - Updated compiled code snapshots to reflect corrected variable numbering in union branches

## Implementation Details

The fix ensures that when a primitive decoder produces a transformed value (like `let v0 = +i`), that transformation is self-contained in `codeFromPrev` rather than split across `varsAllocation`. This makes the val non-hoistable in `merge`, so union dispatch discriminants stay anchored to their branch's conversion code. The approach mirrors how the string→bool decoder already works.

https://claude.ai/code/session_01ELw6DkgodEsygPMGjjK7Xm