### PR TITLE
Optimize S.Output/Input extraction to match only ~standard marker

### DIFF
--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -303,11 +303,20 @@ export const Error: {
   prototype: Error;
 };
 
-export type Output<T> = T extends Schema<infer Output, unknown>
+// Extract Output/Input by matching only the `~standard` marker instead of the
+// full `Schema<…>` shape (whose 14-member union + `with` overloads are costly to
+// instantiate per match). `types` is optional, so the pattern keeps it optional.
+export type Output<T> = T extends {
+  readonly ["~standard"]: { readonly types?: { readonly output: infer Output } };
+}
   ? Output
   : never;
 export type Infer<T> = Output<T>;
-export type Input<T> = T extends Schema<unknown, infer Input> ? Input : never;
+export type Input<T> = T extends {
+  readonly ["~standard"]: { readonly types?: { readonly input: infer Input } };
+}
+  ? Input
+  : never;
 
 // Utility types for decoder function with multiple schemas
 type ExtractFirstInput<T extends readonly Schema<any, any>[]> =

--- a/packages/sury/tests/types.bench.ts
+++ b/packages/sury/tests/types.bench.ts
@@ -128,7 +128,9 @@ bench("S.union — 5 object members", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // S.Output<T> / S.Input<T> extraction — measures the cost users actually pay
 // at every `type Foo = S.Output<typeof fooSchema>` site (138 usages mentioned
-// in issue #166).
+// in issue #166). Extraction matches only the `~standard` marker (S.d.ts:306)
+// rather than instantiating the full `Schema<…>` shape, so the cost no longer
+// scales with how complex the extracted Output/Input is.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const flatSchema = S.schema({
@@ -141,11 +143,11 @@ const flatSchema = S.schema({
 
 bench("S.Output on 5-field object", () => {
   return {} as S.Output<typeof flatSchema>;
-}).types([6951, "instantiations"]);
+}).types([501, "instantiations"]);
 
 bench("S.Input on 5-field object", () => {
   return {} as S.Input<typeof flatSchema>;
-}).types([5816, "instantiations"]);
+}).types([501, "instantiations"]);
 
 const deepSchema = S.schema({
   a: S.string,
@@ -160,7 +162,7 @@ const deepSchema = S.schema({
 
 bench("S.Output on 3-level nested object", () => {
   return {} as S.Output<typeof deepSchema>;
-}).types([6951, "instantiations"]);
+}).types([501, "instantiations"]);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Compound: define + extract (the realistic per-schema cost).
@@ -180,7 +182,7 @@ bench("S.schema + S.Output — 10-field object", () => {
     j: S.symbol,
   });
   return {} as S.Output<typeof s>;
-}).types([7294, "instantiations"]);
+}).types([844, "instantiations"]);
 
 // ─────────────────────────────────────────────────────────────────────────────
 // S.merge — exercises the Omit<O1, keyof O2> & O2 intersection in the return
@@ -220,5 +222,5 @@ bench("S.merge — 3 optional + 2 required (issue #157 case)", () => {
 bench("S.merge — output extraction with optional preservation", () => {
   const m = S.merge(mergeLeftOptional, mergeRightForOptional);
   return {} as S.Output<typeof m>;
-}).types([12426, "instantiations"]);
+}).types([7039, "instantiations"]);
 


### PR DESCRIPTION
## Summary

Dramatically reduce type instantiation cost for `S.Output<T>` and `S.Input<T>` extraction by matching only the `~standard` marker instead of the full `Schema<…>` shape. This eliminates the expensive 14-member union instantiation that was scaling with schema complexity.

## Changes

- **S.d.ts**: Rewrote `Output<T>` and `Input<T>` type helpers to match a minimal structural pattern (`{ readonly ["~standard"]: { readonly types?: { readonly output/input: … } } }`) instead of the full `Schema<infer Output, infer Input>` union. This avoids instantiating the entire Schema type's 14-member union and `with` overloads on every extraction site.

- **types.bench.ts**: Updated benchmark expectations to reflect the new, dramatically lower instantiation counts:
  - `S.Output on 5-field object`: 6951 → 501 instantiations
  - `S.Input on 5-field object`: 5816 → 501 instantiations  
  - `S.Output on 3-level nested object`: 6951 → 501 instantiations
  - `S.schema + S.Output — 10-field object`: 7294 → 844 instantiations
  - `S.merge — output extraction with optional preservation`: 12426 → 7039 instantiations

- Added clarifying comments explaining the optimization strategy and why extraction cost no longer scales with schema complexity.

## Implementation Details

The new pattern leverages TypeScript's structural matching to extract the `output` and `input` types from the `~standard` marker object without forcing full Schema union resolution. The `types` field is marked optional to preserve compatibility with the existing marker structure, ensuring the pattern matches all valid schema instances while keeping type checking work minimal.

This aligns with the project's performance goal of minimizing type instantiation overhead at high-frequency extraction sites (138+ usages noted in issue #166).

https://claude.ai/code/session_01XRT3uesSCEU3VRGStkczAm