### PR TITLE
Fix transform decoding in flattened schemas

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -5672,7 +5672,7 @@ module Schema = {
         let flattenedSchema = flattened->Array.getUnsafe(idx)
         let flattenedInput = input->B.Val.scope
         flattenedInput.expected = flattenedSchema
-        flattenedInput.isOutput = Some(false)
+        flattenedInput.isOutput = Some(flattenedSchema.parser !== None)
         let flattenedVal = flattenedInput->parse
         flattenedVals->Array.push(flattenedVal)->ignore
         input.codeFromPrev = input.codeFromPrev ++ flattenedVal->B.merge

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -3911,7 +3911,7 @@ function shapedParser(input) {
       let flattenedSchema = flattened[idx];
       let flattenedInput = scope(input);
       flattenedInput.e = flattenedSchema;
-      flattenedInput.io = false;
+      flattenedInput.io = flattenedSchema.parser !== undefined;
       let flattenedVal = parse$1(flattenedInput);
       flattenedVals.push(flattenedVal);
       input.cp = input.cp + merge(flattenedVal, undefined);

--- a/packages/sury/tests/S_object_flatten_test.res
+++ b/packages/sury/tests/S_object_flatten_test.res
@@ -191,6 +191,39 @@ test("Can flatten transformed object schema", t => {
   )
 })
 
+module Timestamp = {
+  type t = Date.t
+
+  let schema = S.string->S.transform(_ => {
+    parser: Date.fromString,
+    serializer: Date.toISOString,
+  })
+}
+
+type itemProperties = {
+  createdAt: Timestamp.t,
+}
+type item = {
+  properties: itemProperties,
+}
+
+test("Can flatten schema with transformed field", t => {
+  let itemPropertiesSchema = S.object(s => {
+    createdAt: s.field("createdAt", Timestamp.schema),
+  })
+  let schema = S.object(s => {
+    properties: s.flatten(itemPropertiesSchema),
+  })
+
+  let result: item = S.decodeOrThrow(
+    ~from=S.jsonString,
+    ~to=schema,
+    `{"createdAt":"2024-07-17T08:42:58.563Z"}`,
+  )
+
+  t->Assert.is(result.properties.createdAt->Date.toISOString, "2024-07-17T08:42:58.563Z")
+})
+
 test("Fails to flatten non-object schema", t => {
   t->Assert.throws(
     () => {


### PR DESCRIPTION
## Summary

Fixes #271.

Fixes decode failures when `S.object(... s.flatten(...))` contains fields with transform parsers, such as `S.string->S.transform(Date.fromString)`.

The flattened schema handoff now treats already-decoded flattened schemas with parser pipelines as output values, avoiding a second input-side parse on transformed field values.

## Testing

- `pnpm --filter=sury test -- S_object_flatten_test`
- `pnpm --filter=sury test`