### PR TITLE
Refactor val access and union dispatch for dict coercion

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1084,15 +1084,6 @@ module Error = {
   external classify: error => errorDetails = "%identity"
 }
 
-// Forward reference to `option` (defined far below, after the Union/Option
-// modules). `B.Val.get` uses it to model dict additionalProperties reads as
-// optional. A standalone ref is required: `Option.factory` references
-// `objectDecoder` (via `nestedOption`), so `option` is necessarily defined after
-// the decoders that need it — an unbreakable definition cycle. Assigned once,
-// right after `option` is defined; the placeholder is never invoked because
-// decoders are only built lazily after module load.
-let optionForwardRef: ref<internal => internal> = ref(s => s)
-
 module Builder = {
   type t = builder
 
@@ -1783,79 +1774,6 @@ module Builder = {
           }
         }
         nextVal
-      }
-
-      let get = (parent: val, location) => {
-        let vals = switch parent.vals {
-        | Some(d) => d
-        | None => {
-            let d = dict{}
-            parent.vals = Some(d)
-            d
-          }
-        }
-
-        switch vals->X.Dict.getUnsafeOption(location) {
-        | Some(v) => v->scope
-        | None => {
-            let locationSchema = if parent.schema.tag === objectTag {
-              parent.schema.properties->X.Option.getUnsafe->X.Dict.getUnsafeOption(location)
-            } else {
-              parent.schema.items
-              ->X.Option.getUnsafe
-              ->X.Array.getUnsafeOptionByString(location)
-            }
-            let schema = switch locationSchema {
-            | Some(s) => s
-            | None =>
-              switch parent.schema.additionalItems->X.Option.getUnsafe {
-              | Schema(s) =>
-                let s = s->castToInternal
-                // A `dict<V>` read by fixed key may be absent (no required keys),
-                // so model it as `option<V>` and let the union coercion handle a
-                // missing key uniformly. Scoped to object (dict) parents with a
-                // concrete value type: array→tuple rest reads (arrayTag) and
-                // json/unknown value types are left untouched.
-                if (
-                  parent.schema.tag === objectTag &&
-                  s.tag !== unknownTag &&
-                  !(s.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
-                  !(s->isOptional)
-                ) {
-                  optionForwardRef.contents(s)
-                } else {
-                  s
-                }
-              | _ =>
-                // The input type has no such field. Throw a catchable error,
-                // so a union case decoder treats it as a failed case
-                parent->unsupportedDecode(~from=parent.schema, ~target=parent.expected)
-              }
-            }
-
-            let pathAppend = Path.fromInlinedLocation(parent.global->inlineLocation(location))
-
-            let item = {
-              // FIXME: vals and other object.val fields should be copied
-              var: _notVarAtParent,
-              inline: if schema->isLiteral {
-                parent->inlineConst(schema)
-              } else {
-                `${parent->var}${pathAppend}`
-              },
-              flag: ValFlag.none,
-              schema,
-              expected: schema,
-              codeFromPrev: "",
-              hoistedDecls: "",
-              path: parent.path->Path.concat(pathAppend),
-              global: parent.global,
-              parent,
-            }
-            vals->Dict.set(location, item)
-            item
-          }
-        }
       }
     }
 
@@ -2654,6 +2572,63 @@ external getDecoder2: (~s1: internal, ~s2: internal, ~flag: flag=?) => 'a => 'b 
 external getDecoder3: (~s1: internal, ~s2: internal, ~s3: internal, ~flag: flag=?) => 'a => 'b =
   "getDecoder"
 
+
+let nestedLoc = "BS_PRIVATE_NESTED_SOME_NONE"
+
+  @unboxed
+  type itemCode = Single(string) | Multiple(array<string>)
+
+let rec neverBuilderFn = (~input) => {
+  let output = input->B.refine(~expected=never_())
+  output.codeFromPrev = B.embedInvalidInput(~input) ++ ";"
+  output
+}
+and never_ = () =>
+  cached((neverTag :> string), neverTag, s => {
+    s.decoder = Builder.make(neverBuilderFn)
+  })
+
+let nestedOptionParser = Builder.make((~input) => {
+      let nextSchema = input.expected.to->X.Option.getUnsafe
+      input->B.next(
+        `{${nestedLoc}:${(
+            (input.expected->getOutputSchema).properties
+            ->X.Option.getUnsafe
+            ->Dict.getUnsafe(nestedLoc)
+          ).const->Obj.magic}}`,
+        ~schema=nextSchema,
+        ~expected=nextSchema,
+      )
+    })
+
+let instanceDecoder = Builder.make((~input) => {
+  let inputTagFlag = input.schema.tag->TagFlag.get
+  if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
+    input->B.refine(
+      ~schema=input.expected,
+      ~checks=[
+        {
+          cond: (~inputVar) => `${inputVar} instanceof ${input->B.embed(input.expected.class)}`,
+          fail: B.failInvalidType,
+        },
+      ],
+    )
+  } else if (
+    inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === input.expected.class
+  ) {
+    input
+  } else {
+    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
+  }
+})
+
+let instance = class_ => {
+  let mut = base(instanceTag, ~selfReverse=true)
+  mut.class = class_->Obj.magic
+  mut.decoder = instanceDecoder
+  mut->castToPublic
+}
+
 let rec makeObjectVal = (prev: val, ~schema): B.Val.Object.t => {
   {
     prev,
@@ -2887,7 +2862,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     for idx in 0 to expectedLength - 1 {
       let schema = expectedItems->Array.getUnsafe(idx)
       let key = idx->Int.toString
-      let itemInput = input->B.Val.get(key)
+      let itemInput = input->valGet(key)
       itemInput.expected = schema
       itemInput.isOutput = Some(false)
       itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
@@ -3050,7 +3025,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         let key = keys->Array.getUnsafe(idx)
         let schema = properties->Dict.getUnsafe(key)
 
-        let itemInput = input->B.Val.get(key)
+        let itemInput = input->valGet(key)
         itemInput.expected = schema
         itemInput.isOutput = Some(false)
         itemInput.isUnion = Some(isUnion) // We want to controll validation on the decoder side
@@ -3119,499 +3094,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
   output->B.markOutput(~valInput=input)
 }
 
-let recursiveDecoder = Builder.make((~input) => {
-  let expectedSchema = input.expected
-
-  let schemaRef = expectedSchema.ref->X.Option.getUnsafe
-  let defs = input.global.defs->X.Option.getUnsafe
-  // Ignore #/$defs/
-  let identifier = schemaRef->String.slice(~start=8)
-  let def = defs->Dict.getUnsafe(identifier)
-  let flag = input.global.flag
-
-  let inputSchema = if input.schema.seq === expectedSchema.seq {
-    def
-  } else {
-    input.schema
-  }
-
-  let key = `${inputSchema.seq->Obj.magic}-${def.seq->Obj.magic}--${flag->Obj.magic}`
-  let recOperation = ref("")
-
-  switch def->Obj.magic->X.Dict.getUnsafeOption(key) {
-  | Some(fn) =>
-    // Circular reference (fn === 0) or already compiled
-    recOperation := if fn === %raw(`0`) {
-        input->B.embed(def) ++ `["${key}"]`
-      } else {
-        input->B.embed(fn)
-      }
-  | None => {
-      // Optimistic compilation with recompile if assumptions were wrong
-      let assumedHasTransform = ref(def.hasTransform->Option.getOr(false))
-      let assumedIsAsync = ref(def.isAsync->Option.getOr(false))
-      let compileNeeded = ref(true)
-      let finalFn = ref(Obj.magic(0))
-
-      while compileNeeded.contents {
-        compileNeeded := false
-
-        // Set optimistic values on def before compiling (if not already set)
-        // Inner circular references will read these values
-        if def.hasTransform === None {
-          def.hasTransform = Some(assumedHasTransform.contents)
-        }
-        if def.isAsync === None {
-          def.isAsync = Some(assumedIsAsync.contents)
-        }
-
-        // Mark as in-progress
-        configurableValueOptions->Dict.set(valKey, 0->Obj.magic)
-        let _ = X.Object.defineProperty(def, key, configurableValueOptions->Obj.magic)
-
-        // Compile
-        let fn = compileDecoder(~schema=inputSchema, ~expected=def, ~flag, ~defs=Some(defs))
-
-        // Cache result
-        valueOptions->Dict.set(valKey, fn)
-        let _ = X.Object.defineProperty(def, key, valueOptions->Obj.magic)
-
-        finalFn := fn
-
-        // Check if actual values differ from assumed
-        let actualHasTransform = def.hasTransform->X.Option.getUnsafe
-        let actualIsAsync = def.isAsync->X.Option.getUnsafe
-
-        if (
-          actualHasTransform !== assumedHasTransform.contents ||
-            actualIsAsync !== assumedIsAsync.contents
-        ) {
-          // Wrong assumption - update and recompile
-          assumedHasTransform := actualHasTransform
-          assumedIsAsync := actualIsAsync
-          // Delete cached function to force recompilation
-          let _ = %raw(`delete def[key]`)
-          compileNeeded := true
-        }
-      }
-
-      // Embed only the final compiled function to avoid wasting embed slots on recompiles
-      recOperation := input->B.embed(finalFn.contents)
-    }
-  }
-
-  let hasTransform = def.hasTransform === Some(true)
-  let isAsync = def.isAsync->X.Option.getUnsafe
-
-  // Result var decl, prepended after the re-merge below so it sits outside the
-  // try/catch mergeWithPathPrepend may wrap the assignment in (stays in scope).
-  let outputDecl = ref("")
-  let output = if hasTransform || isAsync {
-    let outputVar = input.global->B.varWithoutAllocation
-    outputDecl := `let ${outputVar};`
-
-    let output = input->B.next(outputVar, ~schema=expectedSchema, ~expected=expectedSchema)
-    output.var = B._var
-
-    output.codeFromPrev = `${outputVar}=${recOperation.contents}(${input.inline});`
-
-    if isAsync {
-      output.flag = output.flag->Flag.with(ValFlag.async)
-    }
-    output
-  } else {
-    // No transform: call for validation but don't capture result
-    let output = input->B.refine(~schema=expectedSchema, ~expected=expectedSchema)
-    output.codeFromPrev = `${recOperation.contents}(${input.inline});`
-    output
-  }
-
-  output.prev = None
-  output.codeFromPrev = outputDecl.contents ++ output->B.mergeWithPathPrepend(~parent=input)
-
-  // Un-finalize: this val may be reused as input to a subsequent parser (e.g.
-  // S.transform on a recursive schema) and must accept hoisted decls again.
-  output.finalized = None
-  output.prev = Some(input)
-
-  output
-})
-
-let instanceDecoder = Builder.make((~input) => {
-  let inputTagFlag = input.schema.tag->TagFlag.get
-  if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
-    input->B.refine(
-      ~schema=input.expected,
-      ~checks=[
-        {
-          cond: (~inputVar) => `${inputVar} instanceof ${input->B.embed(input.expected.class)}`,
-          fail: B.failInvalidType,
-        },
-      ],
-    )
-  } else if (
-    inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === input.expected.class
-  ) {
-    input
-  } else {
-    input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
-  }
-})
-
-let instance = class_ => {
-  let mut = base(instanceTag, ~selfReverse=true)
-  mut.class = class_->Obj.magic
-  mut.decoder = instanceDecoder
-  mut->castToPublic
-}
-
-X.Object.defineProperty(
-  %raw(`sp`),
-  "~standard",
-  {
-    get: (
-      () => {
-        let schema = %raw(`this`)
-        {
-          version: 1,
-          vendor,
-          validate: input => {
-            try {
-              {
-                "value": getDecoder2(~s1=unknown, ~s2=schema)(input->Obj.magic)->Obj.magic,
-              }
-            } catch {
-            | _ => {
-                let error = %raw(`exn`)->InternalError.getOrRethrow
-                {
-                  "issues": [
-                    {
-                      "message": error.reason,
-                      "path": error.path === Path.empty ? None : Some(error.path->Path.toArray),
-                    },
-                  ],
-                }->Obj.magic
-              }
-            }
-          },
-        }
-      }
-    )->X.Function.toExpression,
-  },
-)
-
-// =============
-// Builder functions
-// =============
-
-let parser = (~to as schema) => {
-  getDecoder2(~s1=unknown, ~s2=schema->castToInternal)
-}
-
-let asyncParser = (~to as schema) => {
-  getDecoder2(~s1=unknown, ~s2=schema->castToInternal, ~flag=Flag.async)
-}
-
-let decoder = (type from to, ~from: t<from>, ~to: t<to>): (from => to) => {
-  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal)
-}
-
-let asyncDecoder = (type from to, ~from: t<from>, ~to: t<to>): (from => promise<to>) => {
-  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal, ~flag=Flag.async)
-}
-
-let decoder1 = (type value, schema: t<value>): (unknown => value) => {
-  getDecoder(~s1=schema->castToInternal)
-}
-
-let asyncDecoder1 = (type value, schema: t<value>): (unknown => promise<value>) => {
-  getDecoder(~s1=schema->castToInternal, ~flag=Flag.async)
-}
-
-// =============
-// Operations
-// =============
-
-let getAssertResult = () =>
-  cached("a", undefinedTag, s => {
-    s.const = %raw(`void 0`)
-    s.decoder = literalDecoder
-    s.noValidation = Some(true)
-  })
-
-@inline
-let parseOrThrow = (any, ~to as schema) => {
-  getDecoder2(~s1=unknown, ~s2=schema->castToInternal)(any)
-}
-
-let parseAsyncOrThrow = (any, ~to as schema) => {
-  getDecoder2(~s1=unknown, ~s2=schema->castToInternal, ~flag=Flag.async)(any)
-}
-
-let assertOrThrow = (any, ~to as schema) => {
-  getDecoder3(~s1=unknown, ~s2=schema->castToInternal, ~s3=getAssertResult())(any)
-}
-
-let assertAsyncOrThrow = (any, ~to as schema) => {
-  getDecoder3(~s1=unknown, ~s2=schema->castToInternal, ~s3=getAssertResult(), ~flag=Flag.async)(any)
-}
-
-let decodeOrThrow = (any, ~from, ~to) => {
-  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal)(any)
-}
-
-let decodeAsyncOrThrow = (any, ~from, ~to) => {
-  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal, ~flag=Flag.async)(any)
-}
-
-let isAsync = schema => {
-  let schema = schema->castToInternal
-  switch schema.isAsync {
-  | None => schema->isAsyncInternal(~defs=%raw(`0`))
-  | Some(v) => v
-  }
-}
-
-let wrapExnToFailure = exn => {
-  if %raw("exn&&exn.s===s") {
-    Failure({error: exn->(Obj.magic: exn => error)})
-  } else {
-    throw(exn)
-  }
-}
-
-let js_safe = fn => {
-  try {
-    Success({
-      value: fn(),
-    })
-  } catch {
-  | _ => wrapExnToFailure(%raw(`exn`))
-  }
-}
-
-let js_safeAsync = fn => {
-  try {
-    fn()->X.Promise.thenResolveWithCatch(value => Success({value: value}), wrapExnToFailure)
-  } catch {
-  | _ => X.Promise.resolve(wrapExnToFailure(%raw(`exn`)))
-  }
-}
-
-module Metadata = {
-  module Id: {
-    type t<'metadata>
-    let make: (~namespace: string, ~name: string) => t<'metadata>
-    let internal: string => t<'metadata>
-    external toKey: t<'metadata> => string = "%identity"
-  } = {
-    type t<'metadata> = string
-
-    let make = (~namespace, ~name) => {
-      `m:${namespace}:${name}`
-    }
-
-    let internal = name => {
-      `m:${name}`
-    }
-
-    external toKey: t<'metadata> => string = "%identity"
-  }
-
-  let get = (schema, ~id: Id.t<'metadata>) => {
-    schema->(Obj.magic: t<'a> => dict<option<'metadata>>)->Dict.getUnsafe(id->Id.toKey)
-  }
-
-  @inline
-  let setInPlace = (schema, ~id: Id.t<'metadata>, metadata: 'metadata) => {
-    schema->(Obj.magic: internal => dict<'metadata>)->Dict.set(id->Id.toKey, metadata)
-  }
-
-  let set = (schema, ~id: Id.t<'metadata>, metadata: 'metadata) => {
-    let schema = schema->castToInternal
-    let mut = schema->copySchema
-    mut->setInPlace(~id, metadata)
-    mut->castToPublic
-  }
-}
-
-let defsPath = `#/$defs/`
-let recursive = (name, fn) => {
-  let ref = `${defsPath}${name}`
-  let refSchema = base(refTag, ~selfReverse=false)
-  refSchema.ref = Some(ref)
-  refSchema.name = Some(name)
-  refSchema.decoder = recursiveDecoder
-
-  // This is for mutual recursion
-  let isNestedRec = globalConfig.defsAccumulator->Obj.magic
-  if !isNestedRec {
-    globalConfig.defsAccumulator = Some(dict{})
-  }
-  let def = fn(refSchema->castToPublic)->castToInternal
-  if def.name->Obj.magic {
-    refSchema.name = def.name
-  }
-  globalConfig.defsAccumulator
-  ->X.Option.getUnsafe
-  ->Dict.set(name, def)
-
-  if isNestedRec {
-    refSchema->castToPublic
-  } else {
-    let schema = base(refTag, ~selfReverse=false)
-    schema.name = refSchema.name
-    schema.ref = Some(ref)
-    schema.defs = globalConfig.defsAccumulator
-    schema.decoder = recursiveDecoder
-
-    globalConfig.defsAccumulator = None
-
-    schema->castToPublic
-  }
-}
-
-let noValidation = (schema, value) => {
-  let schema = schema->castToInternal
-  let mut = schema->copySchema
-
-  // TODO: Test for discriminant literal
-  // TODO: Better test reverse
-  mut.noValidation = Some(value)
-  mut->castToPublic
-}
-
-let internalRefine = (schema, makeRefiner) => {
-  let schema = schema->castToInternal
-  updateOutput(schema, mut => {
-    let refiner = makeRefiner(mut)
-    switch mut.refiner {
-    | Some(existingRefiner) =>
-      mut.refiner = Some(
-        (~input) => {
-          let arr = existingRefiner(~input)
-          let next = refiner(~input)
-          for i in 0 to next->Array.length - 1 {
-            arr->Array.push(next->Array.getUnsafe(i))->ignore
-          }
-          arr
-        },
-      )
-    | None => mut.refiner = Some(refiner)
-    }
-  })
-}
-
-let refine: (t<'value>, 'value => bool, ~error: string=?, ~path: array<string>=?) => t<'value> = (
-  schema,
-  refineCheck,
-  ~error=?,
-  ~path=?,
-) => {
-  let message = switch error {
-  | Some(e) => e
-  | None => "Refinement failed"
-  }
-  let extraPath = switch path {
-  | Some(p) => Path.fromArray(p)
-  | None => Path.empty
-  }
-  schema->internalRefine(_ =>
-    (~input) => {
-      let embeddedCheck = input->B.embed(refineCheck)
-      [
-        {
-          cond: (~inputVar) => `${embeddedCheck}(${inputVar})`,
-          fail: B.invalidInputBuilder(~extraPath, ~reasonOverride=message),
-        },
-      ]
-    }
-  )
-}
-
-let getMutErrorMessage = (~mut: internal): dict<string> => {
-  let em: dict<string> =
-    mut.errorMessage->X.Option.unsafeToBool
-      ? mut.errorMessage
-        ->X.Option.getUnsafe
-        ->(Obj.magic: schemaErrorMessage => dict<string>)
-        ->X.Dict.copy
-      : dict{}
-  mut.errorMessage = Some(em->Obj.magic)
-  em
-}
-
-type transformDefinition<'input, 'output> = {
-  @as("p")
-  parser?: 'input => 'output,
-  @as("a")
-  asyncParser?: 'input => promise<'output>,
-  @as("s")
-  serializer?: 'output => 'input,
-}
-let transform: (t<'input>, s<'output> => transformDefinition<'input, 'output>) => t<'output> = (
-  schema,
-  transformer,
-) => {
-  let schema = schema->castToInternal
-  updateOutput(schema, mut => {
-    mut.parser = Some(
-      Builder.make((~input) => {
-        switch transformer(input->B.effectCtx) {
-        | {parser, asyncParser: ?None} => B.embedTransformation(~input, ~fn=parser, ~isAsync=false)
-        | {parser: ?None, asyncParser} =>
-          B.embedTransformation(~input, ~fn=asyncParser, ~isAsync=true)
-        | {parser: ?None, asyncParser: ?None, serializer: ?None} =>
-          input->B.refine(~expected=input.expected.to->Option.getUnsafe)
-        | {parser: ?None, asyncParser: ?None, serializer: _} =>
-          input->B.invalidOperation(~description=`The S.transform parser is missing`)
-        | {parser: _, asyncParser: _} =>
-          input->B.invalidOperation(
-            ~description=`The S.transform doesn't allow parser and asyncParser at the same time. Remove parser in favor of asyncParser`,
-          )
-        }
-      }),
-    )
-    mut.to = Some({
-      let to = unknown->copySchema
-      to.serializer = Some(
-        (~input) => {
-          switch transformer(input->B.effectCtx) {
-          | {serializer} => B.embedTransformation(~input, ~fn=serializer, ~isAsync=false)
-          | {parser: ?None, asyncParser: ?None, serializer: ?None} =>
-            input->B.refine(~expected=input.expected.to->Option.getUnsafe)
-          | {serializer: ?None, asyncParser: ?Some(_)}
-          | {serializer: ?None, parser: ?Some(_)} =>
-            input->B.invalidOperation(~description=`The S.transform serializer is missing`)
-          }
-        },
-      )
-      to
-    })
-    let _ = %raw(`delete mut.isAsync`)
-  })
-}
-
-let nullAsUnit = () => {
-  let s = nullLiteral()->copySchema
-  s.to = Some(unit())
-  s
-}
-
-let rec neverBuilderFn = (~input) => {
-  let output = input->B.refine(~expected=never_())
-  output.codeFromPrev = B.embedInvalidInput(~input) ++ ";"
-  output
-}
-and never_ = () =>
-  cached((neverTag :> string), neverTag, s => {
-    s.decoder = Builder.make(neverBuilderFn)
-  })
-
-let nestedLoc = "BS_PRIVATE_NESTED_SOME_NONE"
-
-module DictSchema = {
-  let factory = item => {
+and dictFactory = item => {
     let item = item->castToInternal
     let mut = base(
       objectTag,
@@ -3622,18 +3105,13 @@ module DictSchema = {
     mut.decoder = objectDecoder
     mut->castToPublic
   }
-}
 
-module Union = {
-  @unboxed
-  type itemCode = Single(string) | Multiple(array<string>)
-
-  let toKey = (schema: internal): string =>
+and toKey = (schema: internal): string =>
     schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.instance)
       ? (schema.class->Obj.magic)["name"]
       : (schema.tag :> string)
 
-  let isPriority = (tagFlag, byKey: dict<array<unknown>>) => {
+and isPriority = (tagFlag, byKey: dict<array<unknown>>) => {
     (tagFlag->Flag.unsafeHas(TagFlag.array->Flag.with(TagFlag.instance)) &&
       byKey->Stdlib.Dict.has((objectTag: tag :> string))) ||
       (tagFlag->Flag.unsafeHas(TagFlag.nan) && byKey->Stdlib.Dict.has((numberTag: tag :> string)))
@@ -3642,7 +3120,7 @@ module Union = {
   // Whether decoding a value already known to be of the schema type
   // is a noop — no transformation anywhere in the schema tree.
   // Recursive refs are conservatively treated as transforming
-  let rec isSelfDecodeNoop = (schema: internal) => {
+and isSelfDecodeNoop = (schema: internal) => {
     schema.to === None &&
     schema.parser === None &&
     !(schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
@@ -3664,7 +3142,7 @@ module Union = {
     }
   }
 
-  let isWiderUnionSchema = (~schemaAnyOf, ~inputAnyOf) => {
+and isWiderUnionSchema = (~schemaAnyOf, ~inputAnyOf) => {
     inputAnyOf->Array.everyWithIndex((inputSchema, idx) => {
       switch schemaAnyOf->X.Array.getUnsafeOption(idx) {
       | Some(schema) =>
@@ -3689,7 +3167,7 @@ module Union = {
 
   // The union's own `.to` chain which is applied per case during decoding.
   // None when the union has a custom parser owning the `.to` conversion
-  let getToPerCase = (schema: internal) =>
+and getToPerCase = (schema: internal) =>
     switch schema {
     | {parser: ?None, to} => Some(to)
     | _ => None
@@ -3697,7 +3175,7 @@ module Union = {
 
   // Whether a union-typed input can be decoded by dispatching
   // over its variants with `.to(target)` appended to each
-  let canDispatchPerVariant = (~inputAnyOf, ~target: internal) =>
+and canDispatchPerVariant = (~inputAnyOf, ~target: internal) =>
     // S.json and recursive targets keep their dedicated union-input handling
     !((target->getOutputSchema).tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
     !(
@@ -3717,7 +3195,7 @@ module Union = {
   // Re-drives the source union with `.to(target)` appended, so its decoder
   // dispatches per variant and each variant converts to the target
   // independently (the documented per-source-variant algorithm)
-  let perVariantVal = (~input: val, ~target) =>
+and perVariantVal = (~input: val, ~target) =>
     input->B.refine(
       ~schema=unknown,
       ~expected=input.schema->updateOutput(mut => mut.to = Some(target))->castToInternal,
@@ -3725,7 +3203,7 @@ module Union = {
 
   // Applied by the parse loop when a union-typed val
   // meets a different expected schema
-  let encoder = Builder.encoder((~input, ~target) => {
+and encoder: encoder = (~input: val, ~target: internal) => {
     let inputAnyOf = input.schema.anyOf->X.Option.getUnsafe
     if (
       target.tag === unionTag &&
@@ -3739,9 +3217,9 @@ module Union = {
     } else {
       input
     }
-  })
+  }
 
-  let rec unionDecoder: Builder.t = (~input) => {
+and unionDecoder: Builder.t = (~input) => {
     let selfSchema = input.expected
     let schemas = selfSchema.anyOf->X.Option.getUnsafe
     let initialInputTagFlag = input.schema.tag->TagFlag.get
@@ -4173,7 +3651,7 @@ module Union = {
             } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
               unit()
             } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
-              DictSchema.factory(unknown->castToPublic)->castToInternal
+              dictFactory(unknown->castToPublic)->castToInternal
             } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
               array(unknown->castToPublic)->castToInternal
             } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
@@ -4357,7 +3835,7 @@ module Union = {
 
       // Build the output schema from collected case output schemas
       o.schema = if outputAnyOf->Stdlib.Array.length->X.Int.unsafeToBool {
-        factory(outputAnyOf)->castToInternal
+        unionFactory(outputAnyOf)->castToInternal
       } else {
         never_()
       }
@@ -4372,7 +3850,7 @@ module Union = {
       o
     }
   }
-  and factory = schemas => {
+and unionFactory: 'a 'b. array<t<'a>> => t<'b> = schemas => {
     let schemas: array<internal> = schemas->Obj.magic
     // TODO:
     // 1. Fitler out items without parser
@@ -4410,13 +3888,8 @@ module Union = {
       mut->castToPublic
     }
   }
-}
 
-module Option = {
-  type default = Value(unknown) | Callback(unit => unknown)
-
-  let nestedOption = {
-    let nestedNone = () => {
+and nestedNone = () => {
       let itemSchema = Literal.parse(0)
       // FIXME: dict{}
       let properties = dict{}
@@ -4436,34 +3909,20 @@ module Option = {
       }
     }
 
-    let parser = Builder.make((~input) => {
-      let nextSchema = input.expected.to->X.Option.getUnsafe
-      input->B.next(
-        `{${nestedLoc}:${(
-            (input.expected->getOutputSchema).properties
-            ->X.Option.getUnsafe
-            ->Dict.getUnsafe(nestedLoc)
-          ).const->Obj.magic}}`,
-        ~schema=nextSchema,
-        ~expected=nextSchema,
-      )
-    })
-
-    item => {
+and nestedOption = item => {
       item
       ->updateOutput(mut => {
         mut.to = Some(nestedNone())
-        mut.parser = Some(parser)
+        mut.parser = Some(nestedOptionParser)
       })
       ->castToInternal
     }
-  }
 
-  let factory = (item, ~unit=unit()->castToPublic) => {
+and optionFactory = (item, ~unit=unit()->castToPublic) => {
     let item = item->castToInternal
 
     switch item->getOutputSchema {
-    | {tag: Undefined} => Union.factory([unit->castToUnknown, item->nestedOption->castToPublic])
+    | {tag: Undefined} => unionFactory([unit->castToUnknown, item->nestedOption->castToPublic])
     | {tag: Union, ?anyOf, ?has} =>
       item->updateOutput(mut => {
         let schemas = anyOf->X.Option.getUnsafe
@@ -4513,10 +3972,537 @@ module Option = {
         mut.anyOf = Some(newAnyOf)
         mut.has = Some(mutHas)
       })
-    | _ => Union.factory([item->castToPublic, unit->castToUnknown])
+    | _ => unionFactory([item->castToPublic, unit->castToUnknown])
     }
   }
 
+and option = item => item->optionFactory(~unit=unit()->castToPublic)
+
+and valGet = (parent: val, location) => {
+  let vals = switch parent.vals {
+  | Some(d) => d
+  | None => {
+      let d = dict{}
+      parent.vals = Some(d)
+      d
+    }
+  }
+
+  switch vals->X.Dict.getUnsafeOption(location) {
+  | Some(v) => v->B.Val.scope
+  | None => {
+      let locationSchema = if parent.schema.tag === objectTag {
+        parent.schema.properties->X.Option.getUnsafe->X.Dict.getUnsafeOption(location)
+      } else {
+        parent.schema.items
+        ->X.Option.getUnsafe
+        ->X.Array.getUnsafeOptionByString(location)
+      }
+      let schema = switch locationSchema {
+      | Some(s) => s
+      | None =>
+        switch parent.schema.additionalItems->X.Option.getUnsafe {
+        | Schema(s) =>
+          let s = s->castToInternal
+          // A `dict<V>` read by a fixed key may be absent (dicts have no required
+          // keys), so model it as `option<V>` and let the union coercion handle a
+          // missing key uniformly. Scoped to dict parents (objectTag) with a
+          // concrete value type — array->tuple rest reads (arrayTag) and
+          // json/unknown values read as-is. `option` is reachable directly because
+          // B.Val.get now lives in the decoder `let rec` group (no forward ref).
+          if (
+            parent.schema.tag === objectTag &&
+            s.tag !== unknownTag &&
+            !(s.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
+            !(s->isOptional)
+          ) {
+            option(s->castToPublic)->castToInternal
+          } else {
+            s
+          }
+        | _ => parent->B.unsupportedDecode(~from=parent.schema, ~target=parent.expected)
+        }
+      }
+
+      let pathAppend = Path.fromInlinedLocation(parent.global->B.inlineLocation(location))
+
+      let item = {
+        var: B._notVarAtParent,
+        inline: if schema->isLiteral {
+          parent->B.inlineConst(schema)
+        } else {
+          `${parent->B.Val.var}${pathAppend}`
+        },
+        flag: ValFlag.none,
+        schema,
+        expected: schema,
+        codeFromPrev: "",
+        hoistedDecls: "",
+        path: parent.path->Path.concat(pathAppend),
+        global: parent.global,
+        parent,
+      }
+      vals->Dict.set(location, item)
+      item
+    }
+  }
+}
+
+let recursiveDecoder = Builder.make((~input) => {
+  let expectedSchema = input.expected
+
+  let schemaRef = expectedSchema.ref->X.Option.getUnsafe
+  let defs = input.global.defs->X.Option.getUnsafe
+  // Ignore #/$defs/
+  let identifier = schemaRef->String.slice(~start=8)
+  let def = defs->Dict.getUnsafe(identifier)
+  let flag = input.global.flag
+
+  let inputSchema = if input.schema.seq === expectedSchema.seq {
+    def
+  } else {
+    input.schema
+  }
+
+  let key = `${inputSchema.seq->Obj.magic}-${def.seq->Obj.magic}--${flag->Obj.magic}`
+  let recOperation = ref("")
+
+  switch def->Obj.magic->X.Dict.getUnsafeOption(key) {
+  | Some(fn) =>
+    // Circular reference (fn === 0) or already compiled
+    recOperation := if fn === %raw(`0`) {
+        input->B.embed(def) ++ `["${key}"]`
+      } else {
+        input->B.embed(fn)
+      }
+  | None => {
+      // Optimistic compilation with recompile if assumptions were wrong
+      let assumedHasTransform = ref(def.hasTransform->Option.getOr(false))
+      let assumedIsAsync = ref(def.isAsync->Option.getOr(false))
+      let compileNeeded = ref(true)
+      let finalFn = ref(Obj.magic(0))
+
+      while compileNeeded.contents {
+        compileNeeded := false
+
+        // Set optimistic values on def before compiling (if not already set)
+        // Inner circular references will read these values
+        if def.hasTransform === None {
+          def.hasTransform = Some(assumedHasTransform.contents)
+        }
+        if def.isAsync === None {
+          def.isAsync = Some(assumedIsAsync.contents)
+        }
+
+        // Mark as in-progress
+        configurableValueOptions->Dict.set(valKey, 0->Obj.magic)
+        let _ = X.Object.defineProperty(def, key, configurableValueOptions->Obj.magic)
+
+        // Compile
+        let fn = compileDecoder(~schema=inputSchema, ~expected=def, ~flag, ~defs=Some(defs))
+
+        // Cache result
+        valueOptions->Dict.set(valKey, fn)
+        let _ = X.Object.defineProperty(def, key, valueOptions->Obj.magic)
+
+        finalFn := fn
+
+        // Check if actual values differ from assumed
+        let actualHasTransform = def.hasTransform->X.Option.getUnsafe
+        let actualIsAsync = def.isAsync->X.Option.getUnsafe
+
+        if (
+          actualHasTransform !== assumedHasTransform.contents ||
+            actualIsAsync !== assumedIsAsync.contents
+        ) {
+          // Wrong assumption - update and recompile
+          assumedHasTransform := actualHasTransform
+          assumedIsAsync := actualIsAsync
+          // Delete cached function to force recompilation
+          let _ = %raw(`delete def[key]`)
+          compileNeeded := true
+        }
+      }
+
+      // Embed only the final compiled function to avoid wasting embed slots on recompiles
+      recOperation := input->B.embed(finalFn.contents)
+    }
+  }
+
+  let hasTransform = def.hasTransform === Some(true)
+  let isAsync = def.isAsync->X.Option.getUnsafe
+
+  // Result var decl, prepended after the re-merge below so it sits outside the
+  // try/catch mergeWithPathPrepend may wrap the assignment in (stays in scope).
+  let outputDecl = ref("")
+  let output = if hasTransform || isAsync {
+    let outputVar = input.global->B.varWithoutAllocation
+    outputDecl := `let ${outputVar};`
+
+    let output = input->B.next(outputVar, ~schema=expectedSchema, ~expected=expectedSchema)
+    output.var = B._var
+
+    output.codeFromPrev = `${outputVar}=${recOperation.contents}(${input.inline});`
+
+    if isAsync {
+      output.flag = output.flag->Flag.with(ValFlag.async)
+    }
+    output
+  } else {
+    // No transform: call for validation but don't capture result
+    let output = input->B.refine(~schema=expectedSchema, ~expected=expectedSchema)
+    output.codeFromPrev = `${recOperation.contents}(${input.inline});`
+    output
+  }
+
+  output.prev = None
+  output.codeFromPrev = outputDecl.contents ++ output->B.mergeWithPathPrepend(~parent=input)
+
+  // Un-finalize: this val may be reused as input to a subsequent parser (e.g.
+  // S.transform on a recursive schema) and must accept hoisted decls again.
+  output.finalized = None
+  output.prev = Some(input)
+
+  output
+})
+
+
+
+X.Object.defineProperty(
+  %raw(`sp`),
+  "~standard",
+  {
+    get: (
+      () => {
+        let schema = %raw(`this`)
+        {
+          version: 1,
+          vendor,
+          validate: input => {
+            try {
+              {
+                "value": getDecoder2(~s1=unknown, ~s2=schema)(input->Obj.magic)->Obj.magic,
+              }
+            } catch {
+            | _ => {
+                let error = %raw(`exn`)->InternalError.getOrRethrow
+                {
+                  "issues": [
+                    {
+                      "message": error.reason,
+                      "path": error.path === Path.empty ? None : Some(error.path->Path.toArray),
+                    },
+                  ],
+                }->Obj.magic
+              }
+            }
+          },
+        }
+      }
+    )->X.Function.toExpression,
+  },
+)
+
+// =============
+// Builder functions
+// =============
+
+let parser = (~to as schema) => {
+  getDecoder2(~s1=unknown, ~s2=schema->castToInternal)
+}
+
+let asyncParser = (~to as schema) => {
+  getDecoder2(~s1=unknown, ~s2=schema->castToInternal, ~flag=Flag.async)
+}
+
+let decoder = (type from to, ~from: t<from>, ~to: t<to>): (from => to) => {
+  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal)
+}
+
+let asyncDecoder = (type from to, ~from: t<from>, ~to: t<to>): (from => promise<to>) => {
+  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal, ~flag=Flag.async)
+}
+
+let decoder1 = (type value, schema: t<value>): (unknown => value) => {
+  getDecoder(~s1=schema->castToInternal)
+}
+
+let asyncDecoder1 = (type value, schema: t<value>): (unknown => promise<value>) => {
+  getDecoder(~s1=schema->castToInternal, ~flag=Flag.async)
+}
+
+// =============
+// Operations
+// =============
+
+let getAssertResult = () =>
+  cached("a", undefinedTag, s => {
+    s.const = %raw(`void 0`)
+    s.decoder = literalDecoder
+    s.noValidation = Some(true)
+  })
+
+@inline
+let parseOrThrow = (any, ~to as schema) => {
+  getDecoder2(~s1=unknown, ~s2=schema->castToInternal)(any)
+}
+
+let parseAsyncOrThrow = (any, ~to as schema) => {
+  getDecoder2(~s1=unknown, ~s2=schema->castToInternal, ~flag=Flag.async)(any)
+}
+
+let assertOrThrow = (any, ~to as schema) => {
+  getDecoder3(~s1=unknown, ~s2=schema->castToInternal, ~s3=getAssertResult())(any)
+}
+
+let assertAsyncOrThrow = (any, ~to as schema) => {
+  getDecoder3(~s1=unknown, ~s2=schema->castToInternal, ~s3=getAssertResult(), ~flag=Flag.async)(any)
+}
+
+let decodeOrThrow = (any, ~from, ~to) => {
+  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal)(any)
+}
+
+let decodeAsyncOrThrow = (any, ~from, ~to) => {
+  getDecoder2(~s1=from->castToInternal->reverse, ~s2=to->castToInternal, ~flag=Flag.async)(any)
+}
+
+let isAsync = schema => {
+  let schema = schema->castToInternal
+  switch schema.isAsync {
+  | None => schema->isAsyncInternal(~defs=%raw(`0`))
+  | Some(v) => v
+  }
+}
+
+let wrapExnToFailure = exn => {
+  if %raw("exn&&exn.s===s") {
+    Failure({error: exn->(Obj.magic: exn => error)})
+  } else {
+    throw(exn)
+  }
+}
+
+let js_safe = fn => {
+  try {
+    Success({
+      value: fn(),
+    })
+  } catch {
+  | _ => wrapExnToFailure(%raw(`exn`))
+  }
+}
+
+let js_safeAsync = fn => {
+  try {
+    fn()->X.Promise.thenResolveWithCatch(value => Success({value: value}), wrapExnToFailure)
+  } catch {
+  | _ => X.Promise.resolve(wrapExnToFailure(%raw(`exn`)))
+  }
+}
+
+module Metadata = {
+  module Id: {
+    type t<'metadata>
+    let make: (~namespace: string, ~name: string) => t<'metadata>
+    let internal: string => t<'metadata>
+    external toKey: t<'metadata> => string = "%identity"
+  } = {
+    type t<'metadata> = string
+
+    let make = (~namespace, ~name) => {
+      `m:${namespace}:${name}`
+    }
+
+    let internal = name => {
+      `m:${name}`
+    }
+
+    external toKey: t<'metadata> => string = "%identity"
+  }
+
+  let get = (schema, ~id: Id.t<'metadata>) => {
+    schema->(Obj.magic: t<'a> => dict<option<'metadata>>)->Dict.getUnsafe(id->Id.toKey)
+  }
+
+  @inline
+  let setInPlace = (schema, ~id: Id.t<'metadata>, metadata: 'metadata) => {
+    schema->(Obj.magic: internal => dict<'metadata>)->Dict.set(id->Id.toKey, metadata)
+  }
+
+  let set = (schema, ~id: Id.t<'metadata>, metadata: 'metadata) => {
+    let schema = schema->castToInternal
+    let mut = schema->copySchema
+    mut->setInPlace(~id, metadata)
+    mut->castToPublic
+  }
+}
+
+let defsPath = `#/$defs/`
+let recursive = (name, fn) => {
+  let ref = `${defsPath}${name}`
+  let refSchema = base(refTag, ~selfReverse=false)
+  refSchema.ref = Some(ref)
+  refSchema.name = Some(name)
+  refSchema.decoder = recursiveDecoder
+
+  // This is for mutual recursion
+  let isNestedRec = globalConfig.defsAccumulator->Obj.magic
+  if !isNestedRec {
+    globalConfig.defsAccumulator = Some(dict{})
+  }
+  let def = fn(refSchema->castToPublic)->castToInternal
+  if def.name->Obj.magic {
+    refSchema.name = def.name
+  }
+  globalConfig.defsAccumulator
+  ->X.Option.getUnsafe
+  ->Dict.set(name, def)
+
+  if isNestedRec {
+    refSchema->castToPublic
+  } else {
+    let schema = base(refTag, ~selfReverse=false)
+    schema.name = refSchema.name
+    schema.ref = Some(ref)
+    schema.defs = globalConfig.defsAccumulator
+    schema.decoder = recursiveDecoder
+
+    globalConfig.defsAccumulator = None
+
+    schema->castToPublic
+  }
+}
+
+let noValidation = (schema, value) => {
+  let schema = schema->castToInternal
+  let mut = schema->copySchema
+
+  // TODO: Test for discriminant literal
+  // TODO: Better test reverse
+  mut.noValidation = Some(value)
+  mut->castToPublic
+}
+
+let internalRefine = (schema, makeRefiner) => {
+  let schema = schema->castToInternal
+  updateOutput(schema, mut => {
+    let refiner = makeRefiner(mut)
+    switch mut.refiner {
+    | Some(existingRefiner) =>
+      mut.refiner = Some(
+        (~input) => {
+          let arr = existingRefiner(~input)
+          let next = refiner(~input)
+          for i in 0 to next->Array.length - 1 {
+            arr->Array.push(next->Array.getUnsafe(i))->ignore
+          }
+          arr
+        },
+      )
+    | None => mut.refiner = Some(refiner)
+    }
+  })
+}
+
+let refine: (t<'value>, 'value => bool, ~error: string=?, ~path: array<string>=?) => t<'value> = (
+  schema,
+  refineCheck,
+  ~error=?,
+  ~path=?,
+) => {
+  let message = switch error {
+  | Some(e) => e
+  | None => "Refinement failed"
+  }
+  let extraPath = switch path {
+  | Some(p) => Path.fromArray(p)
+  | None => Path.empty
+  }
+  schema->internalRefine(_ =>
+    (~input) => {
+      let embeddedCheck = input->B.embed(refineCheck)
+      [
+        {
+          cond: (~inputVar) => `${embeddedCheck}(${inputVar})`,
+          fail: B.invalidInputBuilder(~extraPath, ~reasonOverride=message),
+        },
+      ]
+    }
+  )
+}
+
+let getMutErrorMessage = (~mut: internal): dict<string> => {
+  let em: dict<string> =
+    mut.errorMessage->X.Option.unsafeToBool
+      ? mut.errorMessage
+        ->X.Option.getUnsafe
+        ->(Obj.magic: schemaErrorMessage => dict<string>)
+        ->X.Dict.copy
+      : dict{}
+  mut.errorMessage = Some(em->Obj.magic)
+  em
+}
+
+type transformDefinition<'input, 'output> = {
+  @as("p")
+  parser?: 'input => 'output,
+  @as("a")
+  asyncParser?: 'input => promise<'output>,
+  @as("s")
+  serializer?: 'output => 'input,
+}
+let transform: (t<'input>, s<'output> => transformDefinition<'input, 'output>) => t<'output> = (
+  schema,
+  transformer,
+) => {
+  let schema = schema->castToInternal
+  updateOutput(schema, mut => {
+    mut.parser = Some(
+      Builder.make((~input) => {
+        switch transformer(input->B.effectCtx) {
+        | {parser, asyncParser: ?None} => B.embedTransformation(~input, ~fn=parser, ~isAsync=false)
+        | {parser: ?None, asyncParser} =>
+          B.embedTransformation(~input, ~fn=asyncParser, ~isAsync=true)
+        | {parser: ?None, asyncParser: ?None, serializer: ?None} =>
+          input->B.refine(~expected=input.expected.to->Option.getUnsafe)
+        | {parser: ?None, asyncParser: ?None, serializer: _} =>
+          input->B.invalidOperation(~description=`The S.transform parser is missing`)
+        | {parser: _, asyncParser: _} =>
+          input->B.invalidOperation(
+            ~description=`The S.transform doesn't allow parser and asyncParser at the same time. Remove parser in favor of asyncParser`,
+          )
+        }
+      }),
+    )
+    mut.to = Some({
+      let to = unknown->copySchema
+      to.serializer = Some(
+        (~input) => {
+          switch transformer(input->B.effectCtx) {
+          | {serializer} => B.embedTransformation(~input, ~fn=serializer, ~isAsync=false)
+          | {parser: ?None, asyncParser: ?None, serializer: ?None} =>
+            input->B.refine(~expected=input.expected.to->Option.getUnsafe)
+          | {serializer: ?None, asyncParser: ?Some(_)}
+          | {serializer: ?None, parser: ?Some(_)} =>
+            input->B.invalidOperation(~description=`The S.transform serializer is missing`)
+          }
+        },
+      )
+      to
+    })
+    let _ = %raw(`delete mut.isAsync`)
+  })
+}
+
+let nullAsUnit = () => {
+  let s = nullLiteral()->copySchema
+  s.to = Some(unit())
+  s
+}
+
+module Option = {
+  type default = Value(unknown) | Callback(unit => unknown)
   let getWithDefault = (schema: t<option<'value>>, default) => {
     schema
     ->castToInternal
@@ -4543,11 +4529,11 @@ module Option = {
           let item = switch outputItems {
           | [] => InternalError.panic(`Can't set default for ${mut->castToPublic->toExpression}`)
           | [single] => single
-          | multiple => Union.factory(multiple->Obj.magic)->castToInternal
+          | multiple => unionFactory(multiple->Obj.magic)->castToInternal
           }
           let originalItem = switch originalItems {
           | [single] => single
-          | _ => Union.factory(originalItems->Obj.magic)->castToInternal
+          | _ => unionFactory(originalItems->Obj.magic)->castToInternal
           }
 
           switch default {
@@ -4616,6 +4602,7 @@ module Option = {
   let getOrWith = (schema, defalutCb) =>
     schema->getWithDefault(Callback(defalutCb->(Obj.magic: (unit => 'a) => unit => unknown)))
 }
+
 
 module Object = {
   type rec s = {
@@ -4729,7 +4716,7 @@ let rec jsonEncoderFn = (~input, ~target) => {
   } else if toTagFlag->Flag.unsafeHas(TagFlag.object) {
     // Validate that the input is an object
     // and then update the schema to be an object of json instead of object of unknown
-    let jsonExpected = DictSchema.factory(unknown->castToPublic)->castToInternal
+    let jsonExpected = dictFactory(unknown->castToPublic)->castToInternal
     let output = input->B.refine(~schema=unknown, ~expected=jsonExpected)->parse
     output.schema.additionalItems = Some(Schema(json()->castToPublic))
     output.expected = target
@@ -4796,7 +4783,7 @@ and jsonDecoderFn = (~input) => {
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.object) {
     switch input.schema.additionalItems->X.Option.getUnsafe {
     | Schema(_) => {
-        let expected = DictSchema.factory(json()->castToPublic)->castToInternal
+        let expected = dictFactory(json()->castToPublic)->castToInternal
         expected.to = input.expected.to
         input->B.refine(~expected)->parse
       }
@@ -4811,7 +4798,7 @@ and jsonDecoderFn = (~input) => {
         let keys = input.schema.properties->X.Option.getUnsafe->Dict.keysToArray
         for idx in 0 to keys->Array.length - 1 {
           let key = keys->Array.getUnsafe(idx)
-          let itemVal = input->B.Val.get(key)
+          let itemVal = input->valGet(key)
           itemVal.isOutput = Some(false)
 
           if (
@@ -4819,7 +4806,7 @@ and jsonDecoderFn = (~input) => {
               itemVal.schema.has->X.Option.getUnsafe->Dict.getUnsafe((undefinedTag :> string))
           ) {
             itemVal.expected =
-              Union.factory([unit()->castToPublic, json()->castToPublic])->castToInternal
+              unionFactory([unit()->castToPublic, json()->castToPublic])->castToInternal
             let itemOutput = itemVal->parse
             itemOutput.optional = Some(true)
             jsonVal->B.Val.Object.add(~location=key, itemOutput)
@@ -4838,13 +4825,13 @@ and jsonDecoderFn = (~input) => {
   } else if (
     inputTagFlag->Flag.unsafeHas(TagFlag.union) &&
       // Union-tagged schemas always carry `anyOf` and `has`
-      // (set by Union.factory, reverse and the S.json def).
+      // (set by unionFactory, reverse and the S.json def).
       // Unions with an undefined variant are not supported,
       // since undefined is not representable in JSON
       !(input.schema.has->X.Option.getUnsafe->Stdlib.Dict.has((undefinedTag :> string)))
   ) {
     // Decode each union variant to JSON separately
-    Union.perVariantVal(~input, ~target=input.expected)->parse
+    perVariantVal(~input, ~target=input.expected)->parse
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
     let to = input.expected.to->X.Option.getUnsafe
     // Whether we can optimize encoding during decoding
@@ -4890,7 +4877,7 @@ and json = () =>
       bool(),
       float(),
       nullLiteral(),
-      DictSchema.factory(jsonRef->castToPublic)->castToInternal,
+      dictFactory(jsonRef->castToPublic)->castToInternal,
       array(jsonRef->castToPublic)->castToInternal,
     ]
     let has = dict{}
@@ -4901,7 +4888,7 @@ and json = () =>
     let jsonDef = base(unionTag, ~selfReverse=true)
     jsonDef.anyOf = Some(anyOf)
     jsonDef.has = Some(has)
-    jsonDef.decoder = Union.unionDecoder
+    jsonDef.decoder = unionDecoder
     jsonDef.name = Some(jsonName)
     jsonDef.tag = unionTag
 
@@ -5457,7 +5444,7 @@ module Schema = {
         }
 
         let fieldOr = (fieldName, schema, or) => {
-          field(fieldName, Option.factory(schema)->Option.getOr(or))
+          field(fieldName, optionFactory(schema)->Option.getOr(or))
         }
 
         let flatten = schema => {
@@ -5556,7 +5543,7 @@ module Schema = {
       }
 
       let fieldOr = (fieldName, schema, or) => {
-        field(fieldName, Option.factory(schema)->Option.getOr(or))
+        field(fieldName, optionFactory(schema)->Option.getOr(or))
       }
 
       let ctx = {
@@ -5990,7 +5977,7 @@ let schema = Schema.factory
 let js_schema = definition => definition->Obj.magic->Schema.definitionToSchema->castToPublic
 let literal = js_schema
 
-let enum = values => Union.factory(values->Array.map(literal))
+let enum = values => unionFactory(values->Array.map(literal))
 
 let compactColumnsDecoder = (~input) => {
   let selfSchema = input.expected
@@ -6478,13 +6465,10 @@ let compactColumns = inputSchema => {
 // }
 
 let object = Schema.object
-let nullAsOption = item => Option.factory(item, ~unit=nullAsUnit()->castToPublic)
-let null = item => Union.factory([item->castToUnknown, nullLiteral()->castToPublic])
-let option = item => item->Option.factory(~unit=unit()->castToPublic)
-// Wire up the forward reference used by `B.Val.get` (see `optionForwardRef`).
-optionForwardRef := (s => s->castToPublic->option->castToInternal)
+let nullAsOption = item => optionFactory(item, ~unit=nullAsUnit()->castToPublic)
+let null = item => unionFactory([item->castToUnknown, nullLiteral()->castToPublic])
 let array = array
-let dict = DictSchema.factory
+let dict = dictFactory
 let shape = Schema.shape
 let tuple = Schema.tuple
 let tuple1 = v0 => tuple(s => s.item(0, v0))
@@ -6494,7 +6478,7 @@ let tuple3 = (v0, v1, v2) =>
   Schema.definitionToSchema(
     [v0->castToUnknown, v1->castToUnknown, v2->castToUnknown]->Obj.magic,
   )->castToPublic
-let union = Union.factory
+let union = unionFactory
 
 // =============
 // Built-in refinements
@@ -6745,11 +6729,11 @@ let trim = schema => {
 }
 
 let nullable = schema => {
-  Union.factory([schema->castToUnknown, unit()->castToPublic, nullLiteral()->castToPublic])
+  unionFactory([schema->castToUnknown, unit()->castToPublic, nullLiteral()->castToPublic])
 }
 
 let nullableAsOption = schema => {
-  Union.factory([
+  unionFactory([
     schema->castToUnknown,
     unit()->castToPublic,
     nullAsUnit()->castToPublic->castToUnknown,
@@ -6795,7 +6779,7 @@ let js_is = (a, b) => {
 }
 
 let js_union = values =>
-  Union.factory(
+  unionFactory(
     values->Array.map(Schema.definitionToSchema)->(Obj.magic: array<internal> => array<'a>),
   )
 
@@ -6883,7 +6867,7 @@ let js_asyncDecoderAssert = (schema, assertFn) => {
 
 let js_optional = (schema, maybeOr) => {
   // TODO: maybeOr should be part of the unit schema
-  let schema = Union.factory([schema->castToUnknown, unit()->castToPublic])
+  let schema = unionFactory([schema->castToUnknown, unit()->castToPublic])
   switch maybeOr {
   | Some(or) if typeof(or) === functionTag => schema->Option.getOrWith(or->Obj.magic)->Obj.magic
   | Some(or) => schema->Option.getOr(or->Obj.magic)->Obj.magic
@@ -6895,13 +6879,13 @@ let js_nullable = (schema, maybeOr) => {
   // TODO: maybeOr should be part of the unit schema
   switch maybeOr {
   | Some(or) =>
-    let schema = Union.factory([schema->castToUnknown, nullAsUnit()->castToPublic->castToUnknown])
+    let schema = unionFactory([schema->castToUnknown, nullAsUnit()->castToPublic->castToUnknown])
     if typeof(or) === functionTag {
       schema->Option.getOrWith(or->Obj.magic)->Obj.magic
     } else {
       schema->Option.getOr(or->Obj.magic)->Obj.magic
     }
-  | None => Union.factory([schema->castToUnknown, nullLiteral()->castToPublic->castToUnknown])
+  | None => unionFactory([schema->castToUnknown, nullLiteral()->castToPublic->castToUnknown])
   }
 }
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1085,9 +1085,12 @@ module Error = {
 }
 
 // Forward reference to `option` (defined far below, after the Union/Option
-// modules). `objectDecoder` uses it to model dict additionalProperties reads as
-// optional. Assigned once, right after `option` is defined; the placeholder is
-// never invoked because decoders are only built lazily after module load.
+// modules). `B.Val.get` uses it to model dict additionalProperties reads as
+// optional. A standalone ref is required: `Option.factory` references
+// `objectDecoder` (via `nestedOption`), so `option` is necessarily defined after
+// the decoders that need it — an unbreakable definition cycle. Assigned once,
+// right after `option` is defined; the placeholder is never invoked because
+// decoders are only built lazily after module load.
 let optionForwardRef: ref<internal => internal> = ref(s => s)
 
 module Builder = {
@@ -1806,7 +1809,23 @@ module Builder = {
             | Some(s) => s
             | None =>
               switch parent.schema.additionalItems->X.Option.getUnsafe {
-              | Schema(s) => s->castToInternal
+              | Schema(s) =>
+                let s = s->castToInternal
+                // A `dict<V>` read by fixed key may be absent (no required keys),
+                // so model it as `option<V>` and let the union coercion handle a
+                // missing key uniformly. Scoped to object (dict) parents with a
+                // concrete value type: array→tuple rest reads (arrayTag) and
+                // json/unknown value types are left untouched.
+                if (
+                  parent.schema.tag === objectTag &&
+                  s.tag !== unknownTag &&
+                  !(s.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
+                  !(s->isOptional)
+                ) {
+                  optionForwardRef.contents(s)
+                } else {
+                  s
+                }
               | _ =>
                 // The input type has no such field. Throw a catchable error,
                 // so a union case decoder treats it as a failed case
@@ -3041,27 +3060,6 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
             schema.has->X.Option.getUnsafe->Dict.getUnsafe((undefinedTag :> string))
         ) {
           itemInput.inline = `(${itemInput.inline}??null)`
-        }
-
-        // Option A: a `dict<V>` is `additionalProperties: V` with no required
-        // keys, so a value read from a dict source may be absent. When this
-        // field was read from the dict's additionalItems (its schema IS the
-        // additionalItems value type — not a declared property, nor a
-        // flattened/cached val whose schema differs) and `V` is a concrete type
-        // that can't itself be undefined, model the read as optional. The
-        // existing union coercion then handles a missing key uniformly: an
-        // optional target field decodes absence to None. `unknown` additionalItems
-        // (open objects / flatten rest) are excluded — they already admit
-        // undefined and aren't a `dict<V>` coercion. (`option` via `optionForwardRef`.)
-        if !isJsonParent {
-          switch input.schema.additionalItems->X.Option.getUnsafe {
-          | Schema(vs)
-            if vs->castToInternal === itemInput.schema &&
-            itemInput.schema.tag !== unknownTag &&
-            !(itemInput.schema->isOptional) =>
-            itemInput.schema = optionForwardRef.contents(itemInput.schema)
-          | _ => ()
-          }
         }
 
         let itemOutput = itemInput->parse
@@ -6483,7 +6481,7 @@ let object = Schema.object
 let nullAsOption = item => Option.factory(item, ~unit=nullAsUnit()->castToPublic)
 let null = item => Union.factory([item->castToUnknown, nullLiteral()->castToPublic])
 let option = item => item->Option.factory(~unit=unit()->castToPublic)
-// Wire up the forward reference used by `objectDecoder` (see `optionForwardRef`).
+// Wire up the forward reference used by `B.Val.get` (see `optionForwardRef`).
 optionForwardRef := (s => s->castToPublic->option->castToInternal)
 let array = array
 let dict = DictSchema.factory

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1084,6 +1084,12 @@ module Error = {
   external classify: error => errorDetails = "%identity"
 }
 
+// Forward reference to `option` (defined far below, after the Union/Option
+// modules). `objectDecoder` uses it to model dict additionalProperties reads as
+// optional. Assigned once, right after `option` is defined; the placeholder is
+// never invoked because decoders are only built lazily after module load.
+let optionForwardRef: ref<internal => internal> = ref(s => s)
+
 module Builder = {
   type t = builder
 
@@ -3036,6 +3042,28 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         ) {
           itemInput.inline = `(${itemInput.inline}??null)`
         }
+
+        // Option A: a `dict<V>` is `additionalProperties: V` with no required
+        // keys, so a value read from a dict source may be absent. When this
+        // field was read from the dict's additionalItems (its schema IS the
+        // additionalItems value type — not a declared property, nor a
+        // flattened/cached val whose schema differs) and `V` is a concrete type
+        // that can't itself be undefined, model the read as optional. The
+        // existing union coercion then handles a missing key uniformly: an
+        // optional target field decodes absence to None. `unknown` additionalItems
+        // (open objects / flatten rest) are excluded — they already admit
+        // undefined and aren't a `dict<V>` coercion. (`option` via `optionForwardRef`.)
+        if !isJsonParent {
+          switch input.schema.additionalItems->X.Option.getUnsafe {
+          | Schema(vs)
+            if vs->castToInternal === itemInput.schema &&
+            itemInput.schema.tag !== unknownTag &&
+            !(itemInput.schema->isOptional) =>
+            itemInput.schema = optionForwardRef.contents(itemInput.schema)
+          | _ => ()
+          }
+        }
+
         let itemOutput = itemInput->parse
 
         if isUnion && schema->isLiteral {
@@ -6455,6 +6483,8 @@ let object = Schema.object
 let nullAsOption = item => Option.factory(item, ~unit=nullAsUnit()->castToPublic)
 let null = item => Union.factory([item->castToUnknown, nullLiteral()->castToPublic])
 let option = item => item->Option.factory(~unit=unit()->castToPublic)
+// Wire up the forward reference used by `objectDecoder` (see `optionForwardRef`).
+optionForwardRef := (s => s->castToPublic->option->castToInternal)
 let array = array
 let dict = DictSchema.factory
 let shape = Schema.shape

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3106,12 +3106,12 @@ and dictFactory = item => {
     mut->castToPublic
   }
 
-and toKey = (schema: internal): string =>
+and unionToKey = (schema: internal): string =>
     schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.instance)
       ? (schema.class->Obj.magic)["name"]
       : (schema.tag :> string)
 
-and isPriority = (tagFlag, byKey: dict<array<unknown>>) => {
+and unionIsPriority = (tagFlag, byKey: dict<array<unknown>>) => {
     (tagFlag->Flag.unsafeHas(TagFlag.array->Flag.with(TagFlag.instance)) &&
       byKey->Stdlib.Dict.has((objectTag: tag :> string))) ||
       (tagFlag->Flag.unsafeHas(TagFlag.nan) && byKey->Stdlib.Dict.has((numberTag: tag :> string)))
@@ -3120,29 +3120,29 @@ and isPriority = (tagFlag, byKey: dict<array<unknown>>) => {
   // Whether decoding a value already known to be of the schema type
   // is a noop — no transformation anywhere in the schema tree.
   // Recursive refs are conservatively treated as transforming
-and isSelfDecodeNoop = (schema: internal) => {
+and unionIsSelfDecodeNoop = (schema: internal) => {
     schema.to === None &&
     schema.parser === None &&
     !(schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
     switch schema.anyOf {
-    | Some(anyOf) => anyOf->Array.every(isSelfDecodeNoop)
+    | Some(anyOf) => anyOf->Array.every(unionIsSelfDecodeNoop)
     | None => true
     } &&
     switch schema.items {
-    | Some(items) => items->Array.every(isSelfDecodeNoop)
+    | Some(items) => items->Array.every(unionIsSelfDecodeNoop)
     | None => true
     } &&
     switch schema.properties {
-    | Some(properties) => properties->Stdlib.Dict.valuesToArray->Array.every(isSelfDecodeNoop)
+    | Some(properties) => properties->Stdlib.Dict.valuesToArray->Array.every(unionIsSelfDecodeNoop)
     | None => true
     } &&
     switch schema.additionalItems {
-    | Some(Schema(s)) => s->castToInternal->isSelfDecodeNoop
+    | Some(Schema(s)) => s->castToInternal->unionIsSelfDecodeNoop
     | _ => true
     }
   }
 
-and isWiderUnionSchema = (~schemaAnyOf, ~inputAnyOf) => {
+and unionIsWiderSchema = (~schemaAnyOf, ~inputAnyOf) => {
     inputAnyOf->Array.everyWithIndex((inputSchema, idx) => {
       switch schemaAnyOf->X.Array.getUnsafeOption(idx) {
       | Some(schema) =>
@@ -3167,7 +3167,7 @@ and isWiderUnionSchema = (~schemaAnyOf, ~inputAnyOf) => {
 
   // The union's own `.to` chain which is applied per case during decoding.
   // None when the union has a custom parser owning the `.to` conversion
-and getToPerCase = (schema: internal) =>
+and unionGetToPerCase = (schema: internal) =>
     switch schema {
     | {parser: ?None, to} => Some(to)
     | _ => None
@@ -3175,7 +3175,7 @@ and getToPerCase = (schema: internal) =>
 
   // Whether a union-typed input can be decoded by dispatching
   // over its variants with `.to(target)` appended to each
-and canDispatchPerVariant = (~inputAnyOf, ~target: internal) =>
+and unionCanDispatchPerVariant = (~inputAnyOf, ~target: internal) =>
     // S.json and recursive targets keep their dedicated union-input handling
     !((target->getOutputSchema).tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
     !(
@@ -3195,7 +3195,7 @@ and canDispatchPerVariant = (~inputAnyOf, ~target: internal) =>
   // Re-drives the source union with `.to(target)` appended, so its decoder
   // dispatches per variant and each variant converts to the target
   // independently (the documented per-source-variant algorithm)
-and perVariantVal = (~input: val, ~target) =>
+and unionPerVariantVal = (~input: val, ~target) =>
     input->B.refine(
       ~schema=unknown,
       ~expected=input.schema->updateOutput(mut => mut.to = Some(target))->castToInternal,
@@ -3203,17 +3203,17 @@ and perVariantVal = (~input: val, ~target) =>
 
   // Applied by the parse loop when a union-typed val
   // meets a different expected schema
-and encoder: encoder = (~input: val, ~target: internal) => {
+and unionEncoder: encoder = (~input: val, ~target: internal) => {
     let inputAnyOf = input.schema.anyOf->X.Option.getUnsafe
     if (
       target.tag === unionTag &&
-      getToPerCase(target) === None &&
-      isWiderUnionSchema(~schemaAnyOf=target.anyOf->X.Option.getUnsafe, ~inputAnyOf)
+      unionGetToPerCase(target) === None &&
+      unionIsWiderSchema(~schemaAnyOf=target.anyOf->X.Option.getUnsafe, ~inputAnyOf)
     ) {
       // The target union decoder passes a narrower union input through as-is
       input
-    } else if canDispatchPerVariant(~inputAnyOf, ~target) {
-      perVariantVal(~input, ~target)
+    } else if unionCanDispatchPerVariant(~inputAnyOf, ~target) {
+      unionPerVariantVal(~input, ~target)
     } else {
       input
     }
@@ -3224,14 +3224,14 @@ and unionDecoder: Builder.t = (~input) => {
     let schemas = selfSchema.anyOf->X.Option.getUnsafe
     let initialInputTagFlag = input.schema.tag->TagFlag.get
 
-    let toPerCase = getToPerCase(selfSchema)
+    let toPerCase = unionGetToPerCase(selfSchema)
 
     if (
       // The input val is already of the union type (trusted self-decode).
       // Only allowed when no variant transforms the value
-      (input.schema === selfSchema && toPerCase === None && schemas->Array.every(isSelfDecodeNoop)) ||
+      (input.schema === selfSchema && toPerCase === None && schemas->Array.every(unionIsSelfDecodeNoop)) ||
       (initialInputTagFlag->Flag.unsafeHas(TagFlag.union) &&
-      isWiderUnionSchema(
+      unionIsWiderSchema(
         ~schemaAnyOf=schemas,
         ~inputAnyOf=input.schema.anyOf->X.Option.getUnsafe,
       ) &&
@@ -3254,14 +3254,14 @@ and unionDecoder: Builder.t = (~input) => {
           )
         )
       ) {
-        let sourceKey = toKey(input.schema)
+        let sourceKey = unionToKey(input.schema)
         let hasNull = ref(false)
         let hasUndefined = ref(false)
         let len = schemas->Array.length
         let i = ref(0)
         while activeKey.contents === "" && i.contents < len {
           let s = schemas->Array.getUnsafe(i.contents)
-          if toKey(s) === sourceKey {
+          if unionToKey(s) === sourceKey {
             activeKey := sourceKey
           } else if s.tag === nullTag {
             hasNull := true
@@ -3602,7 +3602,7 @@ and unionDecoder: Builder.t = (~input) => {
         }
         let tag = schema.tag
         let tagFlag = TagFlag.get(tag)
-        let key = toKey(schema)
+        let key = unionToKey(schema)
 
         if activeKey !== "" && activeKey !== key {
           // not in active tier — skip
@@ -3683,7 +3683,7 @@ and unionDecoder: Builder.t = (~input) => {
               }
             }
 
-            if isPriority(tagFlag, byKey.contents) {
+            if unionIsPriority(tagFlag, byKey.contents) {
               // Not the fastest way, but it's the simplest way
               // to make sure NaN is checked before number
               // And instance and array checked before object
@@ -3771,7 +3771,7 @@ and unionDecoder: Builder.t = (~input) => {
           let blockCode = typeValidationOutput->B.merge(~hoistCond=blockCond) ++ itemsCode
           let blockCond = blockCond.contents
 
-          if blockCode->X.String.unsafeToBool || isPriority(firstSchema.tag->TagFlag.get, byKey) {
+          if blockCode->X.String.unsafeToBool || unionIsPriority(firstSchema.tag->TagFlag.get, byKey) {
             let if_ = nextElse.contents ? "else if" : "if"
             start := start.contents ++ if_ ++ `(${blockCond}){${blockCode}}`
             nextElse := true
@@ -3883,7 +3883,7 @@ and unionFactory: 'a 'b. array<t<'a>> => t<'b> = schemas => {
       let mut = base(unionTag, ~selfReverse=false)
       mut.anyOf = Some(anyOf->X.Set.toArray)
       mut.decoder = unionDecoder
-      mut.encoder = Some(encoder)
+      mut.encoder = Some(unionEncoder)
       mut.has = Some(has)
       mut->castToPublic
     }
@@ -4306,7 +4306,7 @@ module Metadata = {
     type t<'metadata>
     let make: (~namespace: string, ~name: string) => t<'metadata>
     let internal: string => t<'metadata>
-    external toKey: t<'metadata> => string = "%identity"
+    external unionToKey: t<'metadata> => string = "%identity"
   } = {
     type t<'metadata> = string
 
@@ -4318,16 +4318,16 @@ module Metadata = {
       `m:${name}`
     }
 
-    external toKey: t<'metadata> => string = "%identity"
+    external unionToKey: t<'metadata> => string = "%identity"
   }
 
   let get = (schema, ~id: Id.t<'metadata>) => {
-    schema->(Obj.magic: t<'a> => dict<option<'metadata>>)->Dict.getUnsafe(id->Id.toKey)
+    schema->(Obj.magic: t<'a> => dict<option<'metadata>>)->Dict.getUnsafe(id->Id.unionToKey)
   }
 
   @inline
   let setInPlace = (schema, ~id: Id.t<'metadata>, metadata: 'metadata) => {
-    schema->(Obj.magic: internal => dict<'metadata>)->Dict.set(id->Id.toKey, metadata)
+    schema->(Obj.magic: internal => dict<'metadata>)->Dict.set(id->Id.unionToKey, metadata)
   }
 
   let set = (schema, ~id: Id.t<'metadata>, metadata: 'metadata) => {
@@ -4831,7 +4831,7 @@ and jsonDecoderFn = (~input) => {
       !(input.schema.has->X.Option.getUnsafe->Stdlib.Dict.has((undefinedTag :> string)))
   ) {
     // Decode each union variant to JSON separately
-    perVariantVal(~input, ~target=input.expected)->parse
+    unionPerVariantVal(~input, ~target=input.expected)->parse
   } else if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
     let to = input.expected.to->X.Option.getUnsafe
     // Whether we can optimize encoding during decoding
@@ -6310,7 +6310,7 @@ let compactColumns = inputSchema => {
 
 //     let inlinedSchema = switch schema->Option.default {
 //     | Some(default) => {
-//         metadataMap->X.Dict.deleteInPlace(Option.defaultMetadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(Option.defaultMetadataId->Metadata.Id.unionToKey)
 //         switch default {
 //         | Value(defaultValue) =>
 //           inlinedSchema ++
@@ -6326,7 +6326,7 @@ let compactColumns = inputSchema => {
 
 //     let inlinedSchema = switch schema->deprecation {
 //     | Some(message) => {
-//         metadataMap->X.Dict.deleteInPlace(deprecationMetadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(deprecationMetadataId->Metadata.Id.unionToKey)
 //         inlinedSchema ++ `->S.deprecate(${message->X.Inlined.Value.fromString})`
 //       }
 
@@ -6335,7 +6335,7 @@ let compactColumns = inputSchema => {
 
 //     let inlinedSchema = switch schema->description {
 //     | Some(message) => {
-//         metadataMap->X.Dict.deleteInPlace(descriptionMetadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(descriptionMetadataId->Metadata.Id.unionToKey)
 //         inlinedSchema ++ `->S.describe(${message->X.Inlined.Value.stringify})`
 //       }
 
@@ -6353,7 +6353,7 @@ let compactColumns = inputSchema => {
 //       switch schema->String.refinements {
 //       | [] => inlinedSchema
 //       | refinements =>
-//         metadataMap->X.Dict.deleteInPlace(String.Refinement.metadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(String.Refinement.metadataId->Metadata.Id.unionToKey)
 //         inlinedSchema ++
 //         refinements
 //         ->Array.map(refinement => {
@@ -6384,7 +6384,7 @@ let compactColumns = inputSchema => {
 //       switch schema->Int.refinements {
 //       | [] => inlinedSchema
 //       | refinements =>
-//         metadataMap->X.Dict.deleteInPlace(Int.Refinement.metadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(Int.Refinement.metadataId->Metadata.Id.unionToKey)
 //         inlinedSchema ++
 //         refinements
 //         ->Array.map(refinement => {
@@ -6404,7 +6404,7 @@ let compactColumns = inputSchema => {
 //       switch schema->Float.refinements {
 //       | [] => inlinedSchema
 //       | refinements =>
-//         metadataMap->X.Dict.deleteInPlace(Float.Refinement.metadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(Float.Refinement.metadataId->Metadata.Id.unionToKey)
 //         inlinedSchema ++
 //         refinements
 //         ->Array.map(refinement => {
@@ -6422,7 +6422,7 @@ let compactColumns = inputSchema => {
 //       switch schema->Array.refinements {
 //       | [] => inlinedSchema
 //       | refinements =>
-//         metadataMap->X.Dict.deleteInPlace(Array.Refinement.metadataId->Metadata.Id.toKey)
+//         metadataMap->X.Dict.deleteInPlace(Array.Refinement.metadataId->Metadata.Id.unionToKey)
 //         inlinedSchema ++
 //         refinements
 //         ->Array.map(refinement => {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -923,7 +923,9 @@ function get(parent, location) {
     schema = locationSchema;
   } else {
     let s = parent.s.additionalItems;
-    schema = s === "strip" || s === "strict" ? unsupportedDecode(parent, parent.s, parent.e) : s;
+    schema = s === "strip" || s === "strict" ? unsupportedDecode(parent, parent.s, parent.e) : (
+        parent.s.type === objectTag && s.type !== unknownTag && !(flags[s.type] & 512) && !isOptional(s) ? optionForwardRef.contents(s) : s
+      );
   }
   let inlinedLocation = inlineLocation(parent.g, location);
   let pathAppend = `[` + inlinedLocation + `]`;
@@ -1347,6 +1349,18 @@ function parse$1(input) {
   return valRef;
 }
 
+function getOutputSchema(_schema) {
+  while (true) {
+    let schema = _schema;
+    let to = schema.to;
+    if (to === undefined) {
+      return schema;
+    }
+    _schema = to;
+    continue;
+  };
+}
+
 function reverse(schema) {
   if (reversedKey in schema) {
     return schema[reversedKey];
@@ -1446,18 +1460,6 @@ function reverse(schema) {
   valueOptions[valKey] = schema;
   d(r, reversedKey, valueOptions);
   return r;
-}
-
-function getOutputSchema(_schema) {
-  while (true) {
-    let schema = _schema;
-    let to = schema.to;
-    if (to === undefined) {
-      return schema;
-    }
-    _schema = to;
-    continue;
-  };
 }
 
 function parseDynamic(input) {
@@ -1836,14 +1838,6 @@ function objectDecoder(unknownInput) {
       itemInput$1.u = isUnion;
       if (isJsonParent && schema$1.type === unionTag && schema$1.has[undefinedTag]) {
         itemInput$1.i = `(` + itemInput$1.i + `??null)`;
-      }
-      if (!isJsonParent) {
-        let vs = input.s.additionalItems;
-        if (vs === "strip" || vs === "strict") {
-          vs === "strip";
-        } else if (vs === itemInput$1.s && itemInput$1.s.type !== unknownTag && !isOptional(itemInput$1.s)) {
-          itemInput$1.s = optionForwardRef.contents(itemInput$1.s);
-        }
       }
       let itemOutput$1 = parse$1(itemInput$1);
       if (isUnion && constField in schema$1) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1891,7 +1891,7 @@ function dictFactory(item) {
   return mut;
 }
 
-function toKey(schema) {
+function unionToKey(schema) {
   if (flags[schema.type] & 8192) {
     return schema.class.name;
   } else {
@@ -1899,7 +1899,7 @@ function toKey(schema) {
   }
 }
 
-function isPriority(tagFlag, byKey) {
+function unionIsPriority(tagFlag, byKey) {
   if (tagFlag & 8320 && objectTag in byKey) {
     return true;
   } else if (tagFlag & 2048) {
@@ -1909,7 +1909,7 @@ function isPriority(tagFlag, byKey) {
   }
 }
 
-function isSelfDecodeNoop(_schema) {
+function unionIsSelfDecodeNoop(_schema) {
   while (true) {
     let schema = _schema;
     let tmp = false;
@@ -1917,15 +1917,15 @@ function isSelfDecodeNoop(_schema) {
     let tmp$2 = false;
     if (schema.to === undefined && schema.parser === undefined && !(flags[schema.type] & 512)) {
       let anyOf = schema.anyOf;
-      tmp$2 = anyOf !== undefined ? anyOf.every(isSelfDecodeNoop) : true;
+      tmp$2 = anyOf !== undefined ? anyOf.every(unionIsSelfDecodeNoop) : true;
     }
     if (tmp$2) {
       let items = schema.items;
-      tmp$1 = items !== undefined ? items.every(isSelfDecodeNoop) : true;
+      tmp$1 = items !== undefined ? items.every(unionIsSelfDecodeNoop) : true;
     }
     if (tmp$1) {
       let properties = schema.properties;
-      tmp = properties !== undefined ? Object.values(properties).every(isSelfDecodeNoop) : true;
+      tmp = properties !== undefined ? Object.values(properties).every(unionIsSelfDecodeNoop) : true;
     }
     if (!tmp) {
       return false;
@@ -1942,7 +1942,7 @@ function isSelfDecodeNoop(_schema) {
   };
 }
 
-function isWiderUnionSchema(schemaAnyOf, inputAnyOf) {
+function unionIsWiderSchema(schemaAnyOf, inputAnyOf) {
   return inputAnyOf.every((inputSchema, idx) => {
     let schema = schemaAnyOf[idx];
     if (schema !== undefined && !(flags[inputSchema.type] & 9152) && inputSchema.type === schema.type && inputSchema.const === schema.const) {
@@ -1953,7 +1953,7 @@ function isWiderUnionSchema(schemaAnyOf, inputAnyOf) {
   });
 }
 
-function getToPerCase(schema) {
+function unionGetToPerCase(schema) {
   let match = schema.parser;
   if (match !== undefined) {
     return;
@@ -1964,7 +1964,7 @@ function getToPerCase(schema) {
   }
 }
 
-function canDispatchPerVariant(inputAnyOf, target) {
+function unionCanDispatchPerVariant(inputAnyOf, target) {
   if (!(flags[getOutputSchema(target).type] & 512) && !(target.type === unionTag && target.anyOf.some(v => flags[v.type] & 512))) {
     return !inputAnyOf.some(v => {
       if (v.to !== undefined || v.parser !== undefined) {
@@ -1978,18 +1978,18 @@ function canDispatchPerVariant(inputAnyOf, target) {
   }
 }
 
-function perVariantVal(input, target) {
+function unionPerVariantVal(input, target) {
   return refine(input, unknown, undefined, updateOutput(input.s, mut => {
     mut.to = target;
   }));
 }
 
-function encoder(input, target) {
+function unionEncoder(input, target) {
   let inputAnyOf = input.s.anyOf;
-  if (target.type === unionTag && getToPerCase(target) === undefined && isWiderUnionSchema(target.anyOf, inputAnyOf) || !canDispatchPerVariant(inputAnyOf, target)) {
+  if (target.type === unionTag && unionGetToPerCase(target) === undefined && unionIsWiderSchema(target.anyOf, inputAnyOf) || !unionCanDispatchPerVariant(inputAnyOf, target)) {
     return input;
   } else {
-    return perVariantVal(input, target);
+    return unionPerVariantVal(input, target);
   }
 }
 
@@ -1997,8 +1997,8 @@ function unionDecoder(input) {
   let selfSchema = input.e;
   let schemas = selfSchema.anyOf;
   let initialInputTagFlag = flags[input.s.type];
-  let toPerCase = getToPerCase(selfSchema);
-  if (input.s === selfSchema && toPerCase === undefined && schemas.every(isSelfDecodeNoop) || initialInputTagFlag & 256 && isWiderUnionSchema(schemas, input.s.anyOf) && toPerCase === undefined || input.io && input.e === input.s) {
+  let toPerCase = unionGetToPerCase(selfSchema);
+  if (input.s === selfSchema && toPerCase === undefined && schemas.every(unionIsSelfDecodeNoop) || initialInputTagFlag & 256 && unionIsWiderSchema(schemas, input.s.anyOf) && toPerCase === undefined || input.io && input.e === input.s) {
     return input;
   }
   if (initialInputTagFlag & 256 || input.s.encoder === undefined && initialInputTagFlag & 512) {
@@ -2006,14 +2006,14 @@ function unionDecoder(input) {
   }
   let activeKey = "";
   if (!(initialInputTagFlag & 769)) {
-    let sourceKey = toKey(input.s);
+    let sourceKey = unionToKey(input.s);
     let hasNull = false;
     let hasUndefined = false;
     let len = schemas.length;
     let i = 0;
     while (activeKey === "" && i < len) {
       let s = schemas[i];
-      if (toKey(s) === sourceKey) {
+      if (unionToKey(s) === sourceKey) {
         activeKey = sourceKey;
       } else if (s.type === nullTag) {
         hasNull = true;
@@ -2271,7 +2271,7 @@ function unionDecoder(input) {
       }) : schemas$1[idx$1];
     let tag = schema$1.type;
     let tagFlag = flags[tag];
-    let key = toKey(schema$1);
+    let key = unionToKey(schema$1);
     if ((activeKey$1 === "" || activeKey$1 === key) && !(tagFlag & 16 && "fromDefault" in selfSchema)) {
       let initialArr = byKey[key];
       if (initialArr !== undefined) {
@@ -2310,7 +2310,7 @@ function unionDecoder(input) {
           typeValidationInput.vc = undefined;
           typeValidationOutput = typeValidationInput;
         }
-        if (isPriority(tagFlag, byKey)) {
+        if (unionIsPriority(tagFlag, byKey)) {
           keys.unshift(key);
         } else {
           keys.push(key);
@@ -2377,7 +2377,7 @@ function unionDecoder(input) {
       };
       let blockCode$1 = merge(typeValidationOutput$2, blockCond) + itemsCode$1;
       let blockCond$1 = blockCond.contents;
-      if (blockCode$1 || isPriority(flags[firstSchema.type], byKey$1)) {
+      if (blockCode$1 || unionIsPriority(flags[firstSchema.type], byKey$1)) {
         let if_ = nextElse ? "else if" : "if";
         start = start + if_ + (`(` + blockCond$1 + `){` + blockCode$1 + `}`);
         nextElse = true;
@@ -2432,7 +2432,7 @@ function unionFactory(schemas) {
     let mut = base(unionTag, false);
     mut.anyOf = Array.from(anyOf);
     mut.decoder = unionDecoder;
-    mut.encoder = encoder;
+    mut.encoder = unionEncoder;
     mut.has = has;
     return mut;
   }
@@ -3159,7 +3159,7 @@ function jsonDecoderFn(input) {
     return recursiveDecoder(input);
   }
   if (inputTagFlag & 256 && !(undefinedTag in input.s.has)) {
-    return parse$1(perVariantVal(input, input.e));
+    return parse$1(unionPerVariantVal(input, input.e));
   }
   if (inputTagFlag & 1) {
     let to = input.e.to;

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -382,10 +382,6 @@ let $$Error = {
   make: make
 };
 
-let optionForwardRef = {
-  contents: s => s
-};
-
 function embed(b, value) {
   let e = b.g.e;
   let l = e.length;
@@ -901,48 +897,6 @@ function scope(val) {
     };
   }
   return nextVal;
-}
-
-function get(parent, location) {
-  let d = parent.d;
-  let vals;
-  if (d !== undefined) {
-    vals = d;
-  } else {
-    let d$1 = {};
-    parent.d = d$1;
-    vals = d$1;
-  }
-  let v = vals[location];
-  if (v !== undefined) {
-    return scope(v);
-  }
-  let locationSchema = parent.s.type === objectTag ? parent.s.properties[location] : parent.s.items[location];
-  let schema;
-  if (locationSchema !== undefined) {
-    schema = locationSchema;
-  } else {
-    let s = parent.s.additionalItems;
-    schema = s === "strip" || s === "strict" ? unsupportedDecode(parent, parent.s, parent.e) : (
-        parent.s.type === objectTag && s.type !== unknownTag && !(flags[s.type] & 512) && !isOptional(s) ? optionForwardRef.contents(s) : s
-      );
-  }
-  let inlinedLocation = inlineLocation(parent.g, location);
-  let pathAppend = `[` + inlinedLocation + `]`;
-  let item = {
-    p: parent,
-    v: _notVarAtParent,
-    i: constField in schema ? inlineConst(parent, schema) : parent.v() + pathAppend,
-    s: schema,
-    e: schema,
-    f: 0,
-    cp: "",
-    hd: "",
-    path: parent.path + pathAppend,
-    g: parent.g
-  };
-  vals[location] = item;
-  return item;
 }
 
 function embedTransformation(input, fn, isAsync) {
@@ -1547,6 +1501,46 @@ function getDecoder(param, param$1) {
   throw new Error(`[Sury] ` + "No schema provided for decoder.");
 }
 
+let nestedLoc = "BS_PRIVATE_NESTED_SOME_NONE";
+
+function neverBuilderFn(input) {
+  let output = refine(input, undefined, undefined, never_());
+  output.cp = embedInvalidInput(input, undefined) + ";";
+  return output;
+}
+
+function never_() {
+  return cached(neverTag, neverTag, s => {
+    s.decoder = neverBuilderFn;
+  });
+}
+
+function nestedOptionParser(input) {
+  let nextSchema = input.e.to;
+  return next(input, `{` + nestedLoc + `:` + getOutputSchema(input.e).properties[nestedLoc].const + `}`, nextSchema, nextSchema);
+}
+
+function instanceDecoder(input) {
+  let inputTagFlag = flags[input.s.type];
+  if (inputTagFlag & 1) {
+    return refine(input, input.e, [{
+        c: inputVar => inputVar + ` instanceof ` + embed(input, input.e.class),
+        f: failInvalidType
+      }], undefined);
+  } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
+    return input;
+  } else {
+    return unsupportedDecode(input, input.s, input.e);
+  }
+}
+
+function instance(class_) {
+  let mut = base(instanceTag, true);
+  mut.class = class_;
+  mut.decoder = instanceDecoder;
+  return mut;
+}
+
 function makeObjectVal(prev, schema) {
   return {
     v: _notVar,
@@ -1714,7 +1708,7 @@ function arrayDecoder(unknownInput) {
     for (let idx = 0; idx < expectedLength; ++idx) {
       let schema$1 = expectedItems[idx];
       let key = idx.toString();
-      let itemInput$1 = get(input, key);
+      let itemInput$1 = valGet(input, key);
       itemInput$1.e = schema$1;
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
@@ -1832,7 +1826,7 @@ function objectDecoder(unknownInput) {
     for (let idx = 0; idx < keysCount; ++idx) {
       let key = keys[idx];
       let schema$1 = properties[key];
-      let itemInput$1 = get(input, key);
+      let itemInput$1 = valGet(input, key);
       itemInput$1.e = schema$1;
       itemInput$1.io = false;
       itemInput$1.u = isUnion;
@@ -1889,382 +1883,7 @@ function objectDecoder(unknownInput) {
   return markOutput(output, input);
 }
 
-function recursiveDecoder(input) {
-  let expectedSchema = input.e;
-  let schemaRef = expectedSchema.$ref;
-  let defs = input.g.d;
-  let identifier = schemaRef.slice(8);
-  let def = defs[identifier];
-  let flag = input.g.o;
-  let inputSchema = input.s.seq === expectedSchema.seq ? def : input.s;
-  let key = inputSchema.seq + `-` + def.seq + `--` + flag;
-  let recOperation = "";
-  let fn = def[key];
-  if (fn !== undefined) {
-    let fn$1 = Primitive_option.valFromOption(fn);
-    recOperation = fn$1 === 0 ? embed(input, def) + (`["` + key + `"]`) : embed(input, fn$1);
-  } else {
-    let assumedHasTransform = Stdlib_Option.getOr(def.hasTransform, false);
-    let assumedIsAsync = Stdlib_Option.getOr(def.isAsync, false);
-    let compileNeeded = true;
-    let finalFn = 0;
-    while (compileNeeded) {
-      compileNeeded = false;
-      if (def.hasTransform === undefined) {
-        def.hasTransform = assumedHasTransform;
-      }
-      if (def.isAsync === undefined) {
-        def.isAsync = assumedIsAsync;
-      }
-      configurableValueOptions[valKey] = 0;
-      d(def, key, configurableValueOptions);
-      let fn$2 = compileDecoder(inputSchema, def, flag, defs);
-      valueOptions[valKey] = fn$2;
-      d(def, key, valueOptions);
-      finalFn = fn$2;
-      let actualHasTransform = def.hasTransform;
-      let actualIsAsync = def.isAsync;
-      if (actualHasTransform !== assumedHasTransform || actualIsAsync !== assumedIsAsync) {
-        assumedHasTransform = actualHasTransform;
-        assumedIsAsync = actualIsAsync;
-        ((delete def[key]));
-        compileNeeded = true;
-      }
-    };
-    recOperation = embed(input, finalFn);
-  }
-  let hasTransform = def.hasTransform === true;
-  let isAsync = def.isAsync;
-  let outputDecl = "";
-  let output;
-  if (hasTransform || isAsync) {
-    let outputVar = varWithoutAllocation(input.g);
-    outputDecl = `let ` + outputVar + `;`;
-    let output$1 = next(input, outputVar, expectedSchema, expectedSchema);
-    output$1.v = _var;
-    output$1.cp = outputVar + `=` + recOperation + `(` + input.i + `);`;
-    if (isAsync) {
-      output$1.f = output$1.f | 1;
-    }
-    output = output$1;
-  } else {
-    let output$2 = refine(input, expectedSchema, undefined, expectedSchema);
-    output$2.cp = recOperation + `(` + input.i + `);`;
-    output = output$2;
-  }
-  output.prev = undefined;
-  output.cp = outputDecl + mergeWithPathPrepend(output, input, undefined, undefined);
-  output.fz = undefined;
-  output.prev = input;
-  return output;
-}
-
-function instanceDecoder(input) {
-  let inputTagFlag = flags[input.s.type];
-  if (inputTagFlag & 1) {
-    return refine(input, input.e, [{
-        c: inputVar => inputVar + ` instanceof ` + embed(input, input.e.class),
-        f: failInvalidType
-      }], undefined);
-  } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
-    return input;
-  } else {
-    return unsupportedDecode(input, input.s, input.e);
-  }
-}
-
-function instance(class_) {
-  let mut = base(instanceTag, true);
-  mut.class = class_;
-  mut.decoder = instanceDecoder;
-  return mut;
-}
-
-d(sp, "~standard", {
-  get: function () {
-    let schema = this;
-    return {
-      version: 1,
-      vendor: vendor,
-      validate: input => {
-        try {
-          return {
-            value: getDecoder(unknown, schema)(input)
-          };
-        } catch (exn) {
-          let error = getOrRethrow(exn);
-          return {
-            issues: [{
-                message: error.reason,
-                path: error.path === "" ? undefined : toArray(error.path)
-              }]
-          };
-        }
-      }
-    };
-  }
-});
-
-function parser(schema) {
-  return getDecoder(unknown, schema);
-}
-
-function asyncParser(schema) {
-  return getDecoder(unknown, schema, 1);
-}
-
-function decoder(from, to) {
-  return getDecoder(reverse(from), to);
-}
-
-function asyncDecoder(from, to) {
-  return getDecoder(reverse(from), to, 1);
-}
-
-function decoder1(schema) {
-  return getDecoder(schema, undefined);
-}
-
-function asyncDecoder1(schema) {
-  return getDecoder(schema, 1);
-}
-
-function getAssertResult() {
-  return cached("a", undefinedTag, s => {
-    s.const = (void 0);
-    s.decoder = literalDecoder;
-    s.noValidation = true;
-  });
-}
-
-function parseOrThrow(any, schema) {
-  return getDecoder(unknown, schema)(any);
-}
-
-function parseAsyncOrThrow(any, schema) {
-  return getDecoder(unknown, schema, 1)(any);
-}
-
-function assertOrThrow(any, schema) {
-  return getDecoder(unknown, schema, getAssertResult())(any);
-}
-
-function assertAsyncOrThrow(any, schema) {
-  return getDecoder(unknown, schema, getAssertResult(), 1)(any);
-}
-
-function decodeOrThrow(any, from, to) {
-  return getDecoder(reverse(from), to)(any);
-}
-
-function decodeAsyncOrThrow(any, from, to) {
-  return getDecoder(reverse(from), to, 1)(any);
-}
-
-function isAsync(schema) {
-  let v = schema.isAsync;
-  if (v !== undefined) {
-    return v;
-  } else {
-    let defs = 0;
-    try {
-      let input = operationArg(unknown, schema, 1, defs);
-      let output = parse$1(input);
-      let isAsync$1 = has(output.f, 1);
-      schema.isAsync = isAsync$1;
-      return isAsync$1;
-    } catch (exn) {
-      getOrRethrow(exn);
-      return false;
-    }
-  }
-}
-
-function wrapExnToFailure(exn) {
-  if ((exn&&exn.s===s)) {
-    return {
-      success: false,
-      error: exn
-    };
-  }
-  throw exn;
-}
-
-function js_safe(fn) {
-  try {
-    return {
-      success: true,
-      value: fn()
-    };
-  } catch (exn) {
-    return wrapExnToFailure(exn);
-  }
-}
-
-function js_safeAsync(fn) {
-  try {
-    return fn().then(value => ({
-      success: true,
-      value: value
-    }), wrapExnToFailure);
-  } catch (exn) {
-    return Promise.resolve(wrapExnToFailure(exn));
-  }
-}
-
-function make$1(namespace, name) {
-  return `m:` + namespace + `:` + name;
-}
-
-function internal(name) {
-  return `m:` + name;
-}
-
-let Id = {
-  make: make$1,
-  internal: internal
-};
-
-function get$1(schema, id) {
-  return schema[id];
-}
-
-function set(schema, id, metadata) {
-  let mut = copySchema(schema);
-  mut[id] = metadata;
-  return mut;
-}
-
-let defsPath = `#/$defs/`;
-
-function recursive(name, fn) {
-  let ref = defsPath + name;
-  let refSchema = base(refTag, false);
-  refSchema.$ref = ref;
-  refSchema.name = name;
-  refSchema.decoder = recursiveDecoder;
-  let isNestedRec = globalConfig.d;
-  if (!isNestedRec) {
-    globalConfig.d = {};
-  }
-  let def = fn(refSchema);
-  if (def.name) {
-    refSchema.name = def.name;
-  }
-  globalConfig.d[name] = def;
-  if (isNestedRec) {
-    return refSchema;
-  }
-  let schema = base(refTag, false);
-  schema.name = refSchema.name;
-  schema.$ref = ref;
-  schema.$defs = globalConfig.d;
-  schema.decoder = recursiveDecoder;
-  globalConfig.d = undefined;
-  return schema;
-}
-
-function noValidation(schema, value) {
-  let mut = copySchema(schema);
-  mut.noValidation = value;
-  return mut;
-}
-
-function internalRefine(schema, makeRefiner) {
-  return updateOutput(schema, mut => {
-    let refiner = makeRefiner(mut);
-    let existingRefiner = mut.refiner;
-    if (existingRefiner !== undefined) {
-      mut.refiner = input => {
-        let arr = existingRefiner(input);
-        let next = refiner(input);
-        for (let i = 0, i_finish = next.length; i < i_finish; ++i) {
-          arr.push(next[i]);
-        }
-        return arr;
-      };
-    } else {
-      mut.refiner = refiner;
-    }
-  });
-}
-
-function refine$1(schema, refineCheck, error, path) {
-  let message = error !== undefined ? error : "Refinement failed";
-  let extraPath = path !== undefined ? fromArray(path) : "";
-  return internalRefine(schema, param => (input => {
-    let embeddedCheck = embed(input, refineCheck);
-    return [{
-        c: inputVar => embeddedCheck + `(` + inputVar + `)`,
-        f: invalidInputBuilder(undefined, extraPath, message, undefined)
-      }];
-  }));
-}
-
-function getMutErrorMessage(mut) {
-  let em = mut.errorMessage ? copy(mut.errorMessage) : ({});
-  mut.errorMessage = em;
-  return em;
-}
-
-function transform(schema, transformer) {
-  return updateOutput(schema, mut => {
-    mut.parser = input => {
-      let match = transformer(effectCtx(input));
-      let parser = match.p;
-      if (parser !== undefined) {
-        if (match.a !== undefined) {
-          return invalidOperation(input, `The S.transform doesn't allow parser and asyncParser at the same time. Remove parser in favor of asyncParser`);
-        } else {
-          return embedTransformation(input, parser, false);
-        }
-      }
-      let asyncParser = match.a;
-      if (asyncParser !== undefined) {
-        return embedTransformation(input, asyncParser, true);
-      } else if (match.s !== undefined) {
-        return invalidOperation(input, `The S.transform parser is missing`);
-      } else {
-        return refine(input, undefined, undefined, input.e.to);
-      }
-    };
-    let to = copySchema(unknown);
-    mut.to = (to.serializer = input => {
-      let match = transformer(effectCtx(input));
-      let serializer = match.s;
-      if (serializer !== undefined) {
-        return embedTransformation(input, serializer, false);
-      } else if (match.a !== undefined || match.p !== undefined) {
-        return invalidOperation(input, `The S.transform serializer is missing`);
-      } else {
-        return refine(input, undefined, undefined, input.e.to);
-      }
-    }, to);
-    ((delete mut.isAsync));
-  });
-}
-
-function nullAsUnit() {
-  let s = copySchema(nullLiteral());
-  s.to = unit();
-  return s;
-}
-
-function neverBuilderFn(input) {
-  let output = refine(input, undefined, undefined, never_());
-  output.cp = embedInvalidInput(input, undefined) + ";";
-  return output;
-}
-
-function never_() {
-  return cached(neverTag, neverTag, s => {
-    s.decoder = neverBuilderFn;
-  });
-}
-
-let nestedLoc = "BS_PRIVATE_NESTED_SOME_NONE";
-
-function factory(item) {
+function dictFactory(item) {
   let mut = base(objectTag, item[reversedKey] === item);
   mut.properties = immutableEmpty;
   mut.additionalItems = item;
@@ -2665,7 +2284,7 @@ function unionDecoder(input) {
         let typeValidationInput = scope(input);
         typeValidationInput.e = tagFlag & 32 ? nullLiteral() : (
             tagFlag & 16 ? unit() : (
-                tagFlag & 64 ? factory(unknown) : (
+                tagFlag & 64 ? dictFactory(unknown) : (
                     tagFlag & 128 ? array(unknown) : (
                         tagFlag & 8192 ? instance(schema$1.class) : (
                             tagFlag & 2048 ? nan() : (
@@ -2785,12 +2404,12 @@ function unionDecoder(input) {
   let o = output.f & 1 ? (output.i = `Promise.resolve(` + output.i + `)`, output.v = _notVar, output) : (
       output.v === _var && input.cp === "" && output.cp === "" && initialInline === "i" ? (input.hd = "", input.v = _notVar, input.i = initialInline, input) : output
     );
-  o.s = outputAnyOf.length ? factory$1(outputAnyOf) : never_();
+  o.s = outputAnyOf.length ? unionFactory(outputAnyOf) : never_();
   o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
   return o;
 }
 
-function factory$1(schemas) {
+function unionFactory(schemas) {
   let len = schemas.length;
   if (len === 1) {
     return schemas[0];
@@ -2837,25 +2456,20 @@ function nestedNone() {
   };
 }
 
-function parser$1(input) {
-  let nextSchema = input.e.to;
-  return next(input, `{` + nestedLoc + `:` + getOutputSchema(input.e).properties[nestedLoc].const + `}`, nextSchema, nextSchema);
-}
-
 function nestedOption(item) {
   return updateOutput(item, mut => {
     mut.to = nestedNone();
-    mut.parser = parser$1;
+    mut.parser = nestedOptionParser;
   });
 }
 
-function factory$2(item, unitOpt) {
+function optionFactory(item, unitOpt) {
   let unit$1 = unitOpt !== undefined ? unitOpt : unit();
   let match = getOutputSchema(item);
   let match$1 = match.type;
   switch (match$1) {
     case "undefined" :
-      return factory$1([
+      return unionFactory([
         unit$1,
         nestedOption(item)
       ]);
@@ -2899,11 +2513,397 @@ function factory$2(item, unitOpt) {
         mut.has = mutHas;
       });
     default:
-      return factory$1([
+      return unionFactory([
         item,
         unit$1
       ]);
   }
+}
+
+function option(item) {
+  return optionFactory(item, unit());
+}
+
+function valGet(parent, location) {
+  let d = parent.d;
+  let vals;
+  if (d !== undefined) {
+    vals = d;
+  } else {
+    let d$1 = {};
+    parent.d = d$1;
+    vals = d$1;
+  }
+  let v = vals[location];
+  if (v !== undefined) {
+    return scope(v);
+  }
+  let locationSchema = parent.s.type === objectTag ? parent.s.properties[location] : parent.s.items[location];
+  let schema;
+  if (locationSchema !== undefined) {
+    schema = locationSchema;
+  } else {
+    let s = parent.s.additionalItems;
+    schema = s === "strip" || s === "strict" ? unsupportedDecode(parent, parent.s, parent.e) : (
+        parent.s.type === objectTag && s.type !== unknownTag && !(flags[s.type] & 512) && !isOptional(s) ? option(s) : s
+      );
+  }
+  let inlinedLocation = inlineLocation(parent.g, location);
+  let pathAppend = `[` + inlinedLocation + `]`;
+  let item = {
+    p: parent,
+    v: _notVarAtParent,
+    i: constField in schema ? inlineConst(parent, schema) : parent.v() + pathAppend,
+    s: schema,
+    e: schema,
+    f: 0,
+    cp: "",
+    hd: "",
+    path: parent.path + pathAppend,
+    g: parent.g
+  };
+  vals[location] = item;
+  return item;
+}
+
+function recursiveDecoder(input) {
+  let expectedSchema = input.e;
+  let schemaRef = expectedSchema.$ref;
+  let defs = input.g.d;
+  let identifier = schemaRef.slice(8);
+  let def = defs[identifier];
+  let flag = input.g.o;
+  let inputSchema = input.s.seq === expectedSchema.seq ? def : input.s;
+  let key = inputSchema.seq + `-` + def.seq + `--` + flag;
+  let recOperation = "";
+  let fn = def[key];
+  if (fn !== undefined) {
+    let fn$1 = Primitive_option.valFromOption(fn);
+    recOperation = fn$1 === 0 ? embed(input, def) + (`["` + key + `"]`) : embed(input, fn$1);
+  } else {
+    let assumedHasTransform = Stdlib_Option.getOr(def.hasTransform, false);
+    let assumedIsAsync = Stdlib_Option.getOr(def.isAsync, false);
+    let compileNeeded = true;
+    let finalFn = 0;
+    while (compileNeeded) {
+      compileNeeded = false;
+      if (def.hasTransform === undefined) {
+        def.hasTransform = assumedHasTransform;
+      }
+      if (def.isAsync === undefined) {
+        def.isAsync = assumedIsAsync;
+      }
+      configurableValueOptions[valKey] = 0;
+      d(def, key, configurableValueOptions);
+      let fn$2 = compileDecoder(inputSchema, def, flag, defs);
+      valueOptions[valKey] = fn$2;
+      d(def, key, valueOptions);
+      finalFn = fn$2;
+      let actualHasTransform = def.hasTransform;
+      let actualIsAsync = def.isAsync;
+      if (actualHasTransform !== assumedHasTransform || actualIsAsync !== assumedIsAsync) {
+        assumedHasTransform = actualHasTransform;
+        assumedIsAsync = actualIsAsync;
+        ((delete def[key]));
+        compileNeeded = true;
+      }
+    };
+    recOperation = embed(input, finalFn);
+  }
+  let hasTransform = def.hasTransform === true;
+  let isAsync = def.isAsync;
+  let outputDecl = "";
+  let output;
+  if (hasTransform || isAsync) {
+    let outputVar = varWithoutAllocation(input.g);
+    outputDecl = `let ` + outputVar + `;`;
+    let output$1 = next(input, outputVar, expectedSchema, expectedSchema);
+    output$1.v = _var;
+    output$1.cp = outputVar + `=` + recOperation + `(` + input.i + `);`;
+    if (isAsync) {
+      output$1.f = output$1.f | 1;
+    }
+    output = output$1;
+  } else {
+    let output$2 = refine(input, expectedSchema, undefined, expectedSchema);
+    output$2.cp = recOperation + `(` + input.i + `);`;
+    output = output$2;
+  }
+  output.prev = undefined;
+  output.cp = outputDecl + mergeWithPathPrepend(output, input, undefined, undefined);
+  output.fz = undefined;
+  output.prev = input;
+  return output;
+}
+
+d(sp, "~standard", {
+  get: function () {
+    let schema = this;
+    return {
+      version: 1,
+      vendor: vendor,
+      validate: input => {
+        try {
+          return {
+            value: getDecoder(unknown, schema)(input)
+          };
+        } catch (exn) {
+          let error = getOrRethrow(exn);
+          return {
+            issues: [{
+                message: error.reason,
+                path: error.path === "" ? undefined : toArray(error.path)
+              }]
+          };
+        }
+      }
+    };
+  }
+});
+
+function parser(schema) {
+  return getDecoder(unknown, schema);
+}
+
+function asyncParser(schema) {
+  return getDecoder(unknown, schema, 1);
+}
+
+function decoder(from, to) {
+  return getDecoder(reverse(from), to);
+}
+
+function asyncDecoder(from, to) {
+  return getDecoder(reverse(from), to, 1);
+}
+
+function decoder1(schema) {
+  return getDecoder(schema, undefined);
+}
+
+function asyncDecoder1(schema) {
+  return getDecoder(schema, 1);
+}
+
+function getAssertResult() {
+  return cached("a", undefinedTag, s => {
+    s.const = (void 0);
+    s.decoder = literalDecoder;
+    s.noValidation = true;
+  });
+}
+
+function parseOrThrow(any, schema) {
+  return getDecoder(unknown, schema)(any);
+}
+
+function parseAsyncOrThrow(any, schema) {
+  return getDecoder(unknown, schema, 1)(any);
+}
+
+function assertOrThrow(any, schema) {
+  return getDecoder(unknown, schema, getAssertResult())(any);
+}
+
+function assertAsyncOrThrow(any, schema) {
+  return getDecoder(unknown, schema, getAssertResult(), 1)(any);
+}
+
+function decodeOrThrow(any, from, to) {
+  return getDecoder(reverse(from), to)(any);
+}
+
+function decodeAsyncOrThrow(any, from, to) {
+  return getDecoder(reverse(from), to, 1)(any);
+}
+
+function isAsync(schema) {
+  let v = schema.isAsync;
+  if (v !== undefined) {
+    return v;
+  } else {
+    let defs = 0;
+    try {
+      let input = operationArg(unknown, schema, 1, defs);
+      let output = parse$1(input);
+      let isAsync$1 = has(output.f, 1);
+      schema.isAsync = isAsync$1;
+      return isAsync$1;
+    } catch (exn) {
+      getOrRethrow(exn);
+      return false;
+    }
+  }
+}
+
+function wrapExnToFailure(exn) {
+  if ((exn&&exn.s===s)) {
+    return {
+      success: false,
+      error: exn
+    };
+  }
+  throw exn;
+}
+
+function js_safe(fn) {
+  try {
+    return {
+      success: true,
+      value: fn()
+    };
+  } catch (exn) {
+    return wrapExnToFailure(exn);
+  }
+}
+
+function js_safeAsync(fn) {
+  try {
+    return fn().then(value => ({
+      success: true,
+      value: value
+    }), wrapExnToFailure);
+  } catch (exn) {
+    return Promise.resolve(wrapExnToFailure(exn));
+  }
+}
+
+function make$1(namespace, name) {
+  return `m:` + namespace + `:` + name;
+}
+
+function internal(name) {
+  return `m:` + name;
+}
+
+let Id = {
+  make: make$1,
+  internal: internal
+};
+
+function get(schema, id) {
+  return schema[id];
+}
+
+function set(schema, id, metadata) {
+  let mut = copySchema(schema);
+  mut[id] = metadata;
+  return mut;
+}
+
+let defsPath = `#/$defs/`;
+
+function recursive(name, fn) {
+  let ref = defsPath + name;
+  let refSchema = base(refTag, false);
+  refSchema.$ref = ref;
+  refSchema.name = name;
+  refSchema.decoder = recursiveDecoder;
+  let isNestedRec = globalConfig.d;
+  if (!isNestedRec) {
+    globalConfig.d = {};
+  }
+  let def = fn(refSchema);
+  if (def.name) {
+    refSchema.name = def.name;
+  }
+  globalConfig.d[name] = def;
+  if (isNestedRec) {
+    return refSchema;
+  }
+  let schema = base(refTag, false);
+  schema.name = refSchema.name;
+  schema.$ref = ref;
+  schema.$defs = globalConfig.d;
+  schema.decoder = recursiveDecoder;
+  globalConfig.d = undefined;
+  return schema;
+}
+
+function noValidation(schema, value) {
+  let mut = copySchema(schema);
+  mut.noValidation = value;
+  return mut;
+}
+
+function internalRefine(schema, makeRefiner) {
+  return updateOutput(schema, mut => {
+    let refiner = makeRefiner(mut);
+    let existingRefiner = mut.refiner;
+    if (existingRefiner !== undefined) {
+      mut.refiner = input => {
+        let arr = existingRefiner(input);
+        let next = refiner(input);
+        for (let i = 0, i_finish = next.length; i < i_finish; ++i) {
+          arr.push(next[i]);
+        }
+        return arr;
+      };
+    } else {
+      mut.refiner = refiner;
+    }
+  });
+}
+
+function refine$1(schema, refineCheck, error, path) {
+  let message = error !== undefined ? error : "Refinement failed";
+  let extraPath = path !== undefined ? fromArray(path) : "";
+  return internalRefine(schema, param => (input => {
+    let embeddedCheck = embed(input, refineCheck);
+    return [{
+        c: inputVar => embeddedCheck + `(` + inputVar + `)`,
+        f: invalidInputBuilder(undefined, extraPath, message, undefined)
+      }];
+  }));
+}
+
+function getMutErrorMessage(mut) {
+  let em = mut.errorMessage ? copy(mut.errorMessage) : ({});
+  mut.errorMessage = em;
+  return em;
+}
+
+function transform(schema, transformer) {
+  return updateOutput(schema, mut => {
+    mut.parser = input => {
+      let match = transformer(effectCtx(input));
+      let parser = match.p;
+      if (parser !== undefined) {
+        if (match.a !== undefined) {
+          return invalidOperation(input, `The S.transform doesn't allow parser and asyncParser at the same time. Remove parser in favor of asyncParser`);
+        } else {
+          return embedTransformation(input, parser, false);
+        }
+      }
+      let asyncParser = match.a;
+      if (asyncParser !== undefined) {
+        return embedTransformation(input, asyncParser, true);
+      } else if (match.s !== undefined) {
+        return invalidOperation(input, `The S.transform parser is missing`);
+      } else {
+        return refine(input, undefined, undefined, input.e.to);
+      }
+    };
+    let to = copySchema(unknown);
+    mut.to = (to.serializer = input => {
+      let match = transformer(effectCtx(input));
+      let serializer = match.s;
+      if (serializer !== undefined) {
+        return embedTransformation(input, serializer, false);
+      } else if (match.a !== undefined || match.p !== undefined) {
+        return invalidOperation(input, `The S.transform serializer is missing`);
+      } else {
+        return refine(input, undefined, undefined, input.e.to);
+      }
+    }, to);
+    ((delete mut.isAsync));
+  });
+}
+
+function nullAsUnit() {
+  let s = copySchema(nullLiteral());
+  s.to = unit();
+  return s;
 }
 
 function getWithDefault(schema, $$default) {
@@ -2925,7 +2925,7 @@ function getWithDefault(schema, $$default) {
       let item;
       if (len !== 1) {
         if (len !== 0) {
-          item = factory$1(outputItems);
+          item = unionFactory(outputItems);
         } else {
           let message = `Can't set default for ` + toExpression(mut);
           throw new Error(`[Sury] ` + message);
@@ -2933,7 +2933,7 @@ function getWithDefault(schema, $$default) {
       } else {
         item = outputItems[0];
       }
-      let originalItem = originalItems.length !== 1 ? factory$1(originalItems) : originalItems[0];
+      let originalItem = originalItems.length !== 1 ? unionFactory(originalItems) : originalItems[0];
       if ($$default.TAG === "Value") {
         let v = $$default._0;
         try {
@@ -3056,7 +3056,7 @@ function jsonEncoderFn(input, target) {
     return output;
   }
   if (toTagFlag & 64) {
-    let jsonExpected$2 = factory(unknown);
+    let jsonExpected$2 = dictFactory(unknown);
     let output$1 = parse$1(refine(input, unknown, undefined, jsonExpected$2));
     output$1.s.additionalItems = json();
     output$1.e = target;
@@ -3125,7 +3125,7 @@ function jsonDecoderFn(input) {
     if (match === "strip" || match === "strict") {
       match === "strip";
     } else {
-      let expected$1 = factory(json());
+      let expected$1 = dictFactory(json());
       expected$1.to = input.e.to;
       return parse$1(refine(input, undefined, undefined, expected$1));
     }
@@ -3138,10 +3138,10 @@ function jsonDecoderFn(input) {
     let keys = Object.keys(input.s.properties);
     for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
       let key = keys[idx];
-      let itemVal = get(input, key);
+      let itemVal = valGet(input, key);
       itemVal.io = false;
       if (itemVal.s.type === unionTag && itemVal.s.has[undefinedTag]) {
-        itemVal.e = factory$1([
+        itemVal.e = unionFactory([
           unit(),
           json()
         ]);
@@ -3200,7 +3200,7 @@ function json() {
       bool(),
       float(),
       nullLiteral(),
-      factory(jsonRef),
+      dictFactory(jsonRef),
       array(jsonRef)
     ];
     let has = {};
@@ -3664,132 +3664,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = `~` + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
-        throw new Error(`[Sury] ` + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
-    throw new Error(`[Sury] ` + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
 function prepareShapedSerializerAcc(acc, input) {
   let match = input.e;
   let from = match.from;
@@ -3846,6 +3720,132 @@ function prepareShapedSerializerAcc(acc, input) {
   }
 }
 
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = `~` + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = optionFactory(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
+        throw new Error(`[Sury] ` + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
+    throw new Error(`[Sury] ` + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
 function getShapedParserOutput(input, targetSchema) {
   let from = targetSchema.from;
   let fromFlattened = targetSchema.fromFlattened;
@@ -3899,6 +3899,12 @@ function getValByFrom(_input, from, _idx) {
   };
 }
 
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
+}
+
 function shapedParser(input) {
   let flattened = input.e.flattened;
   if (flattened !== undefined) {
@@ -3919,12 +3925,6 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return markOutput(output, input);
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
 }
 
 function shape(schema, definer) {
@@ -3978,7 +3978,7 @@ function object(definer) {
     field(tag$1, definitionToSchema(asValue));
   };
   let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = factory$2(schema, undefined);
+    let schema$1 = optionFactory(schema, undefined);
     return field(fieldName, getWithDefault(schema$1, {
       TAG: "Value",
       _0: or
@@ -4046,14 +4046,14 @@ let ctx = {
   m: matches
 };
 
-function factory$3(definer) {
+function factory(definer) {
   return definitionToSchema(definer(ctx));
 }
 
 let js_schema = definitionToSchema;
 
 function $$enum(values) {
-  return factory$1(values.map(js_schema));
+  return unionFactory(values.map(js_schema));
 }
 
 function compactColumnsDecoder(input) {
@@ -4227,21 +4227,15 @@ function compactColumns(inputSchema) {
 }
 
 function nullAsOption(item) {
-  return factory$2(item, nullAsUnit());
+  return optionFactory(item, nullAsUnit());
 }
 
 function $$null(item) {
-  return factory$1([
+  return unionFactory([
     item,
     nullLiteral()
   ]);
 }
-
-function option(item) {
-  return factory$2(item, unit());
-}
-
-optionForwardRef.contents = option;
 
 function tuple1(v0) {
   return tuple(s => s.item(0, v0));
@@ -4407,7 +4401,7 @@ function trim(schema) {
 }
 
 function nullable(schema) {
-  return factory$1([
+  return unionFactory([
     schema,
     unit(),
     nullLiteral()
@@ -4415,7 +4409,7 @@ function nullable(schema) {
 }
 
 function nullableAsOption(schema) {
-  return factory$1([
+  return unionFactory([
     schema,
     unit(),
     nullAsUnit()
@@ -4449,7 +4443,7 @@ function js_is(a, b) {
 }
 
 function js_union(values) {
-  return factory$1(values.map(definitionToSchema));
+  return unionFactory(values.map(definitionToSchema));
 }
 
 function customBuilder(fn) {
@@ -4515,7 +4509,7 @@ function js_asyncDecoderAssert(schema, assertFn) {
 }
 
 function js_optional(schema, maybeOr) {
-  let schema$1 = factory$1([
+  let schema$1 = unionFactory([
     schema,
     unit()
   ]);
@@ -4538,13 +4532,13 @@ function js_optional(schema, maybeOr) {
 
 function js_nullable(schema, maybeOr) {
   if (maybeOr === undefined) {
-    return factory$1([
+    return unionFactory([
       schema,
       nullLiteral()
     ]);
   }
   let or = Primitive_option.valFromOption(maybeOr);
-  let schema$1 = factory$1([
+  let schema$1 = unionFactory([
     schema,
     nullAsUnit()
   ]);
@@ -4945,8 +4939,8 @@ function fromJSONSchema(jsonSchema) {
         let additionalProperties$1 = jsonSchema.additionalProperties;
         schema = additionalProperties$1 !== undefined ? (
             typeof additionalProperties$1 !== "object" ? (
-                additionalProperties$1 === false ? strict(object(param => {})) : factory(anySchema)
-              ) : factory(fromJSONSchema(additionalProperties$1))
+                additionalProperties$1 === false ? strict(object(param => {})) : dictFactory(anySchema)
+              ) : dictFactory(fromJSONSchema(additionalProperties$1))
           ) : definitionToSchema();
       }
     } else if (type_$1 === "array") {
@@ -4980,7 +4974,7 @@ function fromJSONSchema(jsonSchema) {
     if (definitions$1 !== undefined) {
       let len = definitions$1.length;
       schema = len !== 1 ? (
-          len !== 0 ? factory$1(definitions$1.map(definitionToSchema$1)) : anySchema
+          len !== 0 ? unionFactory(definitions$1.map(definitionToSchema$1)) : anySchema
         ) : definitionToSchema$1(definitions$1[0]);
     } else if (definitions !== undefined) {
       let len$1 = definitions.length;
@@ -5029,7 +5023,7 @@ function fromJSONSchema(jsonSchema) {
         } else if (primitives !== undefined) {
           let len$3 = primitives.length;
           schema = len$3 !== 1 ? (
-              len$3 !== 0 ? factory$1(primitives.map(primitiveToSchema)) : anySchema
+              len$3 !== 0 ? unionFactory(primitives.map(primitiveToSchema)) : anySchema
             ) : parse(primitives[0]);
         } else {
           let $$const = jsonSchema.const;
@@ -5040,7 +5034,7 @@ function fromJSONSchema(jsonSchema) {
             let exit$2 = 0;
             let exit$3 = 0;
             if (Array.isArray(type_$2)) {
-              schema = factory$1(type_$2.map(type_ => fromJSONSchema(Object.assign({}, jsonSchema, {
+              schema = unionFactory(type_$2.map(type_ => fromJSONSchema(Object.assign({}, jsonSchema, {
                 type: Primitive_option.some(type_)
               }))));
             } else if (type_$2 === "string") {
@@ -5257,13 +5251,13 @@ let Flag = {
 
 let literal = js_schema;
 
-let dict = factory;
+let dict = dictFactory;
 
-let union = factory$1;
+let union = unionFactory;
 
 let Schema$1 = {};
 
-let schema = factory$3;
+let schema = factory;
 
 let $$Object = {};
 
@@ -5274,7 +5268,7 @@ let Option = {
 
 let Metadata = {
   Id: Id,
-  get: get$1,
+  get: get,
   set: set
 };
 

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -382,6 +382,10 @@ let $$Error = {
   make: make
 };
 
+let optionForwardRef = {
+  contents: s => s
+};
+
 function embed(b, value) {
   let e = b.g.e;
   let l = e.length;
@@ -1832,6 +1836,14 @@ function objectDecoder(unknownInput) {
       itemInput$1.u = isUnion;
       if (isJsonParent && schema$1.type === unionTag && schema$1.has[undefinedTag]) {
         itemInput$1.i = `(` + itemInput$1.i + `??null)`;
+      }
+      if (!isJsonParent) {
+        let vs = input.s.additionalItems;
+        if (vs === "strip" || vs === "strict") {
+          vs === "strip";
+        } else if (vs === itemInput$1.s && itemInput$1.s.type !== unknownTag && !isOptional(itemInput$1.s)) {
+          itemInput$1.s = optionForwardRef.contents(itemInput$1.s);
+        }
       }
       let itemOutput$1 = parse$1(itemInput$1);
       if (isUnion && constField in schema$1) {
@@ -3561,111 +3573,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3763,70 +3670,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = `~` + fieldName;
@@ -3891,6 +3734,175 @@ function nested(fieldName) {
   };
   parentCtx[cacheId] = ctx$1;
   return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function shapedParser(input) {
@@ -4234,6 +4246,8 @@ function $$null(item) {
 function option(item) {
   return factory$2(item, unit());
 }
+
+optionForwardRef.contents = option;
 
 function tuple1(v0) {
   return tuple(s => s.item(0, v0));

--- a/packages/sury/tests/S_to_dictToObject_test.res
+++ b/packages/sury/tests/S_to_dictToObject_test.res
@@ -10,11 +10,20 @@ open Vitest
 //     zoo: S.option(S.float),
 //   }))
 //
-// Parsing fully-populated input already works (thanks to the #265 union-hoist
-// fix). The remaining gaps are captured below. Each test currently asserts the
-// *actual (broken)* behavior so the suite stays green — every one carries a
-// FIXME with the intended `SHOULD:` behavior to switch to as its milestone
-// lands. Agreed semantics: `None` <-> an absent dict key.
+// Milestone 1 is implemented via "Option A": a `dict<V>` is
+// `additionalProperties: V` with no required keys, so a value read by key may be
+// absent. `B.Val.get` reads each additionalProperties value, and objectDecoder
+// now models that read as optional (`option<V>`) when `V` is a concrete type
+// that can't itself be undefined. The existing union coercion then handles a
+// missing key uniformly:
+//   - optional target field  -> absence decodes to None
+//   - required `string` field -> absence stringifies to "undefined" (the
+//     reversibility-locked None <-> "undefined" sentinel; tightening this is a
+//     deferred "tier fix")
+//   - required `bigint` field -> absence errors (no undefined coercion)
+//
+// The remaining gap (encoding back to dict<string>) is still pinned against its
+// current crash with a FIXME for milestone 2-3.
 
 let makeSchema = () =>
   S.dict(S.string)->S.to(
@@ -36,34 +45,59 @@ test("Parses input with every field present", t => {
   )
 })
 
-test("FIXME [milestone 1] absent optional field should decode to None", t => {
+test("[milestone 1] absent optional field decodes to None", t => {
   let schema = makeSchema()
 
-  // SHOULD: an absent `zoo` key decodes to None
-  //   t->Assert.deepEqual(
-  //     %raw(`{"foo":"a","bar":"7"}`)->S.parseOrThrow(~to=schema),
-  //     {"foo": "a", "bar": 7n, "zoo": None},
-  //   )
-  // ACTUAL (broken): a genuinely-missing key throws. The option's None branch is
-  // pinned to the *literal string* "undefined" (because the source is
-  // dict<string> and the whole option is coerced from a string), so real absence
-  // is not recognized as None.
-  t->U.assertThrowsMessage(
-    () => %raw(`{"foo":"a","bar":"7"}`)->S.parseOrThrow(~to=schema),
-    `Failed at ["zoo"]: Expected number | undefined, received undefined
-- At ["zoo"]: Expected number, received undefined`,
+  // A missing `zoo` key is an absent additionalProperty -> None (no longer throws).
+  t->Assert.deepEqual(
+    %raw(`{"foo":"a","bar":"7"}`)->S.parseOrThrow(~to=schema),
+    {"foo": "a", "bar": 7n, "zoo": None},
   )
 })
 
-test("FIXME [milestone 1] None currently comes from the string \"undefined\", not an absent key", t => {
+test("[milestone 1] absent required bigint field errors", t => {
   let schema = makeSchema()
 
-  // ACTUAL (broken): the literal string "undefined" is what decodes to None today.
-  // SHOULD: once `None` <-> absent key, this string should instead fail coercion
-  // (it is not a valid number), and absence should be the only None source.
+  // Modeling the read as `option<string>` doesn't loosen required fields whose
+  // target can't accept undefined: a missing `bar` (coerced to bigint) errors.
+  t->U.assertThrowsMessage(
+    () => %raw(`{"foo":"a","zoo":"1.5"}`)->S.parseOrThrow(~to=schema),
+    `Failed at ["bar"]: Expected string | undefined, received undefined
+- At ["bar"]: Can't decode undefined to bigint. Use S.to to define a custom decoder`,
+  )
+})
+
+test("[milestone 1] absent required string field stringifies to \"undefined\" (deferred tier fix)", t => {
+  let schema = makeSchema()
+
+  // A missing `foo` (required string) flows through the option's undefined arm,
+  // which the string coercion turns into the literal "undefined" — the mirror of
+  // the `string -> option` `"undefined" <-> None` sentinel, locked in by
+  // reversibility. Tightening this to an error is a deferred "tier fix".
+  t->Assert.deepEqual(
+    %raw(`{"bar":"7","zoo":"1.5"}`)->S.parseOrThrow(~to=schema),
+    {"foo": "undefined", "bar": 7n, "zoo": Some(1.5)},
+  )
+})
+
+test("the literal string \"undefined\" decodes to None (string sentinel)", t => {
+  let schema = makeSchema()
+
+  // Present-value coercion routes through the option's string arm, so the literal
+  // string "undefined" maps to None as well — the same sentinel as above.
   t->Assert.deepEqual(
     %raw(`{"foo":"a","bar":"123","zoo":"undefined"}`)->S.parseOrThrow(~to=schema),
     {"foo": "a", "bar": 123n, "zoo": None},
+  )
+})
+
+test("[milestone 1] compiled parse code models each dict read as optional", t => {
+  let schema = makeSchema()
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[9](i);for(let v0 in i){try{let v1=i[v0];typeof v1==="string"||e[0](v1);}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}let v3=i["foo"],v5=i["bar"],v7=i["zoo"];if(v3===void 0){v3="undefined"}else if(!(typeof v3==="string")){e[1](v3)}if(typeof v5==="string"){let v4;try{v4=BigInt(v5)}catch(_){e[2](v5)}v5=v4}else if(v5===void 0){e[4](v5,e[3])}else{e[5](v5)}if(typeof v7==="string"){try{let v6=+v7;!Number.isNaN(v6)||e[6](v7);v7=v6}catch(e0){if(v7==="undefined"){v7=void 0}else{e[7](v7,e0)}}}else if(!(v7===void 0)){e[8](v7)}return {"foo":v3,"bar":v5,"zoo":v7,}}`,
   )
 })
 

--- a/packages/sury/tests/S_to_dictToObject_test.res
+++ b/packages/sury/tests/S_to_dictToObject_test.res
@@ -1,0 +1,88 @@
+open Vitest
+
+// Tracks support for coercing a `dict<string>` into a structured object whose
+// fields need their own coercion (string -> bigint) and include an optional
+// field (string -> option<float>):
+//
+//   S.dict(S.string)->S.to(S.schema({
+//     foo: S.string,
+//     bar: S.bigint,
+//     zoo: S.option(S.float),
+//   }))
+//
+// Parsing fully-populated input already works (thanks to the #265 union-hoist
+// fix). The remaining gaps are captured below. Each test currently asserts the
+// *actual (broken)* behavior so the suite stays green — every one carries a
+// FIXME with the intended `SHOULD:` behavior to switch to as its milestone
+// lands. Agreed semantics: `None` <-> an absent dict key.
+
+let makeSchema = () =>
+  S.dict(S.string)->S.to(
+    S.schema(s =>
+      {
+        "foo": s.matches(S.string),
+        "bar": s.matches(S.bigint),
+        "zoo": s.matches(S.option(S.float)),
+      }
+    ),
+  )
+
+test("Parses input with every field present", t => {
+  let schema = makeSchema()
+
+  t->Assert.deepEqual(
+    %raw(`{"foo":"a","bar":"123","zoo":"1.5"}`)->S.parseOrThrow(~to=schema),
+    {"foo": "a", "bar": 123n, "zoo": Some(1.5)},
+  )
+})
+
+test("FIXME [milestone 1] absent optional field should decode to None", t => {
+  let schema = makeSchema()
+
+  // SHOULD: an absent `zoo` key decodes to None
+  //   t->Assert.deepEqual(
+  //     %raw(`{"foo":"a","bar":"7"}`)->S.parseOrThrow(~to=schema),
+  //     {"foo": "a", "bar": 7n, "zoo": None},
+  //   )
+  // ACTUAL (broken): a genuinely-missing key throws. The option's None branch is
+  // pinned to the *literal string* "undefined" (because the source is
+  // dict<string> and the whole option is coerced from a string), so real absence
+  // is not recognized as None.
+  t->U.assertThrowsMessage(
+    () => %raw(`{"foo":"a","bar":"7"}`)->S.parseOrThrow(~to=schema),
+    `Failed at ["zoo"]: Expected number | undefined, received undefined
+- At ["zoo"]: Expected number, received undefined`,
+  )
+})
+
+test("FIXME [milestone 1] None currently comes from the string \"undefined\", not an absent key", t => {
+  let schema = makeSchema()
+
+  // ACTUAL (broken): the literal string "undefined" is what decodes to None today.
+  // SHOULD: once `None` <-> absent key, this string should instead fail coercion
+  // (it is not a valid number), and absence should be the only None source.
+  t->Assert.deepEqual(
+    %raw(`{"foo":"a","bar":"123","zoo":"undefined"}`)->S.parseOrThrow(~to=schema),
+    {"foo": "a", "bar": 123n, "zoo": None},
+  )
+})
+
+test("FIXME [milestone 2-3] encoding back to dict<string> should round-trip", t => {
+  let schema = makeSchema()
+
+  // SHOULD: encode the object back into a dict of strings (None -> absent key)
+  //   t->Assert.deepEqual(
+  //     {"foo": "a", "bar": 123n, "zoo": Some(1.5)}->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+  //     %raw(`{"foo":"a","bar":"123","zoo":"1.5"}`),
+  //   )
+  //   t->U.assertReverseParsesBack(schema, {"foo": "a", "bar": 7n, "zoo": None})
+  // ACTUAL (broken): building the object->dict reverse crashes at *build* time.
+  // A fixed-property object's `additionalItems` mode (Strip/Strict) is cast to a
+  // schema in `B.dynamicScope`, then reaches `isLiteral` (`"const" in "strip"`).
+  t->Assert.throws(
+    () => {
+      let _ = S.decoder(~from=schema, ~to=S.unknown)
+    },
+    ~expectations={message: "Cannot use 'in' operator to search for 'const' in"},
+  )
+})

--- a/packages/sury/tests/S_to_dictToObject_test.res
+++ b/packages/sury/tests/S_to_dictToObject_test.res
@@ -12,10 +12,9 @@ open Vitest
 //
 // Milestone 1 is implemented via "Option A": a `dict<V>` is
 // `additionalProperties: V` with no required keys, so a value read by key may be
-// absent. `B.Val.get` reads each additionalProperties value, and objectDecoder
-// now models that read as optional (`option<V>`) when `V` is a concrete type
-// that can't itself be undefined. The existing union coercion then handles a
-// missing key uniformly:
+// absent. `B.Val.get` reads each additionalProperties value and models that read
+// as optional (`option<V>`) when `V` is a concrete type that can't itself be
+// undefined. The existing union coercion then handles a missing key uniformly:
 //   - optional target field  -> absence decodes to None
 //   - required `string` field -> absence stringifies to "undefined" (the
 //     reversibility-locked None <-> "undefined" sentinel; tightening this is a


### PR DESCRIPTION
## Summary

This PR refactors the internal value access mechanism and union dispatch logic to support coercing `dict<V>` into structured objects with field-level transformations. The changes reorganize decoder implementations and introduce new helper functions for union variant selection and per-variant encoding.

## Key Changes

- **Renamed `get` → `valGet`**: The internal function for accessing nested values by key is renamed and repositioned in the module structure to clarify its role in the val access pipeline.

- **Extracted union dispatch helpers**: New functions `toKey`, `isPriority`, `isSelfDecodeNoop`, `isWiderUnionSchema`, `canDispatchPerVariant`, and `perVariantVal` consolidate union variant selection logic, enabling more flexible dispatch strategies for coercion scenarios.

- **Added `encoder` function**: Implements per-variant encoding for union types, allowing selective transformation when the target union is wider or requires explicit variant dispatch.

- **Introduced `dictFactory`**: Factory function for creating dict schemas with `additionalProperties` semantics, supporting the dict-to-object coercion pattern.

- **Moved `instance` and `instanceDecoder`**: Repositioned instance type handling alongside other schema factories for better code organization.

- **Moved `never_` and `neverBuilderFn`**: Consolidated never-type handling in the schema factory section.

- **Added test coverage**: New test file `S_to_dictToObject_test.res` documents the dict-to-object coercion milestone with detailed comments on the implementation strategy (Option A: modeling dict value reads as optional unions).

## Implementation Details

The refactoring maintains the existing decode pipeline semantics while improving the organization of union-related logic. The new helper functions enable the compiler to make smarter decisions about when to dispatch per-variant vs. using the default union coercion path, which is essential for supporting transformations on dict values that may be absent.

The test file includes a FIXME for encoding back to `dict<string>` (milestone 2-3), indicating this is a staged implementation addressing the decoding path first.

https://claude.ai/code/session_011GzpHbNmjpmdHHZr8jLCAV