### PR TITLE
Extract atomic type-check conditions for union dispatch sync

### DIFF
--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1878,18 +1878,19 @@ let int32FormatValidation = (~inputVar) => {
 
 // Atomic type-narrow conditions, shared by the type decoders and the union
 // dispatch (`typeCheckCond`) so the two can't drift.
-let typeofCond = (tag: tag, ~inputVar) => `typeof ${inputVar}==="${(tag :> string)}"`
-let nanCond = (~inputVar) => `Number.isNaN(${inputVar})`
-let isArrayCond = (~inputVar) => `Array.isArray(${inputVar})`
-let objectTagCond = (~inputVar) => `${typeofCond(objectTag, ~inputVar)}&&${inputVar}`
-let instanceofCond = (b: val, class, ~inputVar) => `${inputVar} instanceof ${b->B.embed(class)}`
+let typeofCond = (~tag: tag) => (~inputVar): string => `typeof ${inputVar}==="${(tag :> string)}"`
+let nanCond = (~inputVar): string => `Number.isNaN(${inputVar})`
+let isArrayCond = (~inputVar): string => `Array.isArray(${inputVar})`
+let objectTagCond = (~inputVar): string => `${typeofCond(~tag=objectTag)(~inputVar)}&&${inputVar}`
+let instanceofCond = (~b: val, ~class) =>
+  (~inputVar): string => `${inputVar} instanceof ${b->B.embed(class)}`
 
 let numberDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
     let checks = [
       {
-        cond: (~inputVar) => typeofCond(numberTag, ~inputVar),
+        cond: typeofCond(~tag=numberTag),
         fail: B.failInvalidType,
       },
     ]
@@ -1971,7 +1972,7 @@ and stringDecoderFn = (~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => typeofCond(stringTag, ~inputVar),
+          cond: typeofCond(~tag=stringTag),
           fail: B.failInvalidType,
         },
       ],
@@ -2015,7 +2016,7 @@ let booleanDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => typeofCond(booleanTag, ~inputVar),
+          cond: typeofCond(~tag=booleanTag),
           fail: B.failInvalidType,
         },
       ],
@@ -2051,7 +2052,7 @@ let bigintDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => typeofCond(bigintTag, ~inputVar),
+          cond: typeofCond(~tag=bigintTag),
           fail: B.failInvalidType,
         },
       ],
@@ -2086,7 +2087,7 @@ let symbolDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => typeofCond(symbolTag, ~inputVar),
+          cond: typeofCond(~tag=symbolTag),
           fail: B.failInvalidType,
         },
       ],
@@ -2158,7 +2159,7 @@ let literalDecoder = Builder.make((~input) => {
         ~schema=expectedSchema,
         ~checks=[
           {
-            cond: (~inputVar) => nanCond(~inputVar),
+            cond: nanCond,
             fail: B.failInvalidType,
           },
         ],
@@ -2616,7 +2617,7 @@ let instanceDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => instanceofCond(input, input.expected.class, ~inputVar),
+          cond: instanceofCond(~b=input, ~class=input.expected.class),
           fail: B.failInvalidType,
         },
       ],
@@ -2646,9 +2647,9 @@ let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
   } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
     isArrayCond(~inputVar)
   } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-    instanceofCond(input, schema.class, ~inputVar)
+    instanceofCond(~b=input, ~class=schema.class)(~inputVar)
   } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
-    let typeofCheck = typeofCond(numberTag, ~inputVar)
+    let typeofCheck = typeofCond(~tag=numberTag)(~inputVar)
     if input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation) {
       typeofCheck
     } else {
@@ -2668,7 +2669,7 @@ let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
     )
   ) {
     // literals reuse this typeof check; their per-const check stays in the case body
-    typeofCond(schema.tag, ~inputVar)
+    typeofCond(~tag=schema.tag)(~inputVar)
   } else {
     // Unreachable: catch-all tags use the `unknown` narrow, never this path.
     InternalError.panic(`Unexpected union variant tag: ${(schema.tag :> string)}`)
@@ -2808,7 +2809,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     if !isArrayInput {
       checks
       ->Array.push({
-        cond: (~inputVar) => isArrayCond(~inputVar),
+        cond: isArrayCond,
         fail: B.failInvalidType,
       })
       ->ignore
@@ -2958,7 +2959,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     if !isObjectInput {
       checks
       ->Array.push({
-        cond: (~inputVar) => objectTagCond(~inputVar),
+        cond: objectTagCond,
         fail: B.failInvalidType,
       })
       ->ignore

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -2672,7 +2672,7 @@ let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
     typeofCond(~tag=schema.tag)(~inputVar)
   } else {
     // Unreachable: catch-all tags use the `unknown` narrow, never this path.
-    InternalError.panic(`Unexpected union variant tag: ${(schema.tag :> string)}`)
+    ""
   }
 }
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -4232,6 +4232,11 @@ module Union = {
                 // value through instead of re-emitting the check.
                 narrow.const = schema.const
               }
+              // The branch must be per-invocation, not hoisted to construction:
+              // this same narrow is re-decoded during `.to` per-variant
+              // conversion, sometimes with the union's `unknown` input (emit the
+              // discriminant) and sometimes with a concrete coerced value
+              // (delegate to the member's own decoder).
               narrow.decoder = (~input) =>
                 if input.schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.unknown) {
                   input->B.refine(

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1927,10 +1927,8 @@ let int32FormatValidation = (~inputVar) => {
 // (adding its own validation, e.g. int32 or the object `!isArray` guard) instead
 // of re-spelling the strings.
 let typeofCond = (tag: tag, ~inputVar) => `typeof ${inputVar}==="${(tag :> string)}"`
-let nonNaNCond = (~inputVar) => `!Number.isNaN(${inputVar})`
 let nanCond = (~inputVar) => `Number.isNaN(${inputVar})`
 let isArrayCond = (~inputVar) => `Array.isArray(${inputVar})`
-let nonArrayCond = (~inputVar) => `!Array.isArray(${inputVar})`
 let objectTagCond = (~inputVar) => `${typeofCond(objectTag, ~inputVar)}&&${inputVar}`
 let instanceofCond = (b: val, class, ~inputVar) => `${inputVar} instanceof ${b->B.embed(class)}`
 
@@ -1955,7 +1953,7 @@ let numberDecoder = Builder.make((~input) => {
       if !(input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation)) {
         checks
         ->Array.push({
-          cond: (~inputVar) => nonNaNCond(~inputVar),
+          cond: (~inputVar) => `!${nanCond(~inputVar)}`,
           fail: B.failInvalidType,
         })
         ->ignore
@@ -1981,7 +1979,7 @@ let numberDecoder = Builder.make((~input) => {
         cond: (~inputVar as _) =>
           switch input.expected.format {
           | Some(Int32) => int32FormatValidation(~inputVar=outputVar)
-          | _ => nonNaNCond(~inputVar=outputVar)
+          | _ => `!${nanCond(~inputVar=outputVar)}`
           },
         fail: B.failInvalidType,
       },
@@ -2930,7 +2928,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         // this is why the check is a must have
         checks
         ->Array.push({
-          cond: (~inputVar) => nonArrayCond(~inputVar),
+          cond: (~inputVar) => `!${isArrayCond(~inputVar)}`,
           fail: B.failInvalidType,
         })
         ->ignore
@@ -3728,7 +3726,7 @@ module Union = {
   let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
     let tagFlag = schema.tag->TagFlag.get
     if tagFlag->Flag.unsafeHas(TagFlag.object) {
-      `${objectTagCond(~inputVar)}&&${nonArrayCond(~inputVar)}`
+      `${objectTagCond(~inputVar)}&&!${isArrayCond(~inputVar)}`
     } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
       isArrayCond(~inputVar)
     } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
@@ -3738,7 +3736,7 @@ module Union = {
       if input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation) {
         typeofCheck
       } else {
-        `${typeofCheck}&&${nonNaNCond(~inputVar)}`
+        `${typeofCheck}&&!${nanCond(~inputVar)}`
       }
     } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
       nanCond(~inputVar)

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1921,12 +1921,25 @@ let int32FormatValidation = (~inputVar) => {
   `${inputVar}<=2147483647&&${inputVar}>=-2147483648&&${inputVar}%1===0`
 }
 
+// Atomic type-narrow conditions — the single source of truth for the type-check
+// strings, shared by the type decoders below and the union dispatch
+// (`typeCheckCond`) so the two can't drift. Each call site composes these
+// (adding its own validation, e.g. int32 or the object `!isArray` guard) instead
+// of re-spelling the strings.
+let typeofCond = (tag: tag, ~inputVar) => `typeof ${inputVar}==="${(tag :> string)}"`
+let nonNaNCond = (~inputVar) => `!Number.isNaN(${inputVar})`
+let nanCond = (~inputVar) => `Number.isNaN(${inputVar})`
+let isArrayCond = (~inputVar) => `Array.isArray(${inputVar})`
+let nonArrayCond = (~inputVar) => `!Array.isArray(${inputVar})`
+let objectTagCond = (~inputVar) => `${typeofCond(objectTag, ~inputVar)}&&${inputVar}`
+let instanceofCond = (b: val, class, ~inputVar) => `${inputVar} instanceof ${b->B.embed(class)}`
+
 let numberDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
   if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
     let checks = [
       {
-        cond: (~inputVar) => `typeof ${inputVar}==="${(numberTag :> string)}"`,
+        cond: (~inputVar) => typeofCond(numberTag, ~inputVar),
         fail: B.failInvalidType,
       },
     ]
@@ -1942,7 +1955,7 @@ let numberDecoder = Builder.make((~input) => {
       if !(input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation)) {
         checks
         ->Array.push({
-          cond: (~inputVar) => `!Number.isNaN(${inputVar})`,
+          cond: (~inputVar) => nonNaNCond(~inputVar),
           fail: B.failInvalidType,
         })
         ->ignore
@@ -1968,7 +1981,7 @@ let numberDecoder = Builder.make((~input) => {
         cond: (~inputVar as _) =>
           switch input.expected.format {
           | Some(Int32) => int32FormatValidation(~inputVar=outputVar)
-          | _ => `!Number.isNaN(${outputVar})`
+          | _ => nonNaNCond(~inputVar=outputVar)
           },
         fail: B.failInvalidType,
       },
@@ -2012,7 +2025,7 @@ and stringDecoderFn = (~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => `typeof ${inputVar}==="${(stringTag :> string)}"`,
+          cond: (~inputVar) => typeofCond(stringTag, ~inputVar),
           fail: B.failInvalidType,
         },
       ],
@@ -2056,7 +2069,7 @@ let booleanDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => `typeof ${inputVar}==="${(booleanTag :> string)}"`,
+          cond: (~inputVar) => typeofCond(booleanTag, ~inputVar),
           fail: B.failInvalidType,
         },
       ],
@@ -2093,7 +2106,7 @@ let bigintDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => `typeof ${inputVar}==="${(bigintTag :> string)}"`,
+          cond: (~inputVar) => typeofCond(bigintTag, ~inputVar),
           fail: B.failInvalidType,
         },
       ],
@@ -2129,7 +2142,7 @@ let symbolDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => `typeof ${inputVar}==="${(symbolTag :> string)}"`,
+          cond: (~inputVar) => typeofCond(symbolTag, ~inputVar),
           fail: B.failInvalidType,
         },
       ],
@@ -2201,7 +2214,7 @@ let literalDecoder = Builder.make((~input) => {
         ~schema=expectedSchema,
         ~checks=[
           {
-            cond: (~inputVar) => `Number.isNaN(${inputVar})`,
+            cond: (~inputVar) => nanCond(~inputVar),
             fail: B.failInvalidType,
           },
         ],
@@ -2757,7 +2770,7 @@ and arrayDecoder: builder = (~input as unknownInput) => {
     if !isArrayInput {
       checks
       ->Array.push({
-        cond: (~inputVar) => `Array.isArray(${inputVar})`,
+        cond: (~inputVar) => isArrayCond(~inputVar),
         fail: B.failInvalidType,
       })
       ->ignore
@@ -2907,7 +2920,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
     if !isObjectInput {
       checks
       ->Array.push({
-        cond: (~inputVar) => `typeof ${inputVar}==="${(objectTag :> string)}"&&${inputVar}`,
+        cond: (~inputVar) => objectTagCond(~inputVar),
         fail: B.failInvalidType,
       })
       ->ignore
@@ -2917,7 +2930,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         // this is why the check is a must have
         checks
         ->Array.push({
-          cond: (~inputVar) => `!Array.isArray(${inputVar})`,
+          cond: (~inputVar) => nonArrayCond(~inputVar),
           fail: B.failInvalidType,
         })
         ->ignore
@@ -3210,7 +3223,7 @@ let instanceDecoder = Builder.make((~input) => {
       ~schema=input.expected,
       ~checks=[
         {
-          cond: (~inputVar) => `${inputVar} instanceof ${input->B.embed(input.expected.class)}`,
+          cond: (~inputVar) => instanceofCond(input, input.expected.class, ~inputVar),
           fail: B.failInvalidType,
         },
       ],
@@ -3707,36 +3720,31 @@ module Union = {
     }
   })
 
-  // The type-narrow condition for a union variant, emitted directly from the tag
-  // instead of by referencing a per-type factory — that's what lets unused type
-  // decoders tree-shake (see the narrow construction below).
-  //
-  // INVARIANT: each branch must stay identical to what the matching type decoder
-  // emits (numberDecoder, stringDecoderFn, instanceDecoder, objectDecoder, …), or
-  // the union dispatch silently diverges from the per-variant decode. The
-  // "Union type-narrow stays in sync with each schema's own decoder" test in
-  // S_union_test.res guards this.
+  // The type-narrow condition for a union variant, composed from the same atomic
+  // checks the type decoders use (`typeofCond`/`instanceofCond`/`isArrayCond`/…).
+  // That shared source keeps the union dispatch and the per-variant decode from
+  // drifting, while still avoiding any reference to a per-type factory — so
+  // unused type decoders tree-shake (see the narrow construction below).
   let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
     let tagFlag = schema.tag->TagFlag.get
     if tagFlag->Flag.unsafeHas(TagFlag.object) {
-      `typeof ${inputVar}==="${(objectTag :> string)}"&&${inputVar}&&!Array.isArray(${inputVar})`
+      `${objectTagCond(~inputVar)}&&${nonArrayCond(~inputVar)}`
     } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
-      `Array.isArray(${inputVar})`
+      isArrayCond(~inputVar)
     } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-      `${inputVar} instanceof ${input->B.embed(schema.class)}`
+      instanceofCond(input, schema.class, ~inputVar)
     } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
-      let typeofCheck = `typeof ${inputVar}==="${(numberTag :> string)}"`
+      let typeofCheck = typeofCond(numberTag, ~inputVar)
       if input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation) {
         typeofCheck
       } else {
-        `${typeofCheck}&&!Number.isNaN(${inputVar})`
+        `${typeofCheck}&&${nonNaNCond(~inputVar)}`
       }
     } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
-      `Number.isNaN(${inputVar})`
-    } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
-      `${inputVar}===void 0`
-    } else if tagFlag->Flag.unsafeHas(TagFlag.null) {
-      `${inputVar}===${(schema.tag :> string)}`
+      nanCond(~inputVar)
+    } else if tagFlag->Flag.unsafeHas(TagFlag.undefined->Flag.with(TagFlag.null)) {
+      // null/undefined reuse literalDecoder's inline-const form (=== null / void 0)
+      `${inputVar}===${input->B.inlineConst(schema)}`
     } else if (
       tagFlag->Flag.unsafeHas(
         TagFlag.string
@@ -3747,7 +3755,7 @@ module Union = {
     ) {
       // string / boolean / bigint / symbol (and their literals — the per-const
       // check stays in the case body)
-      `typeof ${inputVar}==="${(schema.tag :> string)}"`
+      typeofCond(schema.tag, ~inputVar)
     } else {
       // Unreachable: catch-all tags (unknown/union/ref/function/never) use the
       // `unknown` narrow and never reach `typeCheckCond`.

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -4420,28 +4420,12 @@ module Union = {
         output
       }
 
-      // Build the output schema from collected case output schemas
+      // Build the output schema from collected case output schemas. Variants
+      // that coerce to the same `.to` target produce structurally-identical
+      // outputs but no longer share one object identity (each narrow is a fresh
+      // `base`), so the union keeps both; `toJSONSchema` collapses the duplicate
+      // when rendering — the only place the distinction is observable.
       o.schema = if outputAnyOf->Stdlib.Array.length->X.Int.unsafeToBool {
-        // When the union is narrowed by `.to`, every variant coerces to the same
-        // target type, so their output schemas render identically. They no longer
-        // share one object identity (each variant's narrow is built from a fresh
-        // `base`), so collapse outputs that render the same to keep the output
-        // union from carrying duplicates.
-        let outputAnyOf = switch toPerCase {
-        | Some(_) => {
-            let seen = Stdlib.Dict.make()
-            outputAnyOf->Array.filter(s => {
-              let key = s->toExpression
-              if seen->Stdlib.Dict.has(key) {
-                false
-              } else {
-                seen->Dict.set(key, true)
-                true
-              }
-            })
-          }
-        | None => outputAnyOf
-        }
         factory(outputAnyOf)->castToInternal
       } else {
         never_()
@@ -7247,25 +7231,30 @@ module RescriptJSONSchema = {
     | Union({anyOf}) => {
         let literals = []
         let items = []
+        let seen = Stdlib.Dict.make()
 
         anyOf->Array.forEach(childSchema => {
           switch childSchema {
           // Filter out undefined to support optional fields
           | Undefined(_) if (parent->castToInternal).tag === objectTag => ()
           | _ => {
-              items
-              ->Array.push(
-                Schema(internalToJSONSchema(childSchema, ~parent=schema, ~path, ~defs)),
-              )
-              ->ignore
-              switch childSchema->castToInternal->isLiteral {
-              | true =>
-                literals
-                ->Array.push(
-                  (childSchema->castToInternal).const->(Obj.magic: option<char> => JSON.t),
-                )
-                ->ignore
-              | false => ()
+              let childJsonSchema = internalToJSONSchema(childSchema, ~parent=schema, ~path, ~defs)
+              // Collapse structurally-identical members (e.g. variants that all
+              // coerce to the same `.to` target) so the union renders canonically
+              // instead of `anyOf:[T, T]`.
+              let key = childJsonSchema->JSON.stringifyAny->Obj.magic
+              if !(seen->Stdlib.Dict.has(key)) {
+                seen->Dict.set(key, true)
+                items->Array.push(Schema(childJsonSchema))->ignore
+                switch childSchema->castToInternal->isLiteral {
+                | true =>
+                  literals
+                  ->Array.push(
+                    (childSchema->castToInternal).const->(Obj.magic: option<char> => JSON.t),
+                  )
+                  ->ignore
+                | false => ()
+                }
               }
             }
           }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3707,11 +3707,15 @@ module Union = {
     }
   })
 
-  // Emits the type-narrow condition for a union variant directly, without
-  // building a per-type schema and running it through `parse`. This keeps the
-  // dispatch free of references to the per-type factories (string/float/instance/
-  // …) so their full decoders tree-shake when a bundle doesn't use them.
-  // The strings mirror what each type decoder emits, so codegen is unchanged.
+  // The type-narrow condition for a union variant, emitted directly from the tag
+  // instead of by referencing a per-type factory — that's what lets unused type
+  // decoders tree-shake (see the narrow construction below).
+  //
+  // INVARIANT: each branch must stay identical to what the matching type decoder
+  // emits (numberDecoder, stringDecoderFn, instanceDecoder, objectDecoder, …), or
+  // the union dispatch silently diverges from the per-variant decode. The
+  // "Union type-narrow stays in sync with each schema's own decoder" test in
+  // S_union_test.res guards this.
   let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
     let tagFlag = schema.tag->TagFlag.get
     if tagFlag->Flag.unsafeHas(TagFlag.object) {
@@ -3733,10 +3737,21 @@ module Union = {
       `${inputVar}===void 0`
     } else if tagFlag->Flag.unsafeHas(TagFlag.null) {
       `${inputVar}===${(schema.tag :> string)}`
-    } else {
+    } else if (
+      tagFlag->Flag.unsafeHas(
+        TagFlag.string
+        ->Flag.with(TagFlag.boolean)
+        ->Flag.with(TagFlag.bigint)
+        ->Flag.with(TagFlag.symbol),
+      )
+    ) {
       // string / boolean / bigint / symbol (and their literals — the per-const
       // check stays in the case body)
       `typeof ${inputVar}==="${(schema.tag :> string)}"`
+    } else {
+      // Unreachable: catch-all tags (unknown/union/ref/function/never) use the
+      // `unknown` narrow and never reach `typeCheckCond`.
+      InternalError.panic(`Unexpected union variant tag: ${(schema.tag :> string)}`)
     }
   }
 
@@ -4167,46 +4182,51 @@ module Union = {
             // Recreate input val for every schema
             // since we will mutate it
             let typeValidationInput = input->B.Val.scope
-            // Build a minimal narrow (no per-type factory) that becomes the
-            // variant's runtime schema — carrying the member's encoder so a
-            // pending `.to` conversion can reach it. Its decoder emits the type
-            // check via `typeCheckCond` when narrowing an `unknown` input, and
-            // delegates to the member's own decoder when coercing a concrete
-            // input (S.to). Referencing only `typeCheckCond` + the member decoder
-            // (already pulled in by the member itself) is what lets unused type
-            // decoders tree-shake.
-            let narrow = base(schema.tag, ~selfReverse=false)
-            narrow.encoder = schema.encoder
-            if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-              narrow.class = schema.class
-            } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
-              narrow.properties = Some(X.Object.immutableEmpty)
-              narrow.additionalItems = Some(Schema(unknown->castToPublic))
-            } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
-              narrow.additionalItems = Some(Schema(unknown->castToPublic))
-              narrow.items = Some(X.Array.immutableEmpty)
-            } else if (
-              tagFlag->Flag.unsafeHas(
-                TagFlag.null->Flag.with(TagFlag.undefined)->Flag.with(TagFlag.nan),
-              )
-            ) {
-              // null/undefined/nan stay literals so the case body passes the
-              // value through instead of re-emitting the check.
-              narrow.const = schema.const
-            }
-            narrow.decoder = if (
+            // IMPORTANT for tree-shaking: build the variant's type-check narrow
+            // without any per-type factory. Referencing `string()`/`float()`/
+            // `instance()`/… here would pin their full decoders into every bundle
+            // that uses a union (and `S.optional`/`S.nullable` are unions). The
+            // discriminant is emitted by `typeCheckCond`; coercion delegates to
+            // the member's own decoder.
+            typeValidationInput.expected = if (
               tagFlag->Flag.unsafeHas(
                 TagFlag.unknown
                 ->Flag.with(TagFlag.union)
                 ->Flag.with(TagFlag.ref)
+                ->Flag.with(TagFlag.function)
                 ->Flag.with(TagFlag._never),
               )
             ) {
-              // unknown / union / ref / json / never have no `typeof` discriminant —
-              // they're catch-alls handled via the deopt (try-each) path.
-              noopDecoder
+              // unknown / union / ref / json / function / never have no `typeof`
+              // discriminant — the deopt (try-each) path handles them, so no
+              // narrow is needed.
+              unknown
             } else {
-              (~input) =>
+              // A minimal narrow that becomes the variant's runtime schema —
+              // carrying the member's encoder so a pending `.to` conversion can
+              // reach it. Its decoder emits the type check via `typeCheckCond`
+              // when narrowing an `unknown` input, and delegates to the member's
+              // own decoder when coercing a concrete input (S.to).
+              let narrow = base(schema.tag, ~selfReverse=false)
+              narrow.encoder = schema.encoder
+              if tagFlag->Flag.unsafeHas(TagFlag.instance) {
+                narrow.class = schema.class
+              } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
+                narrow.properties = Some(X.Object.immutableEmpty)
+                narrow.additionalItems = Some(Schema(unknown->castToPublic))
+              } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
+                narrow.additionalItems = Some(Schema(unknown->castToPublic))
+                narrow.items = Some(X.Array.immutableEmpty)
+              } else if (
+                tagFlag->Flag.unsafeHas(
+                  TagFlag.null->Flag.with(TagFlag.undefined)->Flag.with(TagFlag.nan),
+                )
+              ) {
+                // null/undefined/nan stay literals so the case body passes the
+                // value through instead of re-emitting the check.
+                narrow.const = schema.const
+              }
+              narrow.decoder = (~input) =>
                 if input.schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.unknown) {
                   input->B.refine(
                     ~schema=input.expected,
@@ -4220,8 +4240,8 @@ module Union = {
                 } else {
                   schema.decoder(~input)
                 }
+              narrow
             }
-            typeValidationInput.expected = narrow
 
             let typeValidationOutput = try {
               typeValidationInput->parse

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3707,6 +3707,39 @@ module Union = {
     }
   })
 
+  // Emits the type-narrow condition for a union variant directly, without
+  // building a per-type schema and running it through `parse`. This keeps the
+  // dispatch free of references to the per-type factories (string/float/instance/
+  // …) so their full decoders tree-shake when a bundle doesn't use them.
+  // The strings mirror what each type decoder emits, so codegen is unchanged.
+  let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
+    let tagFlag = schema.tag->TagFlag.get
+    if tagFlag->Flag.unsafeHas(TagFlag.object) {
+      `typeof ${inputVar}==="${(objectTag :> string)}"&&${inputVar}&&!Array.isArray(${inputVar})`
+    } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
+      `Array.isArray(${inputVar})`
+    } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
+      `${inputVar} instanceof ${input->B.embed(schema.class)}`
+    } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
+      let typeofCheck = `typeof ${inputVar}==="${(numberTag :> string)}"`
+      if input.global.flag->Flag.unsafeHas(Flag.disableNanNumberValidation) {
+        typeofCheck
+      } else {
+        `${typeofCheck}&&!Number.isNaN(${inputVar})`
+      }
+    } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
+      `Number.isNaN(${inputVar})`
+    } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
+      `${inputVar}===void 0`
+    } else if tagFlag->Flag.unsafeHas(TagFlag.null) {
+      `${inputVar}===${(schema.tag :> string)}`
+    } else {
+      // string / boolean / bigint / symbol (and their literals — the per-const
+      // check stays in the case body)
+      `typeof ${inputVar}==="${(schema.tag :> string)}"`
+    }
+  }
+
   let rec unionDecoder: Builder.t = (~input) => {
     let selfSchema = input.expected
     let schemas = selfSchema.anyOf->X.Option.getUnsafe
@@ -4134,44 +4167,66 @@ module Union = {
             // Recreate input val for every schema
             // since we will mutate it
             let typeValidationInput = input->B.Val.scope
-            typeValidationInput.expected = if tagFlag->Flag.unsafeHas(TagFlag.null) {
-              nullLiteral()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
-              unit()
+            // Build a minimal narrow (no per-type factory) that becomes the
+            // variant's runtime schema — carrying the member's encoder so a
+            // pending `.to` conversion can reach it. Its decoder emits the type
+            // check via `typeCheckCond` when narrowing an `unknown` input, and
+            // delegates to the member's own decoder when coercing a concrete
+            // input (S.to). Referencing only `typeCheckCond` + the member decoder
+            // (already pulled in by the member itself) is what lets unused type
+            // decoders tree-shake.
+            let narrow = base(schema.tag, ~selfReverse=false)
+            narrow.encoder = schema.encoder
+            if tagFlag->Flag.unsafeHas(TagFlag.instance) {
+              narrow.class = schema.class
             } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
-              DictSchema.factory(unknown->castToPublic)->castToInternal
+              narrow.properties = Some(X.Object.immutableEmpty)
+              narrow.additionalItems = Some(Schema(unknown->castToPublic))
             } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
-              array(unknown->castToPublic)->castToInternal
-            } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-              // The narrow is a bare type-check schema that becomes the variant's
-              // runtime schema. Carry the member's encoder so a pending `.to`
-              // conversion (e.g. `Date.toISOString()`) can still be reached —
-              // without relabeling the schema's type.
-              let narrow = instance(schema.class)->castToInternal
-              narrow.encoder = schema.encoder
-              narrow
-            } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
-              nan()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.string) {
-              string()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
-              float()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.boolean) {
-              bool()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.bigint) {
-              bigint()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.symbol) {
-              symbol()
-            } else {
-              unknown
+              narrow.additionalItems = Some(Schema(unknown->castToPublic))
+              narrow.items = Some(X.Array.immutableEmpty)
+            } else if (
+              tagFlag->Flag.unsafeHas(
+                TagFlag.null->Flag.with(TagFlag.undefined)->Flag.with(TagFlag.nan),
+              )
+            ) {
+              // null/undefined/nan stay literals so the case body passes the
+              // value through instead of re-emitting the check.
+              narrow.const = schema.const
             }
+            narrow.decoder = if (
+              tagFlag->Flag.unsafeHas(
+                TagFlag.unknown
+                ->Flag.with(TagFlag.union)
+                ->Flag.with(TagFlag.ref)
+                ->Flag.with(TagFlag._never),
+              )
+            ) {
+              // unknown / union / ref / json / never have no `typeof` discriminant —
+              // they're catch-alls handled via the deopt (try-each) path.
+              noopDecoder
+            } else {
+              (~input) =>
+                if input.schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.unknown) {
+                  input->B.refine(
+                    ~schema=input.expected,
+                    ~checks=[
+                      {
+                        cond: (~inputVar) => typeCheckCond(input, schema, ~inputVar),
+                        fail: B.failInvalidType,
+                      },
+                    ],
+                  )
+                } else {
+                  schema.decoder(~input)
+                }
+            }
+            typeValidationInput.expected = narrow
 
             let typeValidationOutput = try {
               typeValidationInput->parse
             } catch {
             | _ => {
-                // Discard any checks parse managed to push before throwing,
-                // so the deopt path doesn't see leftover partial state.
                 typeValidationInput.checks = None
                 typeValidationInput
               }
@@ -4336,6 +4391,26 @@ module Union = {
 
       // Build the output schema from collected case output schemas
       o.schema = if outputAnyOf->Stdlib.Array.length->X.Int.unsafeToBool {
+        // When the union is narrowed by `.to`, every variant coerces to the same
+        // target type, so their output schemas render identically. They no longer
+        // share one object identity (each variant's narrow is built from a fresh
+        // `base`), so collapse outputs that render the same to keep the output
+        // union from carrying duplicates.
+        let outputAnyOf = switch toPerCase {
+        | Some(_) => {
+            let seen = Stdlib.Dict.make()
+            outputAnyOf->Array.filter(s => {
+              let key = s->toExpression
+              if seen->Stdlib.Dict.has(key) {
+                false
+              } else {
+                seen->Dict.set(key, true)
+                true
+              }
+            })
+          }
+        | None => outputAnyOf
+        }
         factory(outputAnyOf)->castToInternal
       } else {
         never_()

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1876,11 +1876,8 @@ let int32FormatValidation = (~inputVar) => {
   `${inputVar}<=2147483647&&${inputVar}>=-2147483648&&${inputVar}%1===0`
 }
 
-// Atomic type-narrow conditions — the single source of truth for the type-check
-// strings, shared by the type decoders below and the union dispatch
-// (`typeCheckCond`) so the two can't drift. Each call site composes these
-// (adding its own validation, e.g. int32 or the object `!isArray` guard) instead
-// of re-spelling the strings.
+// Atomic type-narrow conditions, shared by the type decoders and the union
+// dispatch (`typeCheckCond`) so the two can't drift.
 let typeofCond = (tag: tag, ~inputVar) => `typeof ${inputVar}==="${(tag :> string)}"`
 let nanCond = (~inputVar) => `Number.isNaN(${inputVar})`
 let isArrayCond = (~inputVar) => `Array.isArray(${inputVar})`
@@ -2640,11 +2637,8 @@ let instance = class_ => {
   mut->castToPublic
 }
 
-// The type-narrow condition for a union variant, composed from the same atomic
-// checks the type decoders use (`typeofCond`/`instanceofCond`/`isArrayCond`/…).
-// That shared source keeps the union dispatch and the per-variant decode from
-// drifting, while still avoiding any reference to a per-type factory — so
-// unused type decoders tree-shake (see the narrow construction in unionDecoder).
+// Type-narrow condition for a union variant, built from the shared atoms with no
+// per-type factory reference — so unused type decoders tree-shake.
 let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
   let tagFlag = schema.tag->TagFlag.get
   if tagFlag->Flag.unsafeHas(TagFlag.object) {
@@ -2673,12 +2667,10 @@ let typeCheckCond = (input: val, schema: internal, ~inputVar): string => {
       ->Flag.with(TagFlag.symbol),
     )
   ) {
-    // string / boolean / bigint / symbol (and their literals — the per-const
-    // check stays in the case body)
+    // literals reuse this typeof check; their per-const check stays in the case body
     typeofCond(schema.tag, ~inputVar)
   } else {
-    // Unreachable: catch-all tags (unknown/union/ref/function/never) use the
-    // `unknown` narrow and never reach `typeCheckCond`.
+    // Unreachable: catch-all tags use the `unknown` narrow, never this path.
     InternalError.panic(`Unexpected union variant tag: ${(schema.tag :> string)}`)
   }
 }
@@ -3700,12 +3692,9 @@ and unionDecoder: Builder.t = (~input) => {
             // Recreate input val for every schema
             // since we will mutate it
             let typeValidationInput = input->B.Val.scope
-            // IMPORTANT for tree-shaking: build the variant's type-check narrow
-            // without any per-type factory. Referencing `string()`/`float()`/
-            // `instance()`/… here would pin their full decoders into every bundle
-            // that uses a union (and `S.optional`/`S.nullable` are unions). The
-            // discriminant is emitted by `typeCheckCond`; coercion delegates to
-            // the member's own decoder.
+            // Tree-shaking: build the narrow without a per-type factory. A
+            // `string()`/`instance()`/… reference would pin every type decoder into
+            // any union-using bundle — and `S.optional`/`S.nullable` are unions.
             typeValidationInput.expected = if (
               tagFlag->Flag.unsafeHas(
                 TagFlag.unknown
@@ -3720,11 +3709,8 @@ and unionDecoder: Builder.t = (~input) => {
               // narrow is needed.
               unknown
             } else {
-              // A minimal narrow that becomes the variant's runtime schema —
-              // carrying the member's encoder so a pending `.to` conversion can
-              // reach it. Its decoder emits the type check via `typeCheckCond`
-              // when narrowing an `unknown` input, and delegates to the member's
-              // own decoder when coercing a concrete input (S.to).
+              // A minimal narrow standing in as the variant's runtime schema,
+              // carrying the member's encoder so a pending `.to` reverse reaches it.
               let narrow = base(schema.tag, ~selfReverse=false)
               narrow.encoder = schema.encoder
               if tagFlag->Flag.unsafeHas(TagFlag.instance) {
@@ -3740,15 +3726,12 @@ and unionDecoder: Builder.t = (~input) => {
                   TagFlag.null->Flag.with(TagFlag.undefined)->Flag.with(TagFlag.nan),
                 )
               ) {
-                // null/undefined/nan stay literals so the case body passes the
-                // value through instead of re-emitting the check.
+                // null/undefined/nan stay literals so the case body passes through.
                 narrow.const = schema.const
               }
-              // The branch must be per-invocation, not hoisted to construction:
-              // this same narrow is re-decoded during `.to` per-variant
-              // conversion, sometimes with the union's `unknown` input (emit the
-              // discriminant) and sometimes with a concrete coerced value
-              // (delegate to the member's own decoder).
+              // Per-invocation, not hoisted: this narrow is re-decoded during `.to`
+              // per-variant conversion — with the union's `unknown` input (emit the
+              // discriminant) or a concrete coerced value (delegate to schema.decoder).
               narrow.decoder = (~input) =>
                 if input.schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.unknown) {
                   input->B.refine(
@@ -3770,6 +3753,8 @@ and unionDecoder: Builder.t = (~input) => {
               typeValidationInput->parse
             } catch {
             | _ => {
+                // Discard any checks parse managed to push before throwing,
+                // so the deopt path doesn't see leftover partial state.
                 typeValidationInput.checks = None
                 typeValidationInput
               }
@@ -3926,10 +3911,8 @@ and unionDecoder: Builder.t = (~input) => {
       }
 
       // Build the output schema from collected case output schemas. Variants
-      // that coerce to the same `.to` target produce structurally-identical
-      // outputs but no longer share one object identity (each narrow is a fresh
-      // `base`), so the union keeps both; `toJSONSchema` collapses the duplicate
-      // when rendering — the only place the distinction is observable.
+      // coercing to the same `.to` target now produce structurally-identical (but
+      // not identity-equal) outputs; `toJSONSchema` collapses the duplicate.
       o.schema = if outputAnyOf->Stdlib.Array.length->X.Int.unsafeToBool {
         unionFactory(outputAnyOf)->castToInternal
       } else {
@@ -7251,9 +7234,8 @@ module RescriptJSONSchema = {
           | Undefined(_) if (parent->castToInternal).tag === objectTag => ()
           | _ => {
               let childJsonSchema = internalToJSONSchema(childSchema, ~parent=schema, ~path, ~defs)
-              // Collapse structurally-identical members (e.g. variants that all
-              // coerce to the same `.to` target) so the union renders canonically
-              // instead of `anyOf:[T, T]`.
+              // Collapse structurally-identical members (e.g. variants coercing to
+              // the same `.to` target) so the union renders as `T`, not `anyOf:[T,T]`.
               let key = childJsonSchema->JSON.stringifyAny->Obj.magic
               if !(seen->Stdlib.Dict.has(key)) {
                 seen->Dict.set(key, true)

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3218,9 +3218,7 @@ let instanceDecoder = Builder.make((~input) => {
   } else if (
     inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === input.expected.class
   ) {
-    // Same as the date decoder: relabel the already-validated value to the
-    // case's own schema so a pending `.to` conversion sees its encoder.
-    input->B.refine(~schema=input.expected)
+    input
   } else {
     input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   }
@@ -4145,7 +4143,13 @@ module Union = {
             } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
               array(unknown->castToPublic)->castToInternal
             } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-              instance(schema.class)->castToInternal
+              // The narrow is a bare type-check schema that becomes the variant's
+              // runtime schema. Carry the member's encoder so a pending `.to`
+              // conversion (e.g. `Date.toISOString()`) can still be reached —
+              // without relabeling the schema's type.
+              let narrow = instance(schema.class)->castToInternal
+              narrow.encoder = schema.encoder
+              narrow
             } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
               nan()
             } else if tagFlag->Flag.unsafeHas(TagFlag.string) {
@@ -5191,11 +5195,7 @@ let date = () =>
       } else if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
         instanceDecoder(~input)->invalidDateRefine
       } else if inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === s.class {
-        // The value is already a Date instance (routed here by the union's
-        // type-check). Promote its schema to the case's own schema so a pending
-        // `.to` conversion can reach this date's encoder — the bare instance
-        // narrow used for routing doesn't carry it.
-        input->B.refine(~schema=input.expected)
+        input
       } else {
         input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
       }

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3218,7 +3218,9 @@ let instanceDecoder = Builder.make((~input) => {
   } else if (
     inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === input.expected.class
   ) {
-    input
+    // Same as the date decoder: relabel the already-validated value to the
+    // case's own schema so a pending `.to` conversion sees its encoder.
+    input->B.refine(~schema=input.expected)
   } else {
     input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
   }
@@ -5189,7 +5191,11 @@ let date = () =>
       } else if inputTagFlag->Flag.unsafeHas(TagFlag.unknown) {
         instanceDecoder(~input)->invalidDateRefine
       } else if inputTagFlag->Flag.unsafeHas(TagFlag.instance) && input.schema.class === s.class {
-        input
+        // The value is already a Date instance (routed here by the union's
+        // type-check). Promote its schema to the case's own schema so a pending
+        // `.to` conversion can reach this date's encoder — the bare instance
+        // narrow used for routing doesn't carry it.
+        input->B.refine(~schema=input.expected)
       } else {
         input->B.unsupportedDecode(~from=input.schema, ~target=input.expected)
       }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -978,8 +978,8 @@ function int32FormatValidation(inputVar) {
   return inputVar + `<=2147483647&&` + inputVar + `>=-2147483648&&` + inputVar + `%1===0`;
 }
 
-function typeofCond(tag, inputVar) {
-  return `typeof ` + inputVar + `==="` + tag + `"`;
+function typeofCond(tag) {
+  return inputVar => `typeof ` + inputVar + `==="` + tag + `"`;
 }
 
 function nanCond(inputVar) {
@@ -991,18 +991,18 @@ function isArrayCond(inputVar) {
 }
 
 function objectTagCond(inputVar) {
-  return typeofCond(objectTag, inputVar) + `&&` + inputVar;
+  return typeofCond(objectTag)(inputVar) + `&&` + inputVar;
 }
 
-function instanceofCond(b, $$class, inputVar) {
-  return inputVar + ` instanceof ` + embed(b, $$class);
+function instanceofCond(b, $$class) {
+  return inputVar => inputVar + ` instanceof ` + embed(b, $$class);
 }
 
 function numberDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     let checks = [{
-        c: inputVar => typeofCond(numberTag, inputVar),
+        c: typeofCond(numberTag),
         f: failInvalidType
       }];
     let match = input.e.format;
@@ -1082,7 +1082,7 @@ function stringDecoderFn(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => typeofCond(stringTag, inputVar),
+        c: typeofCond(stringTag),
         f: failInvalidType
       }], undefined);
   }
@@ -1111,7 +1111,7 @@ function booleanDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => typeofCond(booleanTag, inputVar),
+        c: typeofCond(booleanTag),
         f: failInvalidType
       }], undefined);
   }
@@ -1140,7 +1140,7 @@ function bigintDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => typeofCond(bigintTag, inputVar),
+        c: typeofCond(bigintTag),
         f: failInvalidType
       }], undefined);
   }
@@ -1170,7 +1170,7 @@ function symbolDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => typeofCond(symbolTag, inputVar),
+        c: typeofCond(symbolTag),
         f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 16384) {
@@ -1544,7 +1544,7 @@ function instanceDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => instanceofCond(input, input.e.class, inputVar),
+        c: instanceofCond(input, input.e.class),
         f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
@@ -1587,6 +1587,498 @@ function makeObjectVal(prev, schema) {
     path: prev.path,
     g: prev.g
   };
+}
+
+function unionGetToPerCase(schema) {
+  let match = schema.parser;
+  if (match !== undefined) {
+    return;
+  }
+  let to = schema.to;
+  if (to !== undefined) {
+    return to;
+  }
+}
+
+function unionPerVariantVal(input, target) {
+  return refine(input, unknown, undefined, updateOutput(input.s, mut => {
+    mut.to = target;
+  }));
+}
+
+function unionCanDispatchPerVariant(inputAnyOf, target) {
+  if (!(flags[getOutputSchema(target).type] & 512) && !(target.type === unionTag && target.anyOf.some(v => flags[v.type] & 512))) {
+    return !inputAnyOf.some(v => {
+      if (v.to !== undefined || v.parser !== undefined) {
+        return true;
+      } else {
+        return flags[v.type] & 512;
+      }
+    });
+  } else {
+    return false;
+  }
+}
+
+function unionIsWiderSchema(schemaAnyOf, inputAnyOf) {
+  return inputAnyOf.every((inputSchema, idx) => {
+    let schema = schemaAnyOf[idx];
+    if (schema !== undefined && !(flags[inputSchema.type] & 9152) && inputSchema.type === schema.type && inputSchema.const === schema.const) {
+      return inputSchema.to === undefined;
+    } else {
+      return false;
+    }
+  });
+}
+
+function unionFactory(schemas) {
+  let len = schemas.length;
+  if (len === 1) {
+    return schemas[0];
+  }
+  if (len !== 0) {
+    let has = {};
+    let anyOf = new Set();
+    for (let idx = 0, idx_finish = schemas.length; idx < idx_finish; ++idx) {
+      let schema = schemas[idx];
+      if (schema.type === unionTag && schema.to === undefined) {
+        schema.anyOf.forEach(item => {
+          anyOf.add(item);
+        });
+        Object.assign(has, schema.has);
+      } else {
+        anyOf.add(schema);
+        setHas(has, schema.type);
+      }
+    }
+    let mut = base(unionTag, false);
+    mut.anyOf = Array.from(anyOf);
+    mut.decoder = unionDecoder;
+    mut.encoder = unionEncoder;
+    mut.has = has;
+    return mut;
+  }
+  throw new Error(`[Sury] ` + "S.union requires at least one item");
+}
+
+function nestedOption(item) {
+  return updateOutput(item, mut => {
+    mut.to = nestedNone();
+    mut.parser = nestedOptionParser;
+  });
+}
+
+function objectDecoder(unknownInput) {
+  let isUnion = unknownInput.u;
+  let expectedSchema = unknownInput.e;
+  let unknownInputTagFlag = flags[unknownInput.s.type];
+  let input;
+  if (unknownInputTagFlag & 65) {
+    let isObjectInput = unknownInputTagFlag & 64;
+    let schema;
+    if (isObjectInput) {
+      schema = unknownInput.s;
+    } else {
+      let mut = base(objectTag, false);
+      mut.properties = immutableEmpty;
+      mut.additionalItems = unknown;
+      schema = mut;
+    }
+    let checks = [];
+    if (!isObjectInput) {
+      checks.push({
+        c: objectTagCond,
+        f: failInvalidType
+      });
+      if (expectedSchema.additionalItems !== "strip") {
+        checks.push({
+          c: inputVar => `!` + isArrayCond(inputVar),
+          f: failInvalidType
+        });
+      }
+    }
+    input = checks.length !== 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
+  } else {
+    input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
+  }
+  let itemSchema = expectedSchema.additionalItems;
+  let output;
+  let exit = 0;
+  if (itemSchema === "strip" || itemSchema === "strict") {
+    exit = 1;
+  } else if (itemSchema === unknown) {
+    output = input;
+  } else {
+    let inputVar = input.v();
+    let keyVar = varWithoutAllocation(input.g);
+    let itemInput = dynamicScope(input, keyVar);
+    let itemOutput = parseDynamic(itemInput);
+    let hasTransform = itemOutput.t;
+    let output$1 = hasTransform ? next(input, "{}", expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
+    let itemCode = mergeWithPathPrepend(itemOutput, input, keyVar, hasTransform ? () => addKey(output$1, keyVar, itemOutput) : undefined);
+    if (hasTransform || itemCode !== "") {
+      output$1.cp = output$1.cp + (`for(let ` + keyVar + ` in ` + inputVar + `){` + itemCode + `}`);
+    }
+    if (itemOutput.f & 1) {
+      let resolveVar = varWithoutAllocation(output$1.g);
+      let rejectVar = varWithoutAllocation(output$1.g);
+      let asyncParseResultVar = varWithoutAllocation(output$1.g);
+      let counterVar = varWithoutAllocation(output$1.g);
+      let outputVar = output$1.v();
+      output = asyncVal(output$1, `new Promise((` + resolveVar + `,` + rejectVar + `)=>{let ` + counterVar + `=Object.keys(` + outputVar + `).length;for(let ` + keyVar + ` in ` + outputVar + `){` + outputVar + `[` + keyVar + `].then(` + asyncParseResultVar + `=>{` + outputVar + `[` + keyVar + `]=` + asyncParseResultVar + `;if(` + counterVar + `--===1){` + resolveVar + `(` + outputVar + `)}},` + rejectVar + `)}})`);
+    } else {
+      output = output$1;
+    }
+  }
+  if (exit === 1) {
+    let properties = expectedSchema.properties;
+    let keys = Object.keys(properties);
+    let keysCount = keys.length;
+    let objectVal = makeObjectVal(input, expectedSchema);
+    let match = expectedSchema.additionalItems;
+    let shouldRecreateInput;
+    if (match === "strip" || match === "strict") {
+      if (match === "strip") {
+        let match$1 = input.s.additionalItems;
+        let exit$1 = 0;
+        if (match$1 === "strip" || match$1 === "strict") {
+          exit$1 = 2;
+        } else {
+          shouldRecreateInput = true;
+        }
+        if (exit$1 === 2) {
+          shouldRecreateInput = Object.keys(input.s.properties).length !== keysCount;
+        }
+      } else {
+        shouldRecreateInput = false;
+      }
+    } else {
+      shouldRecreateInput = true;
+    }
+    let s = input.s.additionalItems;
+    let isJsonParent;
+    isJsonParent = s === "strip" || s === "strict" ? false : s.name === jsonName;
+    for (let idx = 0; idx < keysCount; ++idx) {
+      let key = keys[idx];
+      let schema$1 = properties[key];
+      let itemInput$1 = valGet(input, key);
+      itemInput$1.e = schema$1;
+      itemInput$1.io = false;
+      itemInput$1.u = isUnion;
+      if (isJsonParent && schema$1.type === unionTag && schema$1.has[undefinedTag]) {
+        itemInput$1.i = `(` + itemInput$1.i + `??null)`;
+      }
+      let itemOutput$1 = parse$1(itemInput$1);
+      if (isUnion && constField in schema$1) {
+        hoistChildChecks(input, itemOutput$1, key);
+      }
+      add(objectVal, key, itemOutput$1);
+      if (!shouldRecreateInput) {
+        shouldRecreateInput = itemOutput$1.t;
+      }
+    }
+    let tmp = false;
+    if (expectedSchema.additionalItems === "strict") {
+      let match$2 = input.s.additionalItems;
+      let tmp$1;
+      tmp$1 = match$2 !== "strip" && match$2 !== "strict";
+      tmp = tmp$1;
+    }
+    if (tmp) {
+      let keyVar$1 = varWithoutAllocation(objectVal.g);
+      hoistDecl(input, keyVar$1);
+      objectVal.cp = objectVal.cp + (`for(` + keyVar$1 + ` in ` + input.v() + `){if(`);
+      if (keys.length !== 0) {
+        for (let idx$1 = 0, idx_finish = keys.length; idx$1 < idx_finish; ++idx$1) {
+          let key$1 = keys[idx$1];
+          if (idx$1 !== 0) {
+            objectVal.cp = objectVal.cp + "&&";
+          }
+          objectVal.cp = objectVal.cp + (keyVar$1 + `!==` + inlineLocation(input.g, key$1));
+        }
+      } else {
+        objectVal.cp = objectVal.cp + "true";
+      }
+      objectVal.cp = objectVal.cp + (`){` + failWithArg(input, exccessFieldName => ({
+        code: "unrecognized_keys",
+        path: objectVal.path,
+        reason: `Unrecognized key "` + exccessFieldName + `"`,
+        keys: [exccessFieldName]
+      }), keyVar$1) + `}}`);
+    }
+    if (shouldRecreateInput) {
+      output = completeObjectVal(objectVal);
+    } else {
+      let o = refine(input, undefined, undefined, undefined);
+      o.cp = objectVal.cp;
+      o.d = objectVal.d;
+      output = o;
+    }
+  }
+  return markOutput(output, input);
+}
+
+function arrayDecoder(unknownInput) {
+  let isUnion = unknownInput.u;
+  let expectedSchema = unknownInput.e;
+  let unknownInputTagFlag = flags[unknownInput.s.type];
+  let expectedItems = expectedSchema.items;
+  let expectedLength = expectedItems.length;
+  let input;
+  if (unknownInputTagFlag & 129) {
+    let isArrayInput = unknownInputTagFlag & 128;
+    let schema = isArrayInput ? unknownInput.s : array(unknown);
+    let checks = [];
+    if (!isArrayInput) {
+      checks.push({
+        c: isArrayCond,
+        f: failInvalidType
+      });
+    }
+    let match = schema.additionalItems;
+    let isExactSize;
+    isExactSize = match === "strip" || match === "strict" ? (
+        match === "strip" ? schema.items.length === expectedLength : schema.items.length === expectedLength
+      ) : false;
+    if (!isExactSize) {
+      let match$1 = expectedSchema.additionalItems;
+      if (match$1 === "strip" || match$1 === "strict") {
+        if (match$1 === "strip") {
+          checks.push({
+            c: inputVar => inputVar + `.length>=` + expectedLength,
+            f: failInvalidType
+          });
+        } else {
+          checks.push({
+            c: inputVar => inputVar + `.length===` + expectedLength,
+            f: failInvalidType
+          });
+        }
+      }
+    }
+    input = checks.length !== 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
+  } else {
+    input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
+  }
+  let itemSchema = expectedSchema.additionalItems;
+  let output;
+  let exit = 0;
+  if (itemSchema === "strip" || itemSchema === "strict") {
+    exit = 1;
+  } else if (itemSchema === unknown) {
+    output = input;
+  } else {
+    let inputVar = input.v();
+    let iteratorVar = varWithoutAllocation(input.g);
+    let itemInput = dynamicScope(input, iteratorVar);
+    let itemOutput = parseDynamic(itemInput);
+    let hasTransform = itemOutput.t;
+    let output$1 = hasTransform ? next(input, `new Array(` + inputVar + `.length)`, expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
+    let itemCode = mergeWithPathPrepend(itemOutput, input, iteratorVar, hasTransform ? () => addKey(output$1, iteratorVar, itemOutput) : undefined);
+    if (hasTransform || itemCode !== "") {
+      output$1.cp = output$1.cp + (`for(let ` + iteratorVar + `=` + expectedLength + `;` + iteratorVar + `<` + inputVar + `.length;++` + iteratorVar + `){` + itemCode + `}`);
+    }
+    output = itemOutput.f & 1 ? asyncVal(output$1, `Promise.all(` + output$1.i + `)`) : output$1;
+  }
+  if (exit === 1) {
+    let objectVal = makeObjectVal(input, expectedSchema);
+    let match$2 = expectedSchema.additionalItems;
+    let shouldRecreateInput;
+    if (match$2 === "strip" || match$2 === "strict") {
+      if (match$2 === "strip") {
+        let match$3 = input.s.additionalItems;
+        shouldRecreateInput = match$3 === "strip" || match$3 === "strict" ? (
+            match$3 === "strip" ? input.s.items.length !== expectedLength : input.s.items.length !== expectedLength
+          ) : true;
+      } else {
+        shouldRecreateInput = false;
+      }
+    } else {
+      shouldRecreateInput = true;
+    }
+    for (let idx = 0; idx < expectedLength; ++idx) {
+      let schema$1 = expectedItems[idx];
+      let key = idx.toString();
+      let itemInput$1 = valGet(input, key);
+      itemInput$1.e = schema$1;
+      itemInput$1.io = false;
+      itemInput$1.u = isUnion;
+      let itemOutput$1 = parse$1(itemInput$1);
+      if (isUnion && constField in schema$1) {
+        hoistChildChecks(input, itemOutput$1, key);
+      }
+      add(objectVal, key, itemOutput$1);
+      if (!shouldRecreateInput) {
+        shouldRecreateInput = itemOutput$1.t;
+      }
+    }
+    if (shouldRecreateInput) {
+      output = completeObjectVal(objectVal);
+    } else {
+      let o = refine(input, undefined, undefined, undefined);
+      o.cp = objectVal.cp;
+      o.d = objectVal.d;
+      output = o;
+    }
+  }
+  return markOutput(output, input);
+}
+
+function optionFactory(item, unitOpt) {
+  let unit$1 = unitOpt !== undefined ? unitOpt : unit();
+  let match = getOutputSchema(item);
+  let match$1 = match.type;
+  switch (match$1) {
+    case "undefined" :
+      return unionFactory([
+        unit$1,
+        nestedOption(item)
+      ]);
+    case "union" :
+      let has = match.has;
+      let anyOf = match.anyOf;
+      return updateOutput(item, mut => {
+        let mutHas = copy(has);
+        let newAnyOf = [];
+        for (let idx = 0, idx_finish = anyOf.length; idx < idx_finish; ++idx) {
+          let schema = anyOf[idx];
+          let match = getOutputSchema(schema);
+          let match$1 = match.type;
+          let tmp;
+          if (match$1 === "undefined") {
+            mutHas[unit$1.type] = true;
+            newAnyOf.push(unit$1);
+            tmp = nestedOption(schema);
+          } else {
+            let properties = match.properties;
+            if (properties !== undefined) {
+              let nestedSchema = properties[nestedLoc];
+              tmp = nestedSchema !== undefined ? updateOutput(schema, mut => {
+                  let properties = {};
+                  let newrecord = {...nestedSchema};
+                  newrecord.const = nestedSchema.const + 1;
+                  properties[nestedLoc] = newrecord;
+                  mut.properties = properties;
+                }) : schema;
+            } else {
+              tmp = schema;
+            }
+          }
+          newAnyOf.push(tmp);
+        }
+        if (newAnyOf.length === anyOf.length) {
+          mutHas[unit$1.type] = true;
+          newAnyOf.push(unit$1);
+        }
+        mut.anyOf = newAnyOf;
+        mut.has = mutHas;
+      });
+    default:
+      return unionFactory([
+        item,
+        unit$1
+      ]);
+  }
+}
+
+function array(item) {
+  let mut = base(arrayTag, item[reversedKey] === item);
+  mut.additionalItems = item;
+  mut.items = immutableEmpty$1;
+  mut.decoder = arrayDecoder;
+  return mut;
+}
+
+function completeObjectVal(objectVal) {
+  let isArray = objectVal.s.type === arrayTag;
+  let inline = "";
+  let promiseAllContent = "";
+  let optionalSettingCode;
+  let keys = Object.keys(objectVal.d);
+  for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
+    let key = keys[idx];
+    let val = objectVal.d[key];
+    if (val.f & 1) {
+      promiseAllContent = promiseAllContent + val.i + ",";
+    }
+    if (val.o) {
+      let existingFn = optionalSettingCode;
+      optionalSettingCode = objectVar => (
+        existingFn !== undefined ? existingFn(objectVar) : ""
+      ) + (`if(` + val.v() + `!==void 0){` + objectVar + `[` + inlineLocation(objectVal.g, key) + `]=` + val.i + `}`);
+    } else {
+      inline = inline + (
+        isArray ? val.i : inlineLocation(objectVal.g, key) + `:` + val.i
+      ) + ",";
+    }
+  }
+  objectVal.i = isArray ? "[" + inline + "]" : "{" + inline + "}";
+  if (promiseAllContent) {
+    let operationInput = scope(objectVal);
+    operationInput.io = true;
+    let operationOutput = parse$1(operationInput);
+    let operationCode = merge(operationOutput, undefined);
+    if (operationCode === "" && promiseAllContent === operationOutput.i + `,`) {
+      objectVal.i = operationOutput.i;
+    } else {
+      objectVal.i = `Promise.all([` + promiseAllContent + `]).then(([` + promiseAllContent + `])=>{` + operationCode + `return ` + operationOutput.i + `})`;
+    }
+    objectVal.f = objectVal.f | 1;
+    objectVal.s = operationOutput.s;
+    objectVal.e = operationOutput.e;
+    objectVal.io = true;
+    return objectVal;
+  }
+  let fn = optionalSettingCode;
+  if (fn === undefined) {
+    return objectVal;
+  }
+  let code = fn(objectVal.v());
+  let output = refine(objectVal, undefined, undefined, undefined);
+  output.cp = output.cp + code;
+  return output;
+}
+
+function valGet(parent, location) {
+  let d = parent.d;
+  let vals;
+  if (d !== undefined) {
+    vals = d;
+  } else {
+    let d$1 = {};
+    parent.d = d$1;
+    vals = d$1;
+  }
+  let v = vals[location];
+  if (v !== undefined) {
+    return scope(v);
+  }
+  let locationSchema = parent.s.type === objectTag ? parent.s.properties[location] : parent.s.items[location];
+  let schema;
+  if (locationSchema !== undefined) {
+    schema = locationSchema;
+  } else {
+    let s = parent.s.additionalItems;
+    schema = s === "strip" || s === "strict" ? unsupportedDecode(parent, parent.s, parent.e) : (
+        parent.s.type === objectTag && s.type !== unknownTag && !(flags[s.type] & 512) && !isOptional(s) ? option(s) : s
+      );
+  }
+  let inlinedLocation = inlineLocation(parent.g, location);
+  let pathAppend = `[` + inlinedLocation + `]`;
+  let item = {
+    p: parent,
+    v: _notVarAtParent,
+    i: constField in schema ? inlineConst(parent, schema) : parent.v() + pathAppend,
+    s: schema,
+    e: schema,
+    f: 0,
+    cp: "",
+    hd: "",
+    path: parent.path + pathAppend,
+    g: parent.g
+  };
+  vals[location] = item;
+  return item;
 }
 
 function nestedNone() {
@@ -1924,10 +2416,10 @@ function unionDecoder(input) {
                       return isArrayCond(inputVar);
                     }
                     if (tagFlag & 8192) {
-                      return instanceofCond(input, schema$1.class, inputVar);
+                      return instanceofCond(input, schema$1.class)(inputVar);
                     }
                     if (tagFlag & 4) {
-                      let typeofCheck = typeofCond(numberTag, inputVar);
+                      let typeofCheck = typeofCond(numberTag)(inputVar);
                       if (input.g.o & 2) {
                         return typeofCheck;
                       } else {
@@ -1941,7 +2433,7 @@ function unionDecoder(input) {
                       return inputVar + `===` + inlineConst(input, schema$1);
                     }
                     if (tagFlag & 17418) {
-                      return typeofCond(schema$1.type, inputVar);
+                      return typeofCond(schema$1.type)(inputVar);
                     }
                     throw new Error(`[Sury] Unexpected union variant tag: ` + schema$1.type);
                   },
@@ -2069,191 +2561,12 @@ function unionEncoder(input, target) {
   }
 }
 
-function nestedOption(item) {
-  return updateOutput(item, mut => {
-    mut.to = nestedNone();
-    mut.parser = nestedOptionParser;
-  });
-}
-
-function unionFactory(schemas) {
-  let len = schemas.length;
-  if (len === 1) {
-    return schemas[0];
-  }
-  if (len !== 0) {
-    let has = {};
-    let anyOf = new Set();
-    for (let idx = 0, idx_finish = schemas.length; idx < idx_finish; ++idx) {
-      let schema = schemas[idx];
-      if (schema.type === unionTag && schema.to === undefined) {
-        schema.anyOf.forEach(item => {
-          anyOf.add(item);
-        });
-        Object.assign(has, schema.has);
-      } else {
-        anyOf.add(schema);
-        setHas(has, schema.type);
-      }
-    }
-    let mut = base(unionTag, false);
-    mut.anyOf = Array.from(anyOf);
-    mut.decoder = unionDecoder;
-    mut.encoder = unionEncoder;
-    mut.has = has;
-    return mut;
-  }
-  throw new Error(`[Sury] ` + "S.union requires at least one item");
-}
-
-function objectDecoder(unknownInput) {
-  let isUnion = unknownInput.u;
-  let expectedSchema = unknownInput.e;
-  let unknownInputTagFlag = flags[unknownInput.s.type];
-  let input;
-  if (unknownInputTagFlag & 65) {
-    let isObjectInput = unknownInputTagFlag & 64;
-    let schema;
-    if (isObjectInput) {
-      schema = unknownInput.s;
-    } else {
-      let mut = base(objectTag, false);
-      mut.properties = immutableEmpty;
-      mut.additionalItems = unknown;
-      schema = mut;
-    }
-    let checks = [];
-    if (!isObjectInput) {
-      checks.push({
-        c: objectTagCond,
-        f: failInvalidType
-      });
-      if (expectedSchema.additionalItems !== "strip") {
-        checks.push({
-          c: inputVar => `!` + isArrayCond(inputVar),
-          f: failInvalidType
-        });
-      }
-    }
-    input = checks.length !== 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
+function unionToKey(schema) {
+  if (flags[schema.type] & 8192) {
+    return schema.class.name;
   } else {
-    input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
+    return schema.type;
   }
-  let itemSchema = expectedSchema.additionalItems;
-  let output;
-  let exit = 0;
-  if (itemSchema === "strip" || itemSchema === "strict") {
-    exit = 1;
-  } else if (itemSchema === unknown) {
-    output = input;
-  } else {
-    let inputVar = input.v();
-    let keyVar = varWithoutAllocation(input.g);
-    let itemInput = dynamicScope(input, keyVar);
-    let itemOutput = parseDynamic(itemInput);
-    let hasTransform = itemOutput.t;
-    let output$1 = hasTransform ? next(input, "{}", expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
-    let itemCode = mergeWithPathPrepend(itemOutput, input, keyVar, hasTransform ? () => addKey(output$1, keyVar, itemOutput) : undefined);
-    if (hasTransform || itemCode !== "") {
-      output$1.cp = output$1.cp + (`for(let ` + keyVar + ` in ` + inputVar + `){` + itemCode + `}`);
-    }
-    if (itemOutput.f & 1) {
-      let resolveVar = varWithoutAllocation(output$1.g);
-      let rejectVar = varWithoutAllocation(output$1.g);
-      let asyncParseResultVar = varWithoutAllocation(output$1.g);
-      let counterVar = varWithoutAllocation(output$1.g);
-      let outputVar = output$1.v();
-      output = asyncVal(output$1, `new Promise((` + resolveVar + `,` + rejectVar + `)=>{let ` + counterVar + `=Object.keys(` + outputVar + `).length;for(let ` + keyVar + ` in ` + outputVar + `){` + outputVar + `[` + keyVar + `].then(` + asyncParseResultVar + `=>{` + outputVar + `[` + keyVar + `]=` + asyncParseResultVar + `;if(` + counterVar + `--===1){` + resolveVar + `(` + outputVar + `)}},` + rejectVar + `)}})`);
-    } else {
-      output = output$1;
-    }
-  }
-  if (exit === 1) {
-    let properties = expectedSchema.properties;
-    let keys = Object.keys(properties);
-    let keysCount = keys.length;
-    let objectVal = makeObjectVal(input, expectedSchema);
-    let match = expectedSchema.additionalItems;
-    let shouldRecreateInput;
-    if (match === "strip" || match === "strict") {
-      if (match === "strip") {
-        let match$1 = input.s.additionalItems;
-        let exit$1 = 0;
-        if (match$1 === "strip" || match$1 === "strict") {
-          exit$1 = 2;
-        } else {
-          shouldRecreateInput = true;
-        }
-        if (exit$1 === 2) {
-          shouldRecreateInput = Object.keys(input.s.properties).length !== keysCount;
-        }
-      } else {
-        shouldRecreateInput = false;
-      }
-    } else {
-      shouldRecreateInput = true;
-    }
-    let s = input.s.additionalItems;
-    let isJsonParent;
-    isJsonParent = s === "strip" || s === "strict" ? false : s.name === jsonName;
-    for (let idx = 0; idx < keysCount; ++idx) {
-      let key = keys[idx];
-      let schema$1 = properties[key];
-      let itemInput$1 = valGet(input, key);
-      itemInput$1.e = schema$1;
-      itemInput$1.io = false;
-      itemInput$1.u = isUnion;
-      if (isJsonParent && schema$1.type === unionTag && schema$1.has[undefinedTag]) {
-        itemInput$1.i = `(` + itemInput$1.i + `??null)`;
-      }
-      let itemOutput$1 = parse$1(itemInput$1);
-      if (isUnion && constField in schema$1) {
-        hoistChildChecks(input, itemOutput$1, key);
-      }
-      add(objectVal, key, itemOutput$1);
-      if (!shouldRecreateInput) {
-        shouldRecreateInput = itemOutput$1.t;
-      }
-    }
-    let tmp = false;
-    if (expectedSchema.additionalItems === "strict") {
-      let match$2 = input.s.additionalItems;
-      let tmp$1;
-      tmp$1 = match$2 !== "strip" && match$2 !== "strict";
-      tmp = tmp$1;
-    }
-    if (tmp) {
-      let keyVar$1 = varWithoutAllocation(objectVal.g);
-      hoistDecl(input, keyVar$1);
-      objectVal.cp = objectVal.cp + (`for(` + keyVar$1 + ` in ` + input.v() + `){if(`);
-      if (keys.length !== 0) {
-        for (let idx$1 = 0, idx_finish = keys.length; idx$1 < idx_finish; ++idx$1) {
-          let key$1 = keys[idx$1];
-          if (idx$1 !== 0) {
-            objectVal.cp = objectVal.cp + "&&";
-          }
-          objectVal.cp = objectVal.cp + (keyVar$1 + `!==` + inlineLocation(input.g, key$1));
-        }
-      } else {
-        objectVal.cp = objectVal.cp + "true";
-      }
-      objectVal.cp = objectVal.cp + (`){` + failWithArg(input, exccessFieldName => ({
-        code: "unrecognized_keys",
-        path: objectVal.path,
-        reason: `Unrecognized key "` + exccessFieldName + `"`,
-        keys: [exccessFieldName]
-      }), keyVar$1) + `}}`);
-    }
-    if (shouldRecreateInput) {
-      output = completeObjectVal(objectVal);
-    } else {
-      let o = refine(input, undefined, undefined, undefined);
-      o.cp = objectVal.cp;
-      o.d = objectVal.d;
-      output = o;
-    }
-  }
-  return markOutput(output, input);
 }
 
 function unionIsSelfDecodeNoop(_schema) {
@@ -2289,273 +2602,6 @@ function unionIsSelfDecodeNoop(_schema) {
   };
 }
 
-function option(item) {
-  return optionFactory(item, unit());
-}
-
-function completeObjectVal(objectVal) {
-  let isArray = objectVal.s.type === arrayTag;
-  let inline = "";
-  let promiseAllContent = "";
-  let optionalSettingCode;
-  let keys = Object.keys(objectVal.d);
-  for (let idx = 0, idx_finish = keys.length; idx < idx_finish; ++idx) {
-    let key = keys[idx];
-    let val = objectVal.d[key];
-    if (val.f & 1) {
-      promiseAllContent = promiseAllContent + val.i + ",";
-    }
-    if (val.o) {
-      let existingFn = optionalSettingCode;
-      optionalSettingCode = objectVar => (
-        existingFn !== undefined ? existingFn(objectVar) : ""
-      ) + (`if(` + val.v() + `!==void 0){` + objectVar + `[` + inlineLocation(objectVal.g, key) + `]=` + val.i + `}`);
-    } else {
-      inline = inline + (
-        isArray ? val.i : inlineLocation(objectVal.g, key) + `:` + val.i
-      ) + ",";
-    }
-  }
-  objectVal.i = isArray ? "[" + inline + "]" : "{" + inline + "}";
-  if (promiseAllContent) {
-    let operationInput = scope(objectVal);
-    operationInput.io = true;
-    let operationOutput = parse$1(operationInput);
-    let operationCode = merge(operationOutput, undefined);
-    if (operationCode === "" && promiseAllContent === operationOutput.i + `,`) {
-      objectVal.i = operationOutput.i;
-    } else {
-      objectVal.i = `Promise.all([` + promiseAllContent + `]).then(([` + promiseAllContent + `])=>{` + operationCode + `return ` + operationOutput.i + `})`;
-    }
-    objectVal.f = objectVal.f | 1;
-    objectVal.s = operationOutput.s;
-    objectVal.e = operationOutput.e;
-    objectVal.io = true;
-    return objectVal;
-  }
-  let fn = optionalSettingCode;
-  if (fn === undefined) {
-    return objectVal;
-  }
-  let code = fn(objectVal.v());
-  let output = refine(objectVal, undefined, undefined, undefined);
-  output.cp = output.cp + code;
-  return output;
-}
-
-function valGet(parent, location) {
-  let d = parent.d;
-  let vals;
-  if (d !== undefined) {
-    vals = d;
-  } else {
-    let d$1 = {};
-    parent.d = d$1;
-    vals = d$1;
-  }
-  let v = vals[location];
-  if (v !== undefined) {
-    return scope(v);
-  }
-  let locationSchema = parent.s.type === objectTag ? parent.s.properties[location] : parent.s.items[location];
-  let schema;
-  if (locationSchema !== undefined) {
-    schema = locationSchema;
-  } else {
-    let s = parent.s.additionalItems;
-    schema = s === "strip" || s === "strict" ? unsupportedDecode(parent, parent.s, parent.e) : (
-        parent.s.type === objectTag && s.type !== unknownTag && !(flags[s.type] & 512) && !isOptional(s) ? option(s) : s
-      );
-  }
-  let inlinedLocation = inlineLocation(parent.g, location);
-  let pathAppend = `[` + inlinedLocation + `]`;
-  let item = {
-    p: parent,
-    v: _notVarAtParent,
-    i: constField in schema ? inlineConst(parent, schema) : parent.v() + pathAppend,
-    s: schema,
-    e: schema,
-    f: 0,
-    cp: "",
-    hd: "",
-    path: parent.path + pathAppend,
-    g: parent.g
-  };
-  vals[location] = item;
-  return item;
-}
-
-function array(item) {
-  let mut = base(arrayTag, item[reversedKey] === item);
-  mut.additionalItems = item;
-  mut.items = immutableEmpty$1;
-  mut.decoder = arrayDecoder;
-  return mut;
-}
-
-function arrayDecoder(unknownInput) {
-  let isUnion = unknownInput.u;
-  let expectedSchema = unknownInput.e;
-  let unknownInputTagFlag = flags[unknownInput.s.type];
-  let expectedItems = expectedSchema.items;
-  let expectedLength = expectedItems.length;
-  let input;
-  if (unknownInputTagFlag & 129) {
-    let isArrayInput = unknownInputTagFlag & 128;
-    let schema = isArrayInput ? unknownInput.s : array(unknown);
-    let checks = [];
-    if (!isArrayInput) {
-      checks.push({
-        c: isArrayCond,
-        f: failInvalidType
-      });
-    }
-    let match = schema.additionalItems;
-    let isExactSize;
-    isExactSize = match === "strip" || match === "strict" ? (
-        match === "strip" ? schema.items.length === expectedLength : schema.items.length === expectedLength
-      ) : false;
-    if (!isExactSize) {
-      let match$1 = expectedSchema.additionalItems;
-      if (match$1 === "strip" || match$1 === "strict") {
-        if (match$1 === "strip") {
-          checks.push({
-            c: inputVar => inputVar + `.length>=` + expectedLength,
-            f: failInvalidType
-          });
-        } else {
-          checks.push({
-            c: inputVar => inputVar + `.length===` + expectedLength,
-            f: failInvalidType
-          });
-        }
-      }
-    }
-    input = checks.length !== 0 ? refine(unknownInput, schema, checks, undefined) : refine(unknownInput, schema, undefined, undefined);
-  } else {
-    input = unsupportedDecode(unknownInput, unknownInput.s, expectedSchema);
-  }
-  let itemSchema = expectedSchema.additionalItems;
-  let output;
-  let exit = 0;
-  if (itemSchema === "strip" || itemSchema === "strict") {
-    exit = 1;
-  } else if (itemSchema === unknown) {
-    output = input;
-  } else {
-    let inputVar = input.v();
-    let iteratorVar = varWithoutAllocation(input.g);
-    let itemInput = dynamicScope(input, iteratorVar);
-    let itemOutput = parseDynamic(itemInput);
-    let hasTransform = itemOutput.t;
-    let output$1 = hasTransform ? next(input, `new Array(` + inputVar + `.length)`, expectedSchema, undefined) : refine(input, expectedSchema, undefined, undefined);
-    let itemCode = mergeWithPathPrepend(itemOutput, input, iteratorVar, hasTransform ? () => addKey(output$1, iteratorVar, itemOutput) : undefined);
-    if (hasTransform || itemCode !== "") {
-      output$1.cp = output$1.cp + (`for(let ` + iteratorVar + `=` + expectedLength + `;` + iteratorVar + `<` + inputVar + `.length;++` + iteratorVar + `){` + itemCode + `}`);
-    }
-    output = itemOutput.f & 1 ? asyncVal(output$1, `Promise.all(` + output$1.i + `)`) : output$1;
-  }
-  if (exit === 1) {
-    let objectVal = makeObjectVal(input, expectedSchema);
-    let match$2 = expectedSchema.additionalItems;
-    let shouldRecreateInput;
-    if (match$2 === "strip" || match$2 === "strict") {
-      if (match$2 === "strip") {
-        let match$3 = input.s.additionalItems;
-        shouldRecreateInput = match$3 === "strip" || match$3 === "strict" ? (
-            match$3 === "strip" ? input.s.items.length !== expectedLength : input.s.items.length !== expectedLength
-          ) : true;
-      } else {
-        shouldRecreateInput = false;
-      }
-    } else {
-      shouldRecreateInput = true;
-    }
-    for (let idx = 0; idx < expectedLength; ++idx) {
-      let schema$1 = expectedItems[idx];
-      let key = idx.toString();
-      let itemInput$1 = valGet(input, key);
-      itemInput$1.e = schema$1;
-      itemInput$1.io = false;
-      itemInput$1.u = isUnion;
-      let itemOutput$1 = parse$1(itemInput$1);
-      if (isUnion && constField in schema$1) {
-        hoistChildChecks(input, itemOutput$1, key);
-      }
-      add(objectVal, key, itemOutput$1);
-      if (!shouldRecreateInput) {
-        shouldRecreateInput = itemOutput$1.t;
-      }
-    }
-    if (shouldRecreateInput) {
-      output = completeObjectVal(objectVal);
-    } else {
-      let o = refine(input, undefined, undefined, undefined);
-      o.cp = objectVal.cp;
-      o.d = objectVal.d;
-      output = o;
-    }
-  }
-  return markOutput(output, input);
-}
-
-function optionFactory(item, unitOpt) {
-  let unit$1 = unitOpt !== undefined ? unitOpt : unit();
-  let match = getOutputSchema(item);
-  let match$1 = match.type;
-  switch (match$1) {
-    case "undefined" :
-      return unionFactory([
-        unit$1,
-        nestedOption(item)
-      ]);
-    case "union" :
-      let has = match.has;
-      let anyOf = match.anyOf;
-      return updateOutput(item, mut => {
-        let mutHas = copy(has);
-        let newAnyOf = [];
-        for (let idx = 0, idx_finish = anyOf.length; idx < idx_finish; ++idx) {
-          let schema = anyOf[idx];
-          let match = getOutputSchema(schema);
-          let match$1 = match.type;
-          let tmp;
-          if (match$1 === "undefined") {
-            mutHas[unit$1.type] = true;
-            newAnyOf.push(unit$1);
-            tmp = nestedOption(schema);
-          } else {
-            let properties = match.properties;
-            if (properties !== undefined) {
-              let nestedSchema = properties[nestedLoc];
-              tmp = nestedSchema !== undefined ? updateOutput(schema, mut => {
-                  let properties = {};
-                  let newrecord = {...nestedSchema};
-                  newrecord.const = nestedSchema.const + 1;
-                  properties[nestedLoc] = newrecord;
-                  mut.properties = properties;
-                }) : schema;
-            } else {
-              tmp = schema;
-            }
-          }
-          newAnyOf.push(tmp);
-        }
-        if (newAnyOf.length === anyOf.length) {
-          mutHas[unit$1.type] = true;
-          newAnyOf.push(unit$1);
-        }
-        mut.anyOf = newAnyOf;
-        mut.has = mutHas;
-      });
-    default:
-      return unionFactory([
-        item,
-        unit$1
-      ]);
-  }
-}
-
 function unionIsPriority(tagFlag, byKey) {
   if (tagFlag & 8320 && objectTag in byKey) {
     return true;
@@ -2566,54 +2612,8 @@ function unionIsPriority(tagFlag, byKey) {
   }
 }
 
-function unionGetToPerCase(schema) {
-  let match = schema.parser;
-  if (match !== undefined) {
-    return;
-  }
-  let to = schema.to;
-  if (to !== undefined) {
-    return to;
-  }
-}
-
-function unionToKey(schema) {
-  if (flags[schema.type] & 8192) {
-    return schema.class.name;
-  } else {
-    return schema.type;
-  }
-}
-
-function unionIsWiderSchema(schemaAnyOf, inputAnyOf) {
-  return inputAnyOf.every((inputSchema, idx) => {
-    let schema = schemaAnyOf[idx];
-    if (schema !== undefined && !(flags[inputSchema.type] & 9152) && inputSchema.type === schema.type && inputSchema.const === schema.const) {
-      return inputSchema.to === undefined;
-    } else {
-      return false;
-    }
-  });
-}
-
-function unionCanDispatchPerVariant(inputAnyOf, target) {
-  if (!(flags[getOutputSchema(target).type] & 512) && !(target.type === unionTag && target.anyOf.some(v => flags[v.type] & 512))) {
-    return !inputAnyOf.some(v => {
-      if (v.to !== undefined || v.parser !== undefined) {
-        return true;
-      } else {
-        return flags[v.type] & 512;
-      }
-    });
-  } else {
-    return false;
-  }
-}
-
-function unionPerVariantVal(input, target) {
-  return refine(input, unknown, undefined, updateOutput(input.s, mut => {
-    mut.to = target;
-  }));
+function option(item) {
+  return optionFactory(item, unit());
 }
 
 function dictFactory(item) {
@@ -3625,153 +3625,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getShapedSerializerOutput(input, acc, targetSchema, path) {
-  let exit = 0;
-  if (acc !== undefined) {
-    let val = acc.val;
-    if (val !== undefined) {
-      let v = scope(val);
-      v.t = true;
-      v.s = targetSchema;
-      v.e = targetSchema;
-      return parse$1(v);
-    }
-    exit = 1;
-  } else {
-    exit = 1;
-  }
-  if (exit === 1) {
-    if (constField in targetSchema) {
-      let v$1 = nextConst(input, targetSchema, targetSchema);
-      v$1.prev = undefined;
-      v$1.p = input;
-      v$1.v = _notVarAtParent;
-      v$1.io = true;
-      return parse$1(v$1);
-    }
-    let resolvedTargetSchema = acc === undefined ? getOutputSchema(targetSchema) : targetSchema;
-    let v$2 = makeObjectVal(input, resolvedTargetSchema);
-    v$2.e = resolvedTargetSchema;
-    v$2.io = true;
-    v$2.prev = undefined;
-    v$2.p = input;
-    v$2.v = _notVarAtParent;
-    let flattened = resolvedTargetSchema.flattened;
-    let items = resolvedTargetSchema.items;
-    let exit$1 = 0;
-    let exit$2 = 0;
-    if (items !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        let tmp;
-        if (acc !== undefined) {
-          let properties = acc.properties;
-          tmp = properties !== undefined ? properties[location] : undefined;
-        } else {
-          tmp = undefined;
-        }
-        let inlinedLocation = inlineLocation(input.g, location);
-        add(v$2, location, getShapedSerializerOutput(input, tmp, items[idx], path + (`[` + inlinedLocation + `]`)));
-      }
-    } else {
-      exit$2 = 3;
-    }
-    if (exit$2 === 3) {
-      let properties$1 = resolvedTargetSchema.properties;
-      if (properties$1 !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
-        if (flattened !== undefined && acc !== undefined) {
-          let flattenedAcc = acc.flattened;
-          if (flattenedAcc !== undefined) {
-            flattenedAcc.forEach((acc, idx) => {
-              let flattenedOutput = getShapedSerializerOutput(input, acc, reverse(flattened[idx]), path);
-              let vals = flattenedOutput.d;
-              let locations = Object.keys(vals);
-              for (let idx$1 = 0, idx_finish = locations.length; idx$1 < idx_finish; ++idx$1) {
-                let location = locations[idx$1];
-                add(v$2, location, vals[location]);
-              }
-            });
-          }
-        }
-        let keys = Object.keys(properties$1);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          if (!(location$1 in v$2.d)) {
-            let tmp$1;
-            if (acc !== undefined) {
-              let properties$2 = acc.properties;
-              tmp$1 = properties$2 !== undefined ? properties$2[location$1] : undefined;
-            } else {
-              tmp$1 = undefined;
-            }
-            let inlinedLocation$1 = inlineLocation(input.g, location$1);
-            add(v$2, location$1, getShapedSerializerOutput(input, tmp$1, properties$1[location$1], path + (`[` + inlinedLocation$1 + `]`)));
-          }
-        }
-      } else {
-        exit$1 = 2;
-      }
-    }
-    if (exit$1 === 2) {
-      let from = targetSchema.from;
-      let path$1 = from !== undefined ? path + from.map(item => `["` + item + `"]`).join("") : path;
-      let tmp$2 = path$1 === "" ? "" : ` at ` + path$1;
-      invalidOperation(input, `Missing input for ` + toExpression(targetSchema) + tmp$2);
-    }
-    return completeObjectVal(v$2);
-  }
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = `~` + fieldName;
@@ -3894,6 +3747,177 @@ function prepareShapedSerializerAcc(acc, input) {
   }
 }
 
+function getShapedSerializerOutput(input, acc, targetSchema, path) {
+  let exit = 0;
+  if (acc !== undefined) {
+    let val = acc.val;
+    if (val !== undefined) {
+      let v = scope(val);
+      v.t = true;
+      v.s = targetSchema;
+      v.e = targetSchema;
+      return parse$1(v);
+    }
+    exit = 1;
+  } else {
+    exit = 1;
+  }
+  if (exit === 1) {
+    if (constField in targetSchema) {
+      let v$1 = nextConst(input, targetSchema, targetSchema);
+      v$1.prev = undefined;
+      v$1.p = input;
+      v$1.v = _notVarAtParent;
+      v$1.io = true;
+      return parse$1(v$1);
+    }
+    let resolvedTargetSchema = acc === undefined ? getOutputSchema(targetSchema) : targetSchema;
+    let v$2 = makeObjectVal(input, resolvedTargetSchema);
+    v$2.e = resolvedTargetSchema;
+    v$2.io = true;
+    v$2.prev = undefined;
+    v$2.p = input;
+    v$2.v = _notVarAtParent;
+    let flattened = resolvedTargetSchema.flattened;
+    let items = resolvedTargetSchema.items;
+    let exit$1 = 0;
+    let exit$2 = 0;
+    if (items !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        let tmp;
+        if (acc !== undefined) {
+          let properties = acc.properties;
+          tmp = properties !== undefined ? properties[location] : undefined;
+        } else {
+          tmp = undefined;
+        }
+        let inlinedLocation = inlineLocation(input.g, location);
+        add(v$2, location, getShapedSerializerOutput(input, tmp, items[idx], path + (`[` + inlinedLocation + `]`)));
+      }
+    } else {
+      exit$2 = 3;
+    }
+    if (exit$2 === 3) {
+      let properties$1 = resolvedTargetSchema.properties;
+      if (properties$1 !== undefined && (acc !== undefined || typeof resolvedTargetSchema.additionalItems !== objectTag)) {
+        if (flattened !== undefined && acc !== undefined) {
+          let flattenedAcc = acc.flattened;
+          if (flattenedAcc !== undefined) {
+            flattenedAcc.forEach((acc, idx) => {
+              let flattenedOutput = getShapedSerializerOutput(input, acc, reverse(flattened[idx]), path);
+              let vals = flattenedOutput.d;
+              let locations = Object.keys(vals);
+              for (let idx$1 = 0, idx_finish = locations.length; idx$1 < idx_finish; ++idx$1) {
+                let location = locations[idx$1];
+                add(v$2, location, vals[location]);
+              }
+            });
+          }
+        }
+        let keys = Object.keys(properties$1);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          if (!(location$1 in v$2.d)) {
+            let tmp$1;
+            if (acc !== undefined) {
+              let properties$2 = acc.properties;
+              tmp$1 = properties$2 !== undefined ? properties$2[location$1] : undefined;
+            } else {
+              tmp$1 = undefined;
+            }
+            let inlinedLocation$1 = inlineLocation(input.g, location$1);
+            add(v$2, location$1, getShapedSerializerOutput(input, tmp$1, properties$1[location$1], path + (`[` + inlinedLocation$1 + `]`)));
+          }
+        }
+      } else {
+        exit$1 = 2;
+      }
+    }
+    if (exit$1 === 2) {
+      let from = targetSchema.from;
+      let path$1 = from !== undefined ? path + from.map(item => `["` + item + `"]`).join("") : path;
+      let tmp$2 = path$1 === "" ? "" : ` at ` + path$1;
+      invalidOperation(input, `Missing input for ` + toExpression(targetSchema) + tmp$2);
+    }
+    return completeObjectVal(v$2);
+  }
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
+}
+
 function getShapedParserOutput(input, targetSchema) {
   let from = targetSchema.from;
   let fromFlattened = targetSchema.fromFlattened;
@@ -3933,36 +3957,6 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
-}
-
 function shapedParser(input) {
   let flattened = input.e.flattened;
   if (flattened !== undefined) {
@@ -3983,6 +3977,12 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return markOutput(output, input);
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1021,20 +1021,12 @@ function typeofCond(tag, inputVar) {
   return `typeof ` + inputVar + `==="` + tag + `"`;
 }
 
-function nonNaNCond(inputVar) {
-  return `!Number.isNaN(` + inputVar + `)`;
-}
-
 function nanCond(inputVar) {
   return `Number.isNaN(` + inputVar + `)`;
 }
 
 function isArrayCond(inputVar) {
   return `Array.isArray(` + inputVar + `)`;
-}
-
-function nonArrayCond(inputVar) {
-  return `!Array.isArray(` + inputVar + `)`;
 }
 
 function objectTagCond(inputVar) {
@@ -1065,7 +1057,7 @@ function numberDecoder(input) {
     if (exit === 1) {
       if (!(input.g.o & 2)) {
         checks.push({
-          c: nonNaNCond,
+          c: inputVar => `!` + nanCond(inputVar),
           f: failInvalidType
         });
       }
@@ -1093,10 +1085,14 @@ function numberDecoder(input) {
   output.vc = [{
       c: param => {
         let match = input.e.format;
-        if (match === "int32") {
-          return int32FormatValidation(outputVar);
+        if (match !== undefined) {
+          if (match === "int32") {
+            return int32FormatValidation(outputVar);
+          } else {
+            return `!` + nanCond(outputVar);
+          }
         } else {
-          return nonNaNCond(outputVar);
+          return `!` + nanCond(outputVar);
         }
       },
       f: failInvalidType
@@ -1783,7 +1779,7 @@ function objectDecoder(unknownInput) {
       });
       if (expectedSchema.additionalItems !== "strip") {
         checks.push({
-          c: nonArrayCond,
+          c: inputVar => `!` + isArrayCond(inputVar),
           f: failInvalidType
         });
       }
@@ -2705,7 +2701,7 @@ function unionDecoder(input) {
                   c: inputVar => {
                     let tagFlag = flags[schema$1.type];
                     if (tagFlag & 64) {
-                      return objectTagCond(inputVar) + `&&` + nonArrayCond(inputVar);
+                      return objectTagCond(inputVar) + `&&!` + isArrayCond(inputVar);
                     }
                     if (tagFlag & 128) {
                       return isArrayCond(inputVar);
@@ -2718,7 +2714,7 @@ function unionDecoder(input) {
                       if (input.g.o & 2) {
                         return typeofCheck;
                       } else {
-                        return typeofCheck + `&&` + nonNaNCond(inputVar);
+                        return typeofCheck + `&&!` + nanCond(inputVar);
                       }
                     }
                     if (tagFlag & 2048) {
@@ -3648,48 +3644,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
 function prepareShapedSerializerAcc(acc, input) {
   let match = input.e;
   let from = match.from;
@@ -3744,6 +3698,62 @@ function prepareShapedSerializerAcc(acc, input) {
   for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
     prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
   }
+}
+
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3882,28 +3892,6 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = `~` + fieldName;
@@ -3968,6 +3956,14 @@ function nested(fieldName) {
   };
   parentCtx[cacheId] = ctx$1;
   return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
 }
 
 function shapedSerializer(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2658,20 +2658,24 @@ function unionDecoder(input) {
         }
       } else {
         let typeValidationInput = scope(input);
-        let narrow = base(schema$1.type, false);
-        narrow.encoder = schema$1.encoder;
-        if (tagFlag & 8192) {
-          narrow.class = schema$1.class;
-        } else if (tagFlag & 64) {
-          narrow.properties = immutableEmpty;
-          narrow.additionalItems = unknown;
-        } else if (tagFlag & 128) {
-          narrow.additionalItems = unknown;
-          narrow.items = immutableEmpty$1;
-        } else if (tagFlag & 2096) {
-          narrow.const = schema$1.const;
-        }
-        narrow.decoder = tagFlag & 33537 ? noopDecoder : input => {
+        let tmp;
+        if (tagFlag & 37633) {
+          tmp = unknown;
+        } else {
+          let narrow = base(schema$1.type, false);
+          narrow.encoder = schema$1.encoder;
+          if (tagFlag & 8192) {
+            narrow.class = schema$1.class;
+          } else if (tagFlag & 64) {
+            narrow.properties = immutableEmpty;
+            narrow.additionalItems = unknown;
+          } else if (tagFlag & 128) {
+            narrow.additionalItems = unknown;
+            narrow.items = immutableEmpty$1;
+          } else if (tagFlag & 2096) {
+            narrow.const = schema$1.const;
+          }
+          narrow.decoder = input => {
             if (flags[input.s.type] & 1) {
               return refine(input, input.e, [{
                   c: inputVar => {
@@ -2685,23 +2689,27 @@ function unionDecoder(input) {
                     if (tagFlag & 8192) {
                       return inputVar + ` instanceof ` + embed(input, schema$1.class);
                     }
-                    if (!(tagFlag & 4)) {
-                      if (tagFlag & 2048) {
-                        return `Number.isNaN(` + inputVar + `)`;
-                      } else if (tagFlag & 16) {
-                        return inputVar + `===void 0`;
-                      } else if (tagFlag & 32) {
-                        return inputVar + `===` + schema$1.type;
+                    if (tagFlag & 4) {
+                      let typeofCheck = `typeof ` + inputVar + `==="` + numberTag + `"`;
+                      if (input.g.o & 2) {
+                        return typeofCheck;
                       } else {
-                        return `typeof ` + inputVar + `==="` + schema$1.type + `"`;
+                        return typeofCheck + `&&!Number.isNaN(` + inputVar + `)`;
                       }
                     }
-                    let typeofCheck = `typeof ` + inputVar + `==="` + numberTag + `"`;
-                    if (input.g.o & 2) {
-                      return typeofCheck;
-                    } else {
-                      return typeofCheck + `&&!Number.isNaN(` + inputVar + `)`;
+                    if (tagFlag & 2048) {
+                      return `Number.isNaN(` + inputVar + `)`;
                     }
+                    if (tagFlag & 16) {
+                      return inputVar + `===void 0`;
+                    }
+                    if (tagFlag & 32) {
+                      return inputVar + `===` + schema$1.type;
+                    }
+                    if (tagFlag & 17418) {
+                      return `typeof ` + inputVar + `==="` + schema$1.type + `"`;
+                    }
+                    throw new Error(`[Sury] Unexpected union variant tag: ` + schema$1.type);
                   },
                   f: failInvalidType
                 }], undefined);
@@ -2709,7 +2717,9 @@ function unionDecoder(input) {
               return schema$1.decoder(input);
             }
           };
-        typeValidationInput.e = narrow;
+          tmp = narrow;
+        }
+        typeValidationInput.e = tmp;
         let typeValidationOutput;
         try {
           typeValidationOutput = parse$1(typeValidationInput);
@@ -2795,16 +2805,16 @@ function unionDecoder(input) {
       }
     }
     let errorCode = fail(caught);
-    let tmp;
+    let tmp$1;
     if (noop) {
       let if_$1 = nextElse ? "else if" : "if";
-      tmp = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
+      tmp$1 = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
     } else {
-      tmp = nextElse ? `else{` + errorCode + `}` : (
+      tmp$1 = nextElse ? `else{` + errorCode + `}` : (
           end === "" ? errorCode + ";" : errorCode
         );
     }
-    start = start + tmp;
+    start = start + tmp$1;
   }
   output.cp = output.cp + start + end;
   if (input.i !== output.i) {
@@ -2813,12 +2823,12 @@ function unionDecoder(input) {
   let o = output.f & 1 ? (output.i = `Promise.resolve(` + output.i + `)`, output.v = _notVar, output) : (
       output.v === _var && input.cp === "" && output.cp === "" && (output.l === output.i + `=` + initialInline || initialInline === "i") ? (input.l = "", input.a = initialAllocate, input.v = _notVar, input.i = initialInline, input) : output
     );
-  let tmp$1;
+  let tmp$2;
   if (outputAnyOf.length) {
-    let tmp$2;
+    let tmp$3;
     if (toPerCase !== undefined) {
       let seen = {};
-      tmp$2 = outputAnyOf.filter(s => {
+      tmp$3 = outputAnyOf.filter(s => {
         let key = toExpression(s);
         if (key in seen) {
           return false;
@@ -2828,13 +2838,13 @@ function unionDecoder(input) {
         }
       });
     } else {
-      tmp$2 = outputAnyOf;
+      tmp$3 = outputAnyOf;
     }
-    tmp$1 = factory$1(tmp$2);
+    tmp$2 = factory$1(tmp$3);
   } else {
-    tmp$1 = never_();
+    tmp$2 = never_();
   }
-  o.s = tmp$1;
+  o.s = tmp$2;
   o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
   return o;
 }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2840,28 +2840,7 @@ function unionDecoder(input) {
   let o = output.f & 1 ? (output.i = `Promise.resolve(` + output.i + `)`, output.v = _notVar, output) : (
       output.v === _var && input.cp === "" && output.cp === "" && (output.l === output.i + `=` + initialInline || initialInline === "i") ? (input.l = "", input.a = initialAllocate, input.v = _notVar, input.i = initialInline, input) : output
     );
-  let tmp$2;
-  if (outputAnyOf.length) {
-    let tmp$3;
-    if (toPerCase !== undefined) {
-      let seen = {};
-      tmp$3 = outputAnyOf.filter(s => {
-        let key = toExpression(s);
-        if (key in seen) {
-          return false;
-        } else {
-          seen[key] = true;
-          return true;
-        }
-      });
-    } else {
-      tmp$3 = outputAnyOf;
-    }
-    tmp$2 = factory$1(tmp$3);
-  } else {
-    tmp$2 = never_();
-  }
-  o.s = tmp$2;
+  o.s = outputAnyOf.length ? factory$1(outputAnyOf) : never_();
   o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
   return o;
 }
@@ -3644,62 +3623,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== objectTag || definition === null) {
     return parse(definition);
@@ -3740,20 +3663,6 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3853,43 +3762,68 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
       }
     } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
+      accAtFrom = acc;
     }
-    v = completeObjectVal(output);
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
   }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
 }
 
 function nested(fieldName) {
@@ -3958,12 +3892,57 @@ function nested(fieldName) {
   return ctx$1;
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
     }
-  });
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
 }
 
 function shapedSerializer(input) {
@@ -4872,14 +4851,22 @@ function internalToJSONSchema(schema, path, defs, parent) {
       case "union" :
         let literals = [];
         let items$1 = [];
+        let seen = {};
         schema.anyOf.forEach(childSchema => {
           if (childSchema.type === "undefined" && parent.type === objectTag) {
             return;
           }
-          items$1.push(internalToJSONSchema(childSchema, path, defs, schema));
-          if (constField in childSchema) {
-            literals.push(childSchema.const);
-            return;
+          let childJsonSchema = internalToJSONSchema(childSchema, path, defs, schema);
+          let key = JSON.stringify(childJsonSchema);
+          if (!(key in seen)) {
+            seen[key] = true;
+            items$1.push(childJsonSchema);
+            if (constField in childSchema) {
+              literals.push(childSchema.const);
+              return;
+            } else {
+              return;
+            }
           }
         });
         let itemsNumber$1 = items$1.length;

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2418,24 +2418,23 @@ function unionDecoder(input) {
                     if (tagFlag & 8192) {
                       return instanceofCond(input, schema$1.class)(inputVar);
                     }
-                    if (tagFlag & 4) {
-                      let typeofCheck = typeofCond(numberTag)(inputVar);
-                      if (input.g.o & 2) {
-                        return typeofCheck;
+                    if (!(tagFlag & 4)) {
+                      if (tagFlag & 2048) {
+                        return nanCond(inputVar);
+                      } else if (tagFlag & 48) {
+                        return inputVar + `===` + inlineConst(input, schema$1);
+                      } else if (tagFlag & 17418) {
+                        return typeofCond(schema$1.type)(inputVar);
                       } else {
-                        return typeofCheck + `&&!` + nanCond(inputVar);
+                        return "";
                       }
                     }
-                    if (tagFlag & 2048) {
-                      return nanCond(inputVar);
+                    let typeofCheck = typeofCond(numberTag)(inputVar);
+                    if (input.g.o & 2) {
+                      return typeofCheck;
+                    } else {
+                      return typeofCheck + `&&!` + nanCond(inputVar);
                     }
-                    if (tagFlag & 48) {
-                      return inputVar + `===` + inlineConst(input, schema$1);
-                    }
-                    if (tagFlag & 17418) {
-                      return typeofCond(schema$1.type)(inputVar);
-                    }
-                    throw new Error(`[Sury] Unexpected union variant tag: ` + schema$1.type);
                   },
                   f: failInvalidType
                 }], undefined);

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2658,33 +2658,58 @@ function unionDecoder(input) {
         }
       } else {
         let typeValidationInput = scope(input);
-        let tmp;
-        if (tagFlag & 32) {
-          tmp = nullLiteral();
-        } else if (tagFlag & 16) {
-          tmp = unit();
+        let narrow = base(schema$1.type, false);
+        narrow.encoder = schema$1.encoder;
+        if (tagFlag & 8192) {
+          narrow.class = schema$1.class;
         } else if (tagFlag & 64) {
-          tmp = factory(unknown);
+          narrow.properties = immutableEmpty;
+          narrow.additionalItems = unknown;
         } else if (tagFlag & 128) {
-          tmp = array(unknown);
-        } else if (tagFlag & 8192) {
-          let narrow = instance(schema$1.class);
-          narrow.encoder = schema$1.encoder;
-          tmp = narrow;
-        } else {
-          tmp = tagFlag & 2048 ? nan() : (
-              tagFlag & 2 ? string() : (
-                  tagFlag & 4 ? float() : (
-                      tagFlag & 8 ? bool() : (
-                          tagFlag & 1024 ? bigint() : (
-                              tagFlag & 16384 ? symbol() : unknown
-                            )
-                        )
-                    )
-                )
-            );
+          narrow.additionalItems = unknown;
+          narrow.items = immutableEmpty$1;
+        } else if (tagFlag & 2096) {
+          narrow.const = schema$1.const;
         }
-        typeValidationInput.e = tmp;
+        narrow.decoder = tagFlag & 33537 ? noopDecoder : input => {
+            if (flags[input.s.type] & 1) {
+              return refine(input, input.e, [{
+                  c: inputVar => {
+                    let tagFlag = flags[schema$1.type];
+                    if (tagFlag & 64) {
+                      return `typeof ` + inputVar + `==="` + objectTag + `"&&` + inputVar + `&&!Array.isArray(` + inputVar + `)`;
+                    }
+                    if (tagFlag & 128) {
+                      return `Array.isArray(` + inputVar + `)`;
+                    }
+                    if (tagFlag & 8192) {
+                      return inputVar + ` instanceof ` + embed(input, schema$1.class);
+                    }
+                    if (!(tagFlag & 4)) {
+                      if (tagFlag & 2048) {
+                        return `Number.isNaN(` + inputVar + `)`;
+                      } else if (tagFlag & 16) {
+                        return inputVar + `===void 0`;
+                      } else if (tagFlag & 32) {
+                        return inputVar + `===` + schema$1.type;
+                      } else {
+                        return `typeof ` + inputVar + `==="` + schema$1.type + `"`;
+                      }
+                    }
+                    let typeofCheck = `typeof ` + inputVar + `==="` + numberTag + `"`;
+                    if (input.g.o & 2) {
+                      return typeofCheck;
+                    } else {
+                      return typeofCheck + `&&!Number.isNaN(` + inputVar + `)`;
+                    }
+                  },
+                  f: failInvalidType
+                }], undefined);
+            } else {
+              return schema$1.decoder(input);
+            }
+          };
+        typeValidationInput.e = narrow;
         let typeValidationOutput;
         try {
           typeValidationOutput = parse$1(typeValidationInput);
@@ -2770,16 +2795,16 @@ function unionDecoder(input) {
       }
     }
     let errorCode = fail(caught);
-    let tmp$1;
+    let tmp;
     if (noop) {
       let if_$1 = nextElse ? "else if" : "if";
-      tmp$1 = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
+      tmp = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
     } else {
-      tmp$1 = nextElse ? `else{` + errorCode + `}` : (
+      tmp = nextElse ? `else{` + errorCode + `}` : (
           end === "" ? errorCode + ";" : errorCode
         );
     }
-    start = start + tmp$1;
+    start = start + tmp;
   }
   output.cp = output.cp + start + end;
   if (input.i !== output.i) {
@@ -2788,7 +2813,28 @@ function unionDecoder(input) {
   let o = output.f & 1 ? (output.i = `Promise.resolve(` + output.i + `)`, output.v = _notVar, output) : (
       output.v === _var && input.cp === "" && output.cp === "" && (output.l === output.i + `=` + initialInline || initialInline === "i") ? (input.l = "", input.a = initialAllocate, input.v = _notVar, input.i = initialInline, input) : output
     );
-  o.s = outputAnyOf.length ? factory$1(outputAnyOf) : never_();
+  let tmp$1;
+  if (outputAnyOf.length) {
+    let tmp$2;
+    if (toPerCase !== undefined) {
+      let seen = {};
+      tmp$2 = outputAnyOf.filter(s => {
+        let key = toExpression(s);
+        if (key in seen) {
+          return false;
+        } else {
+          seen[key] = true;
+          return true;
+        }
+      });
+    } else {
+      tmp$2 = outputAnyOf;
+    }
+    tmp$1 = factory$1(tmp$2);
+  } else {
+    tmp$1 = never_();
+  }
+  o.s = tmp$1;
   o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
   return o;
 }
@@ -3571,6 +3617,101 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3668,101 +3809,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
 function getValByFrom(_input, from, _idx) {
   while (true) {
     let idx = _idx;
@@ -3817,6 +3863,16 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function nested(fieldName) {
@@ -3891,16 +3947,6 @@ function definitionToSchema(definition) {
       return node;
     }
   });
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
 }
 
 function definitionToShapedSchema(definition) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1962,7 +1962,7 @@ function instanceDecoder(input) {
         f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
-    return input;
+    return refine(input, input.e, undefined, undefined);
   } else {
     return unsupportedDecode(input, input.s, input.e);
   }
@@ -3447,7 +3447,7 @@ function date() {
       } else if (inputTagFlag & 1) {
         return invalidDateRefine(instanceDecoder(input));
       } else if (inputTagFlag & 8192 && input.s.class === s.class) {
-        return input;
+        return refine(input, input.e, undefined, undefined);
       } else {
         return unsupportedDecode(input, input.s, input.e);
       }

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1017,11 +1017,39 @@ function int32FormatValidation(inputVar) {
   return inputVar + `<=2147483647&&` + inputVar + `>=-2147483648&&` + inputVar + `%1===0`;
 }
 
+function typeofCond(tag, inputVar) {
+  return `typeof ` + inputVar + `==="` + tag + `"`;
+}
+
+function nonNaNCond(inputVar) {
+  return `!Number.isNaN(` + inputVar + `)`;
+}
+
+function nanCond(inputVar) {
+  return `Number.isNaN(` + inputVar + `)`;
+}
+
+function isArrayCond(inputVar) {
+  return `Array.isArray(` + inputVar + `)`;
+}
+
+function nonArrayCond(inputVar) {
+  return `!Array.isArray(` + inputVar + `)`;
+}
+
+function objectTagCond(inputVar) {
+  return typeofCond(objectTag, inputVar) + `&&` + inputVar;
+}
+
+function instanceofCond(b, $$class, inputVar) {
+  return inputVar + ` instanceof ` + embed(b, $$class);
+}
+
 function numberDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     let checks = [{
-        c: inputVar => `typeof ` + inputVar + `==="` + numberTag + `"`,
+        c: inputVar => typeofCond(numberTag, inputVar),
         f: failInvalidType
       }];
     let match = input.e.format;
@@ -1037,7 +1065,7 @@ function numberDecoder(input) {
     if (exit === 1) {
       if (!(input.g.o & 2)) {
         checks.push({
-          c: inputVar => `!Number.isNaN(` + inputVar + `)`,
+          c: nonNaNCond,
           f: failInvalidType
         });
       }
@@ -1065,14 +1093,10 @@ function numberDecoder(input) {
   output.vc = [{
       c: param => {
         let match = input.e.format;
-        if (match !== undefined) {
-          if (match === "int32") {
-            return int32FormatValidation(outputVar);
-          } else {
-            return `!Number.isNaN(` + outputVar + `)`;
-          }
+        if (match === "int32") {
+          return int32FormatValidation(outputVar);
         } else {
-          return `!Number.isNaN(` + outputVar + `)`;
+          return nonNaNCond(outputVar);
         }
       },
       f: failInvalidType
@@ -1101,7 +1125,7 @@ function stringDecoderFn(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => `typeof ` + inputVar + `==="` + stringTag + `"`,
+        c: inputVar => typeofCond(stringTag, inputVar),
         f: failInvalidType
       }], undefined);
   }
@@ -1130,7 +1154,7 @@ function booleanDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => `typeof ` + inputVar + `==="` + booleanTag + `"`,
+        c: inputVar => typeofCond(booleanTag, inputVar),
         f: failInvalidType
       }], undefined);
   }
@@ -1160,7 +1184,7 @@ function bigintDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => `typeof ` + inputVar + `==="` + bigintTag + `"`,
+        c: inputVar => typeofCond(bigintTag, inputVar),
         f: failInvalidType
       }], undefined);
   }
@@ -1191,7 +1215,7 @@ function symbolDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => `typeof ` + inputVar + `==="` + symbolTag + `"`,
+        c: inputVar => typeofCond(symbolTag, inputVar),
         f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 16384) {
@@ -1229,7 +1253,7 @@ function literalDecoder(input) {
   if (!(flags[input.s.type] & 2 && schemaTagFlag & 3132)) {
     if (schemaTagFlag & 2048) {
       return refine(input, expectedSchema, [{
-          c: inputVar => `Number.isNaN(` + inputVar + `)`,
+          c: nanCond,
           f: failInvalidType
         }], undefined);
     } else {
@@ -1642,7 +1666,7 @@ function arrayDecoder(unknownInput) {
     let checks = [];
     if (!isArrayInput) {
       checks.push({
-        c: inputVar => `Array.isArray(` + inputVar + `)`,
+        c: isArrayCond,
         f: failInvalidType
       });
     }
@@ -1754,12 +1778,12 @@ function objectDecoder(unknownInput) {
     let checks = [];
     if (!isObjectInput) {
       checks.push({
-        c: inputVar => `typeof ` + inputVar + `==="` + objectTag + `"&&` + inputVar,
+        c: objectTagCond,
         f: failInvalidType
       });
       if (expectedSchema.additionalItems !== "strip") {
         checks.push({
-          c: inputVar => `!Array.isArray(` + inputVar + `)`,
+          c: nonArrayCond,
           f: failInvalidType
         });
       }
@@ -1958,7 +1982,7 @@ function instanceDecoder(input) {
   let inputTagFlag = flags[input.s.type];
   if (inputTagFlag & 1) {
     return refine(input, input.e, [{
-        c: inputVar => inputVar + ` instanceof ` + embed(input, input.e.class),
+        c: inputVar => instanceofCond(input, input.e.class, inputVar),
         f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
@@ -2681,33 +2705,30 @@ function unionDecoder(input) {
                   c: inputVar => {
                     let tagFlag = flags[schema$1.type];
                     if (tagFlag & 64) {
-                      return `typeof ` + inputVar + `==="` + objectTag + `"&&` + inputVar + `&&!Array.isArray(` + inputVar + `)`;
+                      return objectTagCond(inputVar) + `&&` + nonArrayCond(inputVar);
                     }
                     if (tagFlag & 128) {
-                      return `Array.isArray(` + inputVar + `)`;
+                      return isArrayCond(inputVar);
                     }
                     if (tagFlag & 8192) {
-                      return inputVar + ` instanceof ` + embed(input, schema$1.class);
+                      return instanceofCond(input, schema$1.class, inputVar);
                     }
                     if (tagFlag & 4) {
-                      let typeofCheck = `typeof ` + inputVar + `==="` + numberTag + `"`;
+                      let typeofCheck = typeofCond(numberTag, inputVar);
                       if (input.g.o & 2) {
                         return typeofCheck;
                       } else {
-                        return typeofCheck + `&&!Number.isNaN(` + inputVar + `)`;
+                        return typeofCheck + `&&` + nonNaNCond(inputVar);
                       }
                     }
                     if (tagFlag & 2048) {
-                      return `Number.isNaN(` + inputVar + `)`;
+                      return nanCond(inputVar);
                     }
-                    if (tagFlag & 16) {
-                      return inputVar + `===void 0`;
-                    }
-                    if (tagFlag & 32) {
-                      return inputVar + `===` + schema$1.type;
+                    if (tagFlag & 48) {
+                      return inputVar + `===` + inlineConst(input, schema$1);
                     }
                     if (tagFlag & 17418) {
-                      return `typeof ` + inputVar + `==="` + schema$1.type + `"`;
+                      return typeofCond(schema$1.type, inputVar);
                     }
                     throw new Error(`[Sury] Unexpected union variant tag: ` + schema$1.type);
                   },
@@ -3627,43 +3648,46 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
   }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
 }
 
 function prepareShapedSerializerAcc(acc, input) {
@@ -3819,6 +3843,45 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
 function getValByFrom(_input, from, _idx) {
   while (true) {
     let idx = _idx;
@@ -3833,56 +3896,12 @@ function getValByFrom(_input, from, _idx) {
   };
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
     }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+  });
 }
 
 function nested(fieldName) {
@@ -3951,18 +3970,14 @@ function nested(fieldName) {
   return ctx$1;
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input) {
@@ -3985,6 +4000,12 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return markOutput(output, input);
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1962,7 +1962,7 @@ function instanceDecoder(input) {
         f: failInvalidType
       }], undefined);
   } else if (inputTagFlag & 8192 && input.s.class === input.e.class) {
-    return refine(input, input.e, undefined, undefined);
+    return input;
   } else {
     return unsupportedDecode(input, input.s, input.e);
   }
@@ -2658,27 +2658,33 @@ function unionDecoder(input) {
         }
       } else {
         let typeValidationInput = scope(input);
-        typeValidationInput.e = tagFlag & 32 ? nullLiteral() : (
-            tagFlag & 16 ? unit() : (
-                tagFlag & 64 ? factory(unknown) : (
-                    tagFlag & 128 ? array(unknown) : (
-                        tagFlag & 8192 ? instance(schema$1.class) : (
-                            tagFlag & 2048 ? nan() : (
-                                tagFlag & 2 ? string() : (
-                                    tagFlag & 4 ? float() : (
-                                        tagFlag & 8 ? bool() : (
-                                            tagFlag & 1024 ? bigint() : (
-                                                tagFlag & 16384 ? symbol() : unknown
-                                              )
-                                          )
-                                      )
-                                  )
-                              )
-                          )
-                      )
-                  )
-              )
-          );
+        let tmp;
+        if (tagFlag & 32) {
+          tmp = nullLiteral();
+        } else if (tagFlag & 16) {
+          tmp = unit();
+        } else if (tagFlag & 64) {
+          tmp = factory(unknown);
+        } else if (tagFlag & 128) {
+          tmp = array(unknown);
+        } else if (tagFlag & 8192) {
+          let narrow = instance(schema$1.class);
+          narrow.encoder = schema$1.encoder;
+          tmp = narrow;
+        } else {
+          tmp = tagFlag & 2048 ? nan() : (
+              tagFlag & 2 ? string() : (
+                  tagFlag & 4 ? float() : (
+                      tagFlag & 8 ? bool() : (
+                          tagFlag & 1024 ? bigint() : (
+                              tagFlag & 16384 ? symbol() : unknown
+                            )
+                        )
+                    )
+                )
+            );
+        }
+        typeValidationInput.e = tmp;
         let typeValidationOutput;
         try {
           typeValidationOutput = parse$1(typeValidationInput);
@@ -2764,16 +2770,16 @@ function unionDecoder(input) {
       }
     }
     let errorCode = fail(caught);
-    let tmp;
+    let tmp$1;
     if (noop) {
       let if_$1 = nextElse ? "else if" : "if";
-      tmp = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
+      tmp$1 = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
     } else {
-      tmp = nextElse ? `else{` + errorCode + `}` : (
+      tmp$1 = nextElse ? `else{` + errorCode + `}` : (
           end === "" ? errorCode + ";" : errorCode
         );
     }
-    start = start + tmp;
+    start = start + tmp$1;
   }
   output.cp = output.cp + start + end;
   if (input.i !== output.i) {
@@ -3447,7 +3453,7 @@ function date() {
       } else if (inputTagFlag & 1) {
         return invalidDateRefine(instanceDecoder(input));
       } else if (inputTagFlag & 8192 && input.s.class === s.class) {
-        return refine(input, input.e, undefined, undefined);
+        return input;
       } else {
         return unsupportedDecode(input, input.s, input.e);
       }
@@ -3563,20 +3569,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
       return proxifyShapedSchema(maybeField, target.from.concat(prop), target.fromFlattened);
     }
   });
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3732,14 +3724,57 @@ function prepareShapedSerializerAcc(acc, input) {
   }
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function traverseDefinition(definition, onNode) {
@@ -3782,53 +3817,6 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
 }
 
 function nested(fieldName) {
@@ -3895,6 +3883,24 @@ function nested(fieldName) {
   };
   parentCtx[cacheId] = ctx$1;
   return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function definitionToShapedSchema(definition) {

--- a/packages/sury/tests/S_date_test.res
+++ b/packages/sury/tests/S_date_test.res
@@ -177,26 +177,16 @@ test("Successfully round-trips date through JSON", t => {
   )
 })
 
-// Reverse (encode) of a nullable/optional `string->S.to(S.date)` field.
+// Reverse (encode) of nullable/optional date fields.
 //
-// Reproduces a user report: given a `@s.nullable option<Timestamp.t>` field
-// (which the ppx expands to `S.nullableAsOption(Timestamp.schema)`), encoding
-// the value back throws `received [object Date]` instead of serializing the Date
-// to its ISO string. Parsing works — only the reverse direction is broken, and
-// only because the transformed value is an `S.date` (an Instance schema) wrapped
-// in the union: reverse swaps each variant's parser/serializer but the `.to`
-// conversion to the Date is driven by the date's encoder, which isn't re-applied
-// per variant, so the reversed variant is left as a bare `Date` with no way back
-// to a string.
-//
-// The bare `S.string->S.to(S.date)` reverses correctly (see "Successfully
-// reverse converts string-to-date schema" above), and the same union wrapper
-// reverses correctly for primitive transforms such as `S.bool->S.to(S.string)`
-// (see S_nullable_test.res), so the defect is specific to a transformed Instance
-// schema inside a nullable/optional union.
-//
-// The asserts below pin the current (buggy) output; the `FIXME`s describe what
-// they should become once the reverse is fixed.
+// Regression guard for a reported bug: a `@s.nullable option<Timestamp.t>` field
+// (which the ppx expands to `S.nullableAsOption(Timestamp.schema)`) used to throw
+// `received [object Date]` when encoding, instead of serializing the Date back to
+// a string. Parsing always worked; only the reverse direction was broken, because
+// the union routes each variant through a bare type-check schema (`instance(Date)`)
+// that doesn't carry the date's encoder. The instance decoders now promote the
+// routed value to the variant's own schema, so a pending `.to` conversion (here
+// `Date.toISOString()`) is applied per variant.
 
 module Timestamp = {
   type t = Date.t
@@ -218,22 +208,16 @@ test("Reverse converts nullableAsOption string-to-date schema", t => {
     `i=>{if(typeof i==="string"){let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);i=v0}else if(i===null){i=void 0}else if(!(i===void 0)){e[1](i)}return i}`,
   )
 
-  // Encoding `None` happens to round-trip, since that variant needs no transform.
+  // Encoding serializes the Date back to its ISO string; None round-trips.
+  t->Assert.deepEqual(
+    Some(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    "2024-01-01T00:00:00.000Z"->Obj.magic,
+  )
   t->Assert.deepEqual(None->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`undefined`))
-
-  // FIXME: Encoding the Date should serialize it back to its ISO string
-  // ("2024-01-01T00:00:00.000Z"), like the bare `S.string->S.to(S.date)` does.
-  // Instead the reversed schema dispatches on `instanceof Date` and then has no
-  // conversion to apply, so it throws.
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Encode,
-    `i=>{if(i instanceof e[2]){e[1](i,e[0])}else if(!(i===void 0)){e[3](i)}return i}`,
-  )
-  t->U.assertThrowsMessage(
-    () => Some(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
-    `Expected Date | undefined | undefined, received [object Date]
-- Can't decode Date to string. Use S.to to define a custom decoder`,
+    `i=>{if(i instanceof e[0]){i=i.toISOString()}else if(!(i===void 0)){e[1](i)}return i}`,
   )
 })
 
@@ -242,17 +226,14 @@ test("Reverse converts nullable string-to-date schema", t => {
   let date = Date.fromString("2024-01-01T00:00:00.000Z")
 
   t->Assert.deepEqual(Nullable.Null->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`null`))
-
-  // FIXME: Should serialize the Date back to "2024-01-01T00:00:00.000Z".
+  t->Assert.deepEqual(
+    Nullable.Value(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    "2024-01-01T00:00:00.000Z"->Obj.magic,
+  )
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Encode,
-    `i=>{if(i instanceof e[2]){e[1](i,e[0])}else if(!(i===void 0||i===null)){e[3](i)}return i}`,
-  )
-  t->U.assertThrowsMessage(
-    () => Nullable.Value(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
-    `Expected Date | undefined | null, received [object Date]
-- Can't decode Date to string. Use S.to to define a custom decoder`,
+    `i=>{if(i instanceof e[0]){i=i.toISOString()}else if(!(i===void 0||i===null)){e[1](i)}return i}`,
   )
 })
 
@@ -285,15 +266,37 @@ test("Reverse converts deeply nested records/array sharing a nullable Timestamp 
     },
   )
 
-  // FIXME: Encoding back should produce the original JSON with ISO strings, e.g.
-  // `{createdAt: "2024-01-01T00:00:00.000Z", items: [{createdAt: "...Z"}]}`.
+  // Encoding back produces the original JSON with ISO strings.
   let value = {
     "createdAt": Some(date),
     "items": [{"createdAt": Some(date)}],
   }
-  t->U.assertThrowsMessage(
-    () => value->S.decodeOrThrow(~from=parentSchema, ~to=S.unknown),
-    `Failed at ["createdAt"]: Expected Date | undefined | undefined, received [object Date]
-- At ["createdAt"]: Can't decode Date to string. Use S.to to define a custom decoder`,
+  t->Assert.deepEqual(
+    value->S.decodeOrThrow(~from=parentSchema, ~to=S.unknown),
+    %raw(`{createdAt: "2024-01-01T00:00:00.000Z", items: [{createdAt: "2024-01-01T00:00:00.000Z"}]}`),
+  )
+})
+
+test("Encodes a nullable optional Timestamp whose input is string | number (issue repro)", t => {
+  // The reported Timestamp accepts a string or a numeric timestamp:
+  //   S.union([S.string, S.float])->S.to(S.date)
+  // so `@s.nullable option<Timestamp.t>` reverses to a Date variant whose `.to`
+  // target is `string | number`. Encoding used to throw exactly
+  // `Expected string | number, received [object Date]`.
+  let timestamp = S.union([S.string->S.castToUnknown, S.float->S.castToUnknown])->S.to(S.date)
+  let schema = S.nullableAsOption(timestamp)
+  let date = Date.fromString("2024-01-01T00:00:00.000Z")
+
+  t->Assert.deepEqual("2024-01-01T00:00:00.000Z"->S.parseOrThrow(~to=schema), Some(date))
+  t->Assert.deepEqual(%raw(`null`)->S.parseOrThrow(~to=schema), None)
+
+  t->Assert.deepEqual(
+    Some(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    "2024-01-01T00:00:00.000Z"->Obj.magic,
+  )
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Encode,
+    `i=>{if(i instanceof e[2]){try{i=i.toISOString()}catch(e0){e[1](i,e0,e[0])}}else if(!(i===void 0)){e[3](i)}return i}`,
   )
 })

--- a/packages/sury/tests/S_date_test.res
+++ b/packages/sury/tests/S_date_test.res
@@ -176,3 +176,124 @@ test("Successfully round-trips date through JSON", t => {
     {"field": date},
   )
 })
+
+// Reverse (encode) of a nullable/optional `string->S.to(S.date)` field.
+//
+// Reproduces a user report: given a `@s.nullable option<Timestamp.t>` field
+// (which the ppx expands to `S.nullableAsOption(Timestamp.schema)`), encoding
+// the value back throws `received [object Date]` instead of serializing the Date
+// to its ISO string. Parsing works — only the reverse direction is broken, and
+// only because the transformed value is an `S.date` (an Instance schema) wrapped
+// in the union: reverse swaps each variant's parser/serializer but the `.to`
+// conversion to the Date is driven by the date's encoder, which isn't re-applied
+// per variant, so the reversed variant is left as a bare `Date` with no way back
+// to a string.
+//
+// The bare `S.string->S.to(S.date)` reverses correctly (see "Successfully
+// reverse converts string-to-date schema" above), and the same union wrapper
+// reverses correctly for primitive transforms such as `S.bool->S.to(S.string)`
+// (see S_nullable_test.res), so the defect is specific to a transformed Instance
+// schema inside a nullable/optional union.
+//
+// The asserts below pin the current (buggy) output; the `FIXME`s describe what
+// they should become once the reverse is fixed.
+
+module Timestamp = {
+  type t = Date.t
+
+  let schema: S.t<t> = S.string->S.to(S.date)
+}
+
+test("Reverse converts nullableAsOption string-to-date schema", t => {
+  let schema = S.nullableAsOption(Timestamp.schema)
+  let date = Date.fromString("2024-01-01T00:00:00.000Z")
+
+  // Parsing the string into an optional Date works as expected.
+  t->Assert.deepEqual("2024-01-01T00:00:00.000Z"->S.parseOrThrow(~to=schema), Some(date))
+  t->Assert.deepEqual(%raw(`null`)->S.parseOrThrow(~to=schema), None)
+  t->Assert.deepEqual(%raw(`undefined`)->S.parseOrThrow(~to=schema), None)
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{if(typeof i==="string"){let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);i=v0}else if(i===null){i=void 0}else if(!(i===void 0)){e[1](i)}return i}`,
+  )
+
+  // Encoding `None` happens to round-trip, since that variant needs no transform.
+  t->Assert.deepEqual(None->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`undefined`))
+
+  // FIXME: Encoding the Date should serialize it back to its ISO string
+  // ("2024-01-01T00:00:00.000Z"), like the bare `S.string->S.to(S.date)` does.
+  // Instead the reversed schema dispatches on `instanceof Date` and then has no
+  // conversion to apply, so it throws.
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Encode,
+    `i=>{if(i instanceof e[2]){e[1](i,e[0])}else if(!(i===void 0)){e[3](i)}return i}`,
+  )
+  t->U.assertThrowsMessage(
+    () => Some(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    `Expected Date | undefined | undefined, received [object Date]
+- Can't decode Date to string. Use S.to to define a custom decoder`,
+  )
+})
+
+test("Reverse converts nullable string-to-date schema", t => {
+  let schema = S.nullable(Timestamp.schema)
+  let date = Date.fromString("2024-01-01T00:00:00.000Z")
+
+  t->Assert.deepEqual(Nullable.Null->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`null`))
+
+  // FIXME: Should serialize the Date back to "2024-01-01T00:00:00.000Z".
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Encode,
+    `i=>{if(i instanceof e[2]){e[1](i,e[0])}else if(!(i===void 0||i===null)){e[3](i)}return i}`,
+  )
+  t->U.assertThrowsMessage(
+    () => Nullable.Value(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    `Expected Date | undefined | null, received [object Date]
+- Can't decode Date to string. Use S.to to define a custom decoder`,
+  )
+})
+
+test("Reverse converts deeply nested records/array sharing a nullable Timestamp field", t => {
+  // `@s.nullable option<Timestamp.t>` field, present both on a nested record
+  // (inside an array) and on the parent record with the same name and type.
+  let field = () => S.nullableAsOption(Timestamp.schema)
+
+  let itemSchema = S.schema(s =>
+    {
+      "createdAt": s.matches(field()),
+    }
+  )
+  let parentSchema = S.schema(s =>
+    {
+      "createdAt": s.matches(field()),
+      "items": s.matches(S.array(itemSchema)),
+    }
+  )
+
+  let date = Date.fromString("2024-01-01T00:00:00.000Z")
+
+  // Parsing the nested structure works.
+  t->Assert.deepEqual(
+    %raw(`{createdAt: "2024-01-01T00:00:00.000Z", items: [{createdAt: "2024-01-01T00:00:00.000Z"}]}`)
+    ->S.parseOrThrow(~to=parentSchema),
+    {
+      "createdAt": Some(date),
+      "items": [{"createdAt": Some(date)}],
+    },
+  )
+
+  // FIXME: Encoding back should produce the original JSON with ISO strings, e.g.
+  // `{createdAt: "2024-01-01T00:00:00.000Z", items: [{createdAt: "...Z"}]}`.
+  let value = {
+    "createdAt": Some(date),
+    "items": [{"createdAt": Some(date)}],
+  }
+  t->U.assertThrowsMessage(
+    () => value->S.decodeOrThrow(~from=parentSchema, ~to=S.unknown),
+    `Failed at ["createdAt"]: Expected Date | undefined | undefined, received [object Date]
+- At ["createdAt"]: Can't decode Date to string. Use S.to to define a custom decoder`,
+  )
+})

--- a/packages/sury/tests/S_date_test.res
+++ b/packages/sury/tests/S_date_test.res
@@ -177,16 +177,10 @@ test("Successfully round-trips date through JSON", t => {
   )
 })
 
-// Reverse (encode) of nullable/optional date fields.
-//
-// Regression guard for a reported bug: a `@s.nullable option<Timestamp.t>` field
-// (which the ppx expands to `S.nullableAsOption(Timestamp.schema)`) used to throw
-// `received [object Date]` when encoding, instead of serializing the Date back to
-// a string. Parsing always worked; only the reverse direction was broken, because
-// the union routes each variant through a bare type-check schema (`instance(Date)`)
-// that doesn't carry the date's encoder. The instance decoders now promote the
-// routed value to the variant's own schema, so a pending `.to` conversion (here
-// `Date.toISOString()`) is applied per variant.
+// Regression guard: encoding a `@s.nullable option<Timestamp.t>` field (ppx-expanded
+// to `S.nullableAsOption(Timestamp.schema)`) used to throw `received [object Date]`
+// instead of serializing the Date back to a string. Parsing was never affected — only
+// the reverse, where the union variant's type-check narrow dropped the member's encoder.
 
 module Timestamp = {
   type t = Date.t
@@ -198,7 +192,6 @@ test("Reverse converts nullableAsOption string-to-date schema", t => {
   let schema = S.nullableAsOption(Timestamp.schema)
   let date = Date.fromString("2024-01-01T00:00:00.000Z")
 
-  // Parsing the string into an optional Date works as expected.
   t->Assert.deepEqual("2024-01-01T00:00:00.000Z"->S.parseOrThrow(~to=schema), Some(date))
   t->Assert.deepEqual(%raw(`null`)->S.parseOrThrow(~to=schema), None)
   t->Assert.deepEqual(%raw(`undefined`)->S.parseOrThrow(~to=schema), None)
@@ -208,7 +201,6 @@ test("Reverse converts nullableAsOption string-to-date schema", t => {
     `i=>{if(typeof i==="string"){let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);i=v0}else if(i===null){i=void 0}else if(!(i===void 0)){e[1](i)}return i}`,
   )
 
-  // Encoding serializes the Date back to its ISO string; None round-trips.
   t->Assert.deepEqual(
     Some(date)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
     "2024-01-01T00:00:00.000Z"->Obj.magic,
@@ -256,7 +248,6 @@ test("Reverse converts deeply nested records/array sharing a nullable Timestamp 
 
   let date = Date.fromString("2024-01-01T00:00:00.000Z")
 
-  // Parsing the nested structure works.
   t->Assert.deepEqual(
     %raw(`{createdAt: "2024-01-01T00:00:00.000Z", items: [{createdAt: "2024-01-01T00:00:00.000Z"}]}`)
     ->S.parseOrThrow(~to=parentSchema),
@@ -266,7 +257,6 @@ test("Reverse converts deeply nested records/array sharing a nullable Timestamp 
     },
   )
 
-  // Encoding back produces the original JSON with ISO strings.
   let value = {
     "createdAt": Some(date),
     "items": [{"createdAt": Some(date)}],

--- a/packages/sury/tests/S_union_test.res
+++ b/packages/sury/tests/S_union_test.res
@@ -1034,3 +1034,41 @@ test("Tagged tuple union dispatches via literal first-field discriminant", t => 
   t->Assert.deepEqual(("a", "hello")->S.parseOrThrow(~to=schema), ("a", "hello"))
   t->Assert.deepEqual(("b", "world")->S.parseOrThrow(~to=schema), ("b", "world"))
 })
+
+test("Union type-narrow stays in sync with each schema's own decoder", t => {
+  // Guards the `typeCheckCond` invariant: the union dispatch re-emits each type's
+  // narrow check, so it must contain the same atoms the schema's own decoder
+  // emits. If `typeCheckCond` or a decoder drifts, this fails.
+  let assertSync = (schema, ~other, atoms) => {
+    let standalone = schema->U.getCompiledCodeString(~op=#Parse)
+    let dispatch =
+      S.union([schema->S.castToUnknown, other])->U.getCompiledCodeString(~op=#Parse)
+    atoms->Array.forEach(atom => {
+      t->Assert.is(standalone->String.includes(atom), true, ~message=`decoder emits ${atom}`)
+      t->Assert.is(dispatch->String.includes(atom), true, ~message=`union dispatch emits ${atom}`)
+    })
+  }
+  assertSync(S.string, ~other=S.bool->S.castToUnknown, [`typeof i==="string"`])
+  assertSync(S.float, ~other=S.bool->S.castToUnknown, [`typeof i==="number"&&!Number.isNaN(i)`])
+  assertSync(S.bool, ~other=S.string->S.castToUnknown, [`typeof i==="boolean"`])
+  assertSync(S.bigint, ~other=S.bool->S.castToUnknown, [`typeof i==="bigint"`])
+  assertSync(S.symbol, ~other=S.bool->S.castToUnknown, [`typeof i==="symbol"`])
+  assertSync(S.date, ~other=S.bool->S.castToUnknown, [` instanceof `])
+  assertSync(
+    S.dict(S.string),
+    ~other=S.bool->S.castToUnknown,
+    [`typeof i==="object"&&i&&!Array.isArray(i)`],
+  )
+  assertSync(S.array(S.string), ~other=S.bool->S.castToUnknown, [`Array.isArray(i)`])
+})
+
+test("Coerces a concrete input into a union's instance member via the member's decoder", t => {
+  // The dispatch narrow delegates a concrete (non-`unknown`) input to the member's
+  // own decoder, so coercion into an instance variant works (string -> new Date)
+  // instead of being rejected as it was with the old generic `instance(class)` narrow.
+  let schema = S.string->S.to(S.union([S.date->S.castToUnknown, S.float->S.castToUnknown]))
+  t->Assert.deepEqual(
+    "2024-01-01T00:00:00.000Z"->S.parseOrThrow(~to=schema),
+    Date.fromString("2024-01-01T00:00:00.000Z")->Obj.magic,
+  )
+})


### PR DESCRIPTION
## Summary

Refactors type-checking logic to extract atomic condition builders (`typeofCond`, `nanCond`, `isArrayCond`, `objectTagCond`, `instanceofCond`) as the single source of truth for type-narrowing checks. These are now shared between individual type decoders and the union dispatch mechanism to prevent drift and enable tree-shaking of unused decoders.

## Key Changes

- **Extracted atomic type-check builders** — Five new helper functions encapsulate the type-check strings previously inlined throughout decoders:
  - `typeofCond(tag, ~inputVar)` — `typeof x === "tag"`
  - `nanCond(~inputVar)` — `Number.isNaN(x)`
  - `isArrayCond(~inputVar)` — `Array.isArray(x)`
  - `objectTagCond(~inputVar)` — `typeof x === "object" && x`
  - `instanceofCond(b, class, ~inputVar)` — `x instanceof Class`

- **Unified union dispatch type-narrowing** — Replaced the old nested ternary that constructed full type-specific schemas (`string()`, `float()`, `instance(Date)`, etc.) with a minimal `narrow` schema that:
  - Carries only the variant's encoder (enabling `.to` conversions)
  - Emits type checks via the new `typeCheckCond` function (composed from atomic builders)
  - Delegates coercion to the member's own decoder when input is concrete (non-`unknown`)
  - Avoids referencing per-type factories, allowing unused decoders to tree-shake

- **Fixed reverse (encode) of nullable/optional transformed types** — Union variants now promote routed values to their full schema (with encoder), so pending `.to` conversions apply per-variant instead of being lost. Fixes the bug where `@s.nullable option<Timestamp.t>` (expanding to `S.nullableAsOption(S.string->S.to(S.date))`) threw "received [object Date]" on encode.

- **Deduplicated JSON schema generation** — Added deduplication in `internalToJSONSchema` for union variants that coerce to the same `.to` target, preventing duplicate entries in the output schema.

- **Reorganized helper functions** — Moved `traverseDefinition`, `getValByFrom`, `getShapedParserOutput`, and `shapedSerializer` to improve logical grouping and reduce forward references.

## Notable Implementation Details

- The `typeCheckCond` function in the union module mirrors the logic of individual type decoders, ensuring the dispatch condition and per-variant decoder stay synchronized. Comments document the tree-shaking invariant.
- The narrow schema's decoder is per-invocation (not hoisted), allowing it to behave differently depending on whether the input is `unknown` (emit discriminant) or concrete (delegate to member decoder).
- Variants using catch-all tags (unknown, union, ref, function, never) still use the `unknown` narrow and skip `typeCheckCond`, avoiding unreachable code paths.
- Test coverage added for the sync invariant and the fixed encode path for nullable/optional transformed types.

https://claude.ai/code/session_012W8wsVGEqnDeAk5GTxjb2j