### PR TITLE
Bump version to 11.0.0-alpha.9

### DIFF
--- a/packages/sury-ppx/jsr.json
+++ b/packages/sury-ppx/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/ppx",
-  "version": "11.0.0-alpha.6",
+  "version": "11.0.0-alpha.9",
   "license": "MIT",
   "exports": "./index.ts"
 }

--- a/packages/sury-ppx/package.json
+++ b/packages/sury-ppx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury-ppx",
-  "version": "11.0.0-alpha.6",
+  "version": "11.0.0-alpha.9",
   "description": "⚙️ ReScript PPX to generate Sury schema from types",
   "keywords": [
     "Sury",
@@ -33,6 +33,6 @@
     "postinstall": "node ./install.cjs"
   },
   "peerDependencies": {
-    "sury": "^11.0.0-alpha.6"
+    "sury": "^11.0.0-alpha.9"
   }
 }

--- a/packages/sury/jsr.json
+++ b/packages/sury/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/sury",
-  "version": "11.0.0-alpha.6",
+  "version": "11.0.0-alpha.9",
   "license": "MIT",
   "exclude": ["!src", "!rescript.json", "!README.md", "!package.json", "!docs"],
   "exports": "./src/S.mjs"

--- a/packages/sury/package.json
+++ b/packages/sury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury",
-  "version": "11.0.0-alpha.6",
+  "version": "11.0.0-alpha.9",
   "private": true,
   "description": "🧬 The fastest schema with next-gen DX",
   "keywords": [


### PR DESCRIPTION
## Summary
Bump Sury and sury-ppx packages to version 11.0.0-alpha.9 across all package manifests.

## Changes
- Updated `sury` package version from 11.0.0-alpha.6 to 11.0.0-alpha.9 in `package.json` and `jsr.json`
- Updated `sury-ppx` package version from 11.0.0-alpha.6 to 11.0.0-alpha.9 in `package.json` and `jsr.json`
- Updated peer dependency constraint for `sury` in `sury-ppx/package.json` to `^11.0.0-alpha.9`

## Notes
This is a routine version bump across both npm and JSR package manifests to maintain version consistency.

https://claude.ai/code/session_01FN4TStx8kicDeM6i7D8EdR