### PR TITLE
Add missing `schema` param to `pattern` function declaration

### DIFF
--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -768,7 +768,11 @@ export const length: <Output extends string | unknown[], Input>(
   message?: string
 ) => Schema<Output, Input>;
 
-export const pattern: (re: RegExp, message?: string) => Schema<string, string>;
+export const pattern: <Input>(
+  schema: Schema<string, Input>,
+  re: RegExp,
+  message?: string,
+) => Schema<string, Input>;
 export const trim: <Input>(
   schema: Schema<string, Input>
 ) => Schema<string, Input>;


### PR DESCRIPTION
I'm having a typescript error using `S.pattern`. I guess this was removed by mistake because the implementation signature actually has the `schema` param, but the type declaration doesn't.

This simply adds it back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pattern validation helper’s public type definition to support schema-preserving usage with input types.
  * This improves type compatibility for projects relying on the exported helper and helps catch mismatches earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->