### PR TITLE
Improve spec harness error messages and validation robustness

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -84,7 +84,9 @@ All four run on every `spec new`/`spec check --write` — no separate benchmark 
 
 ## Layout
 
-- `packages/sury/specs/<id>.yaml` — authored spec (published with the `sury` package)
+- `packages/sury/specs/<id>.yaml` — authored spec. Deliberately published with the `sury` package:
+  specs double as machine-checked documentation of each schema's exact contract (codegen, JSON
+  Schema, type cost, bundle cost), readable by users and tooling straight out of `node_modules`.
 - `packages/sury/specs/spec.schema.json` — emitted from the format schema (`pnpm spec schema`)
 - `packages/spec/` — the spec CLI (its own workspace package). **Don't touch these files when working on Sury itself** — it's the test harness, not part of the library.
 - `packages/sury/tests/spec_test.ts` — the single, committed, hand-written test that dynamically

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -351,7 +351,10 @@ Implementation notes for `packages/spec` (see the `spec` skill for the authoring
   esbuild (aliasing the bare `sury` specifier to the dev source), minifies, and gzips. Each call is an
   independent esbuild child-process build with no shared state, so concurrent specs' measurements run
   genuinely in parallel via `Promise.all`; `recomputeGoldens` kicks off the bundle-size build *before*
-  the synchronous TS-introspection work so the two overlap within a single spec too.
+  the synchronous TS-introspection work so the two overlap within a single spec too. The recorded
+  golden carries a ±1% tolerance: within the band `recomputeGoldens` keeps the committed number (so a
+  toolchain bump — esbuild, zlib — doesn't go stale across every spec at once); a real size change
+  beyond it re-records exactly.
 
 Both replace the project's former standalone `tests/types.bench.ts` (`@ark/attest`-based, hardcoded
 per-scenario instantiation counts) and `tests/bundle.bench.ts` (a handful of fixed scenarios against a

--- a/packages/spec/cli.ts
+++ b/packages/spec/cli.ts
@@ -131,6 +131,8 @@ const parseNewArgs = (argv: string[]): { id: string; ts: string } => {
       if (val === undefined) fail(`${a} requires a value`);
       flags[a.slice(2)] = val;
       i++;
+    } else {
+      fail(`unknown argument ${JSON.stringify(a)} — usage: spec new --id <id> --ts <schema-ts-source>`);
     }
   }
   const id = flags.id;
@@ -141,6 +143,11 @@ const parseNewArgs = (argv: string[]): { id: string; ts: string } => {
 
 const cmdNew = async (): Promise<void> => {
   const { id, ts } = parseNewArgs(rest);
+  const file = join(SPECS_DIR, `${id}.yaml`);
+  // Overwriting would clobber the one thing the harness can't regenerate:
+  // hand-authored example inputs.
+  if (existsSync(file))
+    fail(`spec ${id} already exists (${file}) — edit it directly, or delete it first to re-scaffold`);
   let schema: any;
   try {
     schema = evalSchema(ts);
@@ -173,7 +180,7 @@ const cmdNew = async (): Promise<void> => {
     jsonSchema: scaffoldJsonSchema(schema),
     operations,
   };
-  writeFileSync(join(SPECS_DIR, `${id}.yaml`), serialize(spec));
+  writeFileSync(file, serialize(spec));
   console.log(`new ${id} -> specs/${id}.yaml (add example inputs, then \`pnpm spec check ${id} --write\`)`);
 };
 

--- a/packages/spec/format.ts
+++ b/packages/spec/format.ts
@@ -28,13 +28,15 @@
 //     without re-verifying against the full, real specSchema, not a toy schema.
 import * as S from "sury-published";
 
-// A dimension that isn't asserted must say so explicitly, with a reason.
-// Reasons are conventionally an enum (`parser-only`, `serializer-only`, `lossy`,
-// `not-applicable`) or `todo(#…)` for a not-yet-built dimension; the CLI lints
-// the reason string (harness.ts's SKIP_REASONS — keep the two in sync).
+// A dimension that isn't asserted must say so explicitly, with a reason:
+// one of SKIP_REASONS, or `todo(#…)` for a not-yet-built dimension. The CLI
+// lints the reason string (harness.ts's isValidSkipReason) and the schema
+// description below is derived from the same array, so there's exactly one
+// list to update.
+export const SKIP_REASONS = ["parser-only", "serializer-only", "lossy", "not-applicable"] as const;
 export const skip = S.schema({
   _skip: S.string.with(S.meta, {
-    description: "Why unasserted: parser-only | serializer-only | lossy | not-applicable | todo(#…).",
+    description: `Why unasserted: ${SKIP_REASONS.join(" | ")} | todo(#…).`,
   }),
 })
   .with(S.strict)

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -19,6 +19,7 @@ import {
   KEY_ORDER,
   TS_KEY_ORDER,
   OP_ORDER,
+  SKIP_REASONS,
   isSkip,
   validate,
   type Spec,
@@ -42,16 +43,13 @@ const OP_BUILDER: Record<OpName, (schema: any) => (input: any) => any> = {
   encode: S.encoder,
 };
 
-// `identity` isn't here — it's no longer a `_skip` reason, see Operation.
-const SKIP_REASONS = new Set([
-  "parser-only",
-  "serializer-only",
-  "lossy",
-  "not-applicable",
-]);
+const SKIP_REASON_SET = new Set<string>(SKIP_REASONS);
 export const isValidSkipReason = (r: unknown): boolean =>
-  typeof r === "string" && (SKIP_REASONS.has(r) || /^todo\(#.+\)$/.test(r));
+  typeof r === "string" && (SKIP_REASON_SET.has(r) || /^todo\(#.+\)$/.test(r));
 
+// `path` is relative to the spec root (e.g. `ts.bundleBytes`) — the reported
+// error already sits under a `✗ <id>` header, so prefixing the id here would
+// print it twice.
 export const lintSkips = (obj: unknown, path: string, out: string[]): void => {
   if (isSkip(obj)) {
     if (!isValidSkipReason(obj._skip))
@@ -59,7 +57,7 @@ export const lintSkips = (obj: unknown, path: string, out: string[]): void => {
     return;
   }
   if (obj && typeof obj === "object")
-    for (const [k, v] of Object.entries(obj)) lintSkips(v, `${path}.${k}`, out);
+    for (const [k, v] of Object.entries(obj)) lintSkips(v, path ? `${path}.${k}` : k, out);
 };
 
 export const specId = (file: string): string =>
@@ -247,7 +245,13 @@ const keyToCode = (k: string): string => (IDENT_RE.test(k) ? k : JSON.stringify(
 // `String(-0)` prints as "0". Only a *registry* symbol (`Symbol.for(key)`)
 // round-trips through source text — a bare `Symbol()` is unique per call, so
 // no source expression can reproduce it.
-const valueToCode = (v: unknown): string => {
+//
+// Anything the emitted source would NOT evaluate back to (structurally) must
+// throw rather than emit: a cyclic value would recurse forever, a class
+// instance would silently flatten to a plain-object literal, and symbol keys
+// would be dropped by Object.entries — each of those would record a golden
+// that looks fine but doesn't equal the real output.
+const valueToCode = (v: unknown, seen: WeakSet<object> = new WeakSet()): string => {
   if (v === undefined) return "undefined";
   if (typeof v === "bigint") return `${v}n`;
   if (typeof v === "number") return Object.is(v, -0) ? "-0" : String(v);
@@ -258,15 +262,26 @@ const valueToCode = (v: unknown): string => {
       throw new Error("cannot represent a non-registry symbol (use Symbol.for(key)) as spec source code");
     return `Symbol.for(${JSON.stringify(key)})`;
   }
+  if (typeof v === "object") {
+    if (seen.has(v)) throw new Error("cannot represent a cyclic value as spec source code");
+    seen.add(v);
+  }
   if (v instanceof Date) return `new Date(${JSON.stringify(v.toISOString())})`;
   if (v instanceof RegExp) return v.toString();
-  if (v instanceof Map) return `new Map(${valueToCode([...v])})`;
-  if (v instanceof Set) return `new Set(${valueToCode([...v])})`;
-  if (Array.isArray(v)) return `[${v.map(valueToCode).join(", ")}]`;
+  if (v instanceof Map) return `new Map(${valueToCode([...v], seen)})`;
+  if (v instanceof Set) return `new Set(${valueToCode([...v], seen)})`;
+  if (Array.isArray(v)) return `[${v.map((x) => valueToCode(x, seen)).join(", ")}]`;
   if (typeof v === "object") {
+    const proto = Object.getPrototypeOf(v);
+    if (proto !== Object.prototype && proto !== null)
+      throw new Error(
+        `cannot represent a ${(v as object).constructor?.name ?? "unknown-class"} instance as spec source code`,
+      );
+    if (Object.getOwnPropertySymbols(v).length)
+      throw new Error("cannot represent an object with symbol keys as spec source code");
     const entries = Object.entries(v);
     if (entries.length === 0) return "{}";
-    return `{ ${entries.map(([k, val]) => `${keyToCode(k)}: ${valueToCode(val)}`).join(", ")} }`;
+    return `{ ${entries.map(([k, val]) => `${keyToCode(k)}: ${valueToCode(val, seen)}`).join(", ")} }`;
   }
   throw new Error(`cannot represent a ${typeof v} as spec source code`);
 };
@@ -318,7 +333,17 @@ export const recomputeGoldens = async (obj: Spec): Promise<Spec> => {
     }
   }
 
-  if (bundleBytesPromise) next.ts.bundleBytes = await bundleBytesPromise;
+  if (bundleBytesPromise) {
+    const measured = await bundleBytesPromise;
+    // ±1% tolerance: gzip byte counts wobble with toolchain bumps (esbuild,
+    // zlib) even when nothing about the schema changed. Within the band the
+    // recorded golden is kept, so an unrelated dependency bump doesn't go
+    // stale across every spec at once; a real size change (>1%) re-records
+    // exactly.
+    const prior = next.ts.bundleBytes;
+    next.ts.bundleBytes =
+      typeof prior === "number" && Math.abs(measured - prior) <= prior * 0.01 ? prior : measured;
+  }
   return next;
 };
 
@@ -373,7 +398,7 @@ export const checkSpec = async (
   if (!v.ok) errs.push(`schema: ${v.error}`);
   const spec = v.ok ? v.value : obj;
 
-  lintSkips(spec, id, errs);
+  lintSkips(spec, "", errs);
 
   const canon = serialize(spec);
   if (raw !== canon)

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -77,7 +77,7 @@ test("invalid _skip reason (not an enum value or todo(#...))", async () => {
   await expect(runCheck("string", serialize(spec))).resolves.toMatchInlineSnapshot(`
     {
       "stderr": "✗ string
-        string.ts.bundleBytes: invalid _skip reason "because-i-said-so"",
+        ts.bundleBytes: invalid _skip reason "because-i-said-so"",
       "stdout": "",
     }
   `);
@@ -221,7 +221,7 @@ test("multiple simultaneous problems all get their own guiding message", async (
   await expect(runCheck("string", serialize(spec))).resolves.toMatchInlineSnapshot(`
     {
       "stderr": "✗ string
-        string.ts.bundleBytes: invalid _skip reason "nonsense-reason"
+        ts.bundleBytes: invalid _skip reason "nonsense-reason"
         goldens stale — run \`pnpm spec check string --write\` (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
     @@ -13,7 +13,7 @@
           type: string

--- a/packages/sury/tests/spec_test.ts
+++ b/packages/sury/tests/spec_test.ts
@@ -6,6 +6,7 @@
 import { readFileSync } from "node:fs";
 import { test, expect, describe, vi } from "vitest";
 import {
+  SCHEMA_PATH,
   listSpecFiles,
   specId,
   readSpec,
@@ -16,7 +17,7 @@ import {
   lintSkips,
   lintSpecsDir,
 } from "../../spec/harness";
-import { validate } from "../../spec/format";
+import { validate, schemaJson } from "../../spec/format";
 
 // recomputeGoldens does a TS-program introspection pass plus an esbuild
 // child-process build per spec; the first spec processed pays the ~1s
@@ -32,6 +33,12 @@ test("there is at least one spec", () => {
   expect(specs.length).toBeGreaterThan(0);
 });
 
+// Otherwise only `pnpm spec check` (which CI doesn't run) would notice a
+// format change whose spec.schema.json wasn't re-emitted.
+test("spec.schema.json is fresh (run `pnpm spec schema`)", () => {
+  expect(readFileSync(SCHEMA_PATH, "utf8")).toBe(schemaJson());
+});
+
 test("specs dir contains only valid spec files (run `pnpm spec check`)", () => {
   const errs = lintSpecsDir();
   expect(errs, errs.join("\n")).toEqual([]);
@@ -45,7 +52,7 @@ test("lintSpecsDir rejects a non-yaml file and a dotted/invalid id", () => {
   ]);
 });
 
-describe.each(specs)("spec: $id", ({ id, file }) => {
+describe.each(specs)("spec: $id", ({ file }) => {
   const spec = readSpec(file);
 
   test("is valid against the format schema", () => {
@@ -69,7 +76,7 @@ describe.each(specs)("spec: $id", ({ id, file }) => {
 
   test("every _skip reason is valid (run `pnpm spec check`)", () => {
     const errs: string[] = [];
-    lintSkips(spec, id, errs);
+    lintSkips(spec, "", errs);
     expect(errs, errs.join("\n")).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

This PR improves the spec harness by fixing error message paths, centralizing skip-reason validation, adding cycle detection to value serialization, and implementing a tolerance band for bundle-size measurements.

## Key Changes

- **Centralized skip-reason validation**: Moved `SKIP_REASONS` from `harness.ts` to `format.ts` as the single source of truth, with the schema description auto-derived from it. This eliminates duplication and ensures consistency between validation and documentation.

- **Improved error message paths**: Fixed `lintSkips` to report relative paths from the spec root (e.g., `ts.bundleBytes` instead of `string.ts.bundleBytes`), since errors already appear under a `✗ <id>` header. Updated call sites to pass empty string as the initial path.

- **Enhanced value serialization safety**: Added cycle detection to `valueToCode` using a `WeakSet` to prevent infinite recursion on cyclic values. Added validation to reject class instances (which would silently flatten to plain objects) and objects with symbol keys (which would be dropped by `Object.entries`), ensuring golden files accurately represent actual output.

- **Bundle-size tolerance band**: Implemented ±1% tolerance in `recomputeGoldens` for `bundleBytes` measurements. Within the band, the committed golden is preserved (so toolchain bumps like esbuild/zlib don't stale every spec); real size changes beyond 1% re-record exactly.

- **Spec creation safety**: Added check in `cmdNew` to prevent overwriting existing specs, since hand-authored example inputs cannot be regenerated.

- **Test improvements**: Added test to verify `spec.schema.json` freshness, ensuring format changes are caught by CI. Updated test snapshots to reflect corrected error message paths.

## Implementation Details

- The `valueToCode` function now threads a `seen` parameter through recursive calls to track visited objects and detect cycles early.
- Bundle-size tolerance uses relative percentage (`Math.abs(measured - prior) <= prior * 0.01`) to handle both increases and decreases.
- Error messages now omit the spec ID prefix since it's already in the header, reducing redundancy and improving readability.

https://claude.ai/code/session_0184gidPSxhfQftHBhQPganb