### PR TITLE
Introduce SchemaLike type to reduce TypeScript instantiation cost

### DIFF
--- a/packages/sury/specs/merge-optional.yaml
+++ b/packages/sury/specs/merge-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.merge(S.schema({_id: S.optional(S.string), _rev: S.optional(S.string), _deleted: S.optional(S.boolean)}), S.schema({code: S.string, name: S.string}))"
   input: "{ _id?: string | undefined; _rev?: string | undefined; _deleted?: boolean | undefined; code: string; name: string; }"
   output: "{ _id?: string | undefined; _rev?: string | undefined; _deleted?: boolean | undefined; code: string; name: string; }"
-  instantiations: 30749
+  instantiations: 11839
   bundleBytes: 10741
 jsonSchema:
   input: '{ type: "object", properties: { _id: { type: "string" }, _rev: { type: "string" }, _deleted: { type: "boolean" }, code: { type: "string" }, name: { type: "string" } }, required: ["code", "name"] }'

--- a/packages/sury/specs/merge-optional.yaml
+++ b/packages/sury/specs/merge-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.merge(S.schema({_id: S.optional(S.string), _rev: S.optional(S.string), _deleted: S.optional(S.boolean)}), S.schema({code: S.string, name: S.string}))"
   input: "{ _id?: string | undefined; _rev?: string | undefined; _deleted?: boolean | undefined; code: string; name: string; }"
   output: "{ _id?: string | undefined; _rev?: string | undefined; _deleted?: boolean | undefined; code: string; name: string; }"
-  instantiations: 11839
+  instantiations: 6634
   bundleBytes: 10741
 jsonSchema:
   input: '{ type: "object", properties: { _id: { type: "string" }, _rev: { type: "string" }, _deleted: { type: "boolean" }, code: { type: "string" }, name: { type: "string" } }, required: ["code", "name"] }'

--- a/packages/sury/specs/merge.yaml
+++ b/packages/sury/specs/merge.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.merge(S.schema({a: S.string, b: S.number, c: S.boolean}), S.schema({d: S.bigint, e: S.symbol}))"
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
-  instantiations: 39269
+  instantiations: 10829
   bundleBytes: 10273
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/merge.yaml
+++ b/packages/sury/specs/merge.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.merge(S.schema({a: S.string, b: S.number, c: S.boolean}), S.schema({d: S.bigint, e: S.symbol}))"
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
-  instantiations: 10829
+  instantiations: 5630
   bundleBytes: 10273
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, nested: S.schema({b: S.number, inner: S.schema({c: S.boolean, d: S.optional(S.string)})})})"
   input: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
   output: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
-  instantiations: 50125
+  instantiations: 10286
   bundleBytes: 10766
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "string" }, nested: { type: "object", properties: { b: { type: "number" }, inner: { type: "object", properties: { c: { type: "boolean" }, d: { type: "string" } }, required: ["c"] } }, required: ["b", "inner"] } }, required: ["a", "nested"] }'

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, nested: S.schema({b: S.number, inner: S.schema({c: S.boolean, d: S.optional(S.string)})})})"
   input: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
   output: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
-  instantiations: 10286
+  instantiations: 5108
   bundleBytes: 10766
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "string" }, nested: { type: "object", properties: { b: { type: "number" }, inner: { type: "object", properties: { c: { type: "boolean" }, d: { type: "string" } }, required: ["c"] } }, required: ["b", "inner"] } }, required: ["a", "nested"] }'

--- a/packages/sury/specs/object1.yaml
+++ b/packages/sury/specs/object1.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string})"
   input: "{ a: string; }"
   output: "{ a: string; }"
-  instantiations: 1243
+  instantiations: 1225
   bundleBytes: 9683
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "string" } }, required: ["a"] }'

--- a/packages/sury/specs/object1.yaml
+++ b/packages/sury/specs/object1.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string})"
   input: "{ a: string; }"
   output: "{ a: string; }"
-  instantiations: 13963
+  instantiations: 1243
   bundleBytes: 9683
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "string" } }, required: ["a"] }'

--- a/packages/sury/specs/object10.yaml
+++ b/packages/sury/specs/object10.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, b: S.number, c: S.boolean, d: S.bigint, e: S.symbol, f: S.string, g: S.number, h: S.boolean, i: S.bigint, j: S.symbol})"
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
-  instantiations: 34149
+  instantiations: 2369
   bundleBytes: 10109
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/object10.yaml
+++ b/packages/sury/specs/object10.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, b: S.number, c: S.boolean, d: S.bigint, e: S.symbol, f: S.string, g: S.number, h: S.boolean, i: S.bigint, j: S.symbol})"
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
-  instantiations: 2369
+  instantiations: 2351
   bundleBytes: 10109
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/object5-optional.yaml
+++ b/packages/sury/specs/object5-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, b: S.optional(S.number), c: S.boolean, d: S.optional(S.bigint), e: S.symbol})"
   input: "{ b?: number | undefined; d?: bigint | undefined; a: string; c: boolean; e: symbol; }"
   output: "{ b?: number | undefined; d?: bigint | undefined; a: string; c: boolean; e: symbol; }"
-  instantiations: 8749
+  instantiations: 3630
   bundleBytes: 10865
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint | undefined'

--- a/packages/sury/specs/object5-optional.yaml
+++ b/packages/sury/specs/object5-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, b: S.optional(S.number), c: S.boolean, d: S.optional(S.bigint), e: S.symbol})"
   input: "{ b?: number | undefined; d?: bigint | undefined; a: string; c: boolean; e: symbol; }"
   output: "{ b?: number | undefined; d?: bigint | undefined; a: string; c: boolean; e: symbol; }"
-  instantiations: 35397
+  instantiations: 8749
   bundleBytes: 10865
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint | undefined'

--- a/packages/sury/specs/object5.yaml
+++ b/packages/sury/specs/object5.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, b: S.number, c: S.boolean, d: S.bigint, e: S.symbol})"
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
-  instantiations: 34079
+  instantiations: 2299
   bundleBytes: 10095
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/object5.yaml
+++ b/packages/sury/specs/object5.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.string, b: S.number, c: S.boolean, d: S.bigint, e: S.symbol})"
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
-  instantiations: 2299
+  instantiations: 2281
   bundleBytes: 10095
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/tuple10.yaml
+++ b/packages/sury/specs/tuple10.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number, S.boolean, S.bigint, S.symbol, S.string, S.number, S.boolean, S.bigint, S.symbol])
   input: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
-  instantiations: 12146
+  instantiations: 2658
   bundleBytes: 10088
 jsonSchema:
   input: 'Failed at ["3"]: Expected JSON, received bigint'

--- a/packages/sury/specs/tuple10.yaml
+++ b/packages/sury/specs/tuple10.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number, S.boolean, S.bigint, S.symbol, S.string, S.number, S.boolean, S.bigint, S.symbol])
   input: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
-  instantiations: 34955
+  instantiations: 12146
   bundleBytes: 10088
 jsonSchema:
   input: 'Failed at ["3"]: Expected JSON, received bigint'

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number])
   input: "[string, number]"
   output: "[string, number]"
-  instantiations: 6156
+  instantiations: 1168
   bundleBytes: 9890
 jsonSchema:
   input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string" }, { type: "number" }] }'

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number])
   input: "[string, number]"
   output: "[string, number]"
-  instantiations: 19179
+  instantiations: 6156
   bundleBytes: 9890
 jsonSchema:
   input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string" }, { type: "number" }] }'

--- a/packages/sury/specs/tuple5.yaml
+++ b/packages/sury/specs/tuple5.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number, S.boolean, S.bigint, S.symbol])
   input: "[string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol]"
-  instantiations: 11676
+  instantiations: 2188
   bundleBytes: 10087
 jsonSchema:
   input: 'Failed at ["3"]: Expected JSON, received bigint'

--- a/packages/sury/specs/tuple5.yaml
+++ b/packages/sury/specs/tuple5.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number, S.boolean, S.bigint, S.symbol])
   input: "[string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol]"
-  instantiations: 34485
+  instantiations: 11676
   bundleBytes: 10087
 jsonSchema:
   input: 'Failed at ["3"]: Expected JSON, received bigint'

--- a/packages/sury/specs/union2.yaml
+++ b/packages/sury/specs/union2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number])
   input: string | number
   output: string | number
-  instantiations: 19217
+  instantiations: 6074
   bundleBytes: 9899
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "number" }] }'

--- a/packages/sury/specs/union2.yaml
+++ b/packages/sury/specs/union2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number])
   input: string | number
   output: string | number
-  instantiations: 6074
+  instantiations: 1083
   bundleBytes: 9899
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "number" }] }'

--- a/packages/sury/specs/union5-discriminated.yaml
+++ b/packages/sury/specs/union5-discriminated.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({kind: "a", a: S.string}), S.schema({kind: "b", b: S.number}), S.schema({kind: "c", c: S.boolean}), S.schema({kind: "d", d: S.bigint}), S.schema({kind: "e", e: S.symbol})])'
   input: "{ kind: string; a: string; } | { kind: string; b: number; } | { kind: string; c: boolean; } | { kind: string; d: bigint; } | { kind: string; e: symbol; }"
   output: "{ kind: string; a: string; } | { kind: string; b: number; } | { kind: string; c: boolean; } | { kind: string; d: bigint; } | { kind: string; e: symbol; }"
-  instantiations: 90193
+  instantiations: 28783
   bundleBytes: 10147
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/union5-discriminated.yaml
+++ b/packages/sury/specs/union5-discriminated.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({kind: "a", a: S.string}), S.schema({kind: "b", b: S.number}), S.schema({kind: "c", c: S.boolean}), S.schema({kind: "d", d: S.bigint}), S.schema({kind: "e", e: S.symbol})])'
   input: "{ kind: string; a: string; } | { kind: string; b: number; } | { kind: string; c: boolean; } | { kind: string; d: bigint; } | { kind: string; e: symbol; }"
   output: "{ kind: string; a: string; } | { kind: string; b: number; } | { kind: string; c: boolean; } | { kind: string; d: bigint; } | { kind: string; e: symbol; }"
-  instantiations: 28783
+  instantiations: 10300
   bundleBytes: 10147
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/specs/union5.yaml
+++ b/packages/sury/specs/union5.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number, S.boolean, S.bigint, S.symbol])
   input: string | number | bigint | boolean | symbol
   output: string | number | bigint | boolean | symbol
-  instantiations: 11547
+  instantiations: 2056
   bundleBytes: 10098
 jsonSchema:
   input: Expected JSON, received string | number | boolean | bigint | symbol

--- a/packages/sury/specs/union5.yaml
+++ b/packages/sury/specs/union5.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number, S.boolean, S.bigint, S.symbol])
   input: string | number | bigint | boolean | symbol
   output: string | number | bigint | boolean | symbol
-  instantiations: 34476
+  instantiations: 11547
   bundleBytes: 10098
 jsonSchema:
   input: Expected JSON, received string | number | boolean | bigint | symbol

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -161,7 +161,7 @@ export type Schema<Output, Input = unknown> = {
       decode?: ((value: unknown) => unknown) | undefined,
       encode?: (value: unknown) => Output
     ) => Schema<unknown, unknown>,
-    target: Schema<TargetOutput, TargetInput>,
+    target: SchemaLike<TargetOutput, TargetInput>,
     decode?: ((value: Output) => TargetInput) | undefined,
     encode?: (value: TargetInput) => Output
   ): Schema<TargetOutput, Input>;
@@ -183,17 +183,17 @@ export type Schema<Output, Input = unknown> = {
     callback: ((value: Output) => Shape) | undefined
   ): Schema<Shape, Input>;
   // with(message: string): t<Output, Input>; TODO: implement
-  with<O, I>(fn: (schema: Schema<Output, Input>) => Schema<O, I>): Schema<O, I>;
+  with<O, I>(fn: (schema: Schema<Output, Input>) => SchemaLike<O, I>): Schema<O, I>;
   with<O, I, A1 extends string>(
-    fn: (schema: Schema<Output, Input>, arg1: A1) => Schema<O, I>,
+    fn: (schema: Schema<Output, Input>, arg1: A1) => SchemaLike<O, I>,
     arg1: A1
   ): Schema<O, I>;
   with<O, I, A1>(
-    fn: (schema: Schema<Output, Input>, arg1: A1) => Schema<O, I>,
+    fn: (schema: Schema<Output, Input>, arg1: A1) => SchemaLike<O, I>,
     arg1: A1
   ): Schema<O, I>;
   with<O, I, A1, A2>(
-    fn: (schema: Schema<Output, Input>, arg1: A1, arg2: A2) => Schema<O, I>,
+    fn: (schema: Schema<Output, Input>, arg1: A1, arg2: A2) => SchemaLike<O, I>,
     arg1: A1,
     arg2: A2
   ): Schema<O, I>;
@@ -378,28 +378,28 @@ export type Input<T> = T extends {
   : never;
 
 // Utility types for decoder function with multiple schemas
-type ExtractFirstInput<T extends readonly Schema<any, any>[]> =
-  T extends readonly [Schema<any, infer FirstInput>, ...any[]]
+type ExtractFirstInput<T extends readonly SchemaLike<any, any>[]> =
+  T extends readonly [SchemaLike<any, infer FirstInput>, ...any[]]
     ? FirstInput
     : never;
 
 // Utility types for encoder function with multiple schemas
-type ExtractFirstOutput<T extends readonly Schema<any, any>[]> =
-  T extends readonly [Schema<infer FirstOutput, any>, ...any[]]
+type ExtractFirstOutput<T extends readonly SchemaLike<any, any>[]> =
+  T extends readonly [SchemaLike<infer FirstOutput, any>, ...any[]]
     ? FirstOutput
     : never;
 
-type ExtractLastOutput<T extends readonly Schema<any, any>[]> =
-  T extends readonly [...any[], Schema<infer LastOutput, any>]
+type ExtractLastOutput<T extends readonly SchemaLike<any, any>[]> =
+  T extends readonly [...any[], SchemaLike<infer LastOutput, any>]
     ? LastOutput
-    : T extends readonly [Schema<infer SingleOutput, any>]
+    : T extends readonly [SchemaLike<infer SingleOutput, any>]
     ? SingleOutput
     : never;
 
-type ExtractLastInput<T extends readonly Schema<any, any>[]> =
-  T extends readonly [...any[], Schema<any, infer LastInput>]
+type ExtractLastInput<T extends readonly SchemaLike<any, any>[]> =
+  T extends readonly [...any[], SchemaLike<any, infer LastInput>]
     ? LastInput
-    : T extends readonly [Schema<any, infer SingleInput>]
+    : T extends readonly [SchemaLike<any, infer SingleInput>]
     ? SingleInput
     : never;
 
@@ -429,6 +429,15 @@ export type UnknownToInput<T> = T extends {
   ? ResolveObject<{ [K in keyof T]: UnknownToInput<T[K]> }>
   : T;
 
+// Lightweight parameter type for inferring a schema's Output/Input: matching
+// the `~standard` marker instead of the full `Schema<…>` shape (14-member
+// union + `with` overloads) keeps per-call instantiation cost low.
+type SchemaLike<Output, Input> = {
+  readonly ["~standard"]: {
+    readonly types?: { readonly output: Output; readonly input: Input } | undefined;
+  };
+};
+
 export type Brand<T, ID extends string> = T & {
   /**
    *  TypeScript won't suggest strings beginning with a space as properties.
@@ -438,7 +447,7 @@ export type Brand<T, ID extends string> = T & {
 };
 
 export function brand<ID extends string, Output = unknown, Input = unknown>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   brandId: ID
 ): Schema<Brand<Output, ID>, Input>;
 
@@ -500,7 +509,7 @@ type Literal =
   | undefined
   | null
   | []
-  | Schema<unknown>;
+  | SchemaLike<unknown, unknown>;
 
 export function schema<T extends Literal>(
   value: T
@@ -570,106 +579,106 @@ export function safeAsync<Value>(
 ): Promise<Result<Value>>;
 
 export function reverse<Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): Schema<Input, Output>;
 
 export function parser<Output>(
-  schema: Schema<Output, unknown>
+  schema: SchemaLike<Output, unknown>
 ): (data: unknown) => Output;
 export function parser<Output>(
-  from: Schema<unknown>,
-  target: Schema<Output, unknown>
+  from: SchemaLike<unknown, unknown>,
+  target: SchemaLike<Output, unknown>
 ): (data: unknown) => Output;
 export function parser<
-  Schemas extends readonly [Schema<any, any>, ...Schema<any, any>[]]
+  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(...schemas: Schemas): (data: unknown) => ExtractLastOutput<Schemas>;
 
 export function asyncParser<Output>(
-  schema: Schema<Output, unknown>
+  schema: SchemaLike<Output, unknown>
 ): (data: unknown) => Promise<Output>;
 export function asyncParser<Output>(
-  from: Schema<unknown>,
-  target: Schema<Output, unknown>
+  from: SchemaLike<unknown, unknown>,
+  target: SchemaLike<Output, unknown>
 ): (data: unknown) => Promise<Output>;
 export function asyncParser<
-  Schemas extends readonly [Schema<any, any>, ...Schema<any, any>[]]
+  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(...schemas: Schemas): (data: unknown) => Promise<ExtractLastOutput<Schemas>>;
 
 export function decoder<Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): (data: Input) => Output;
 export function decoder<Output, Input>(
-  from: Schema<unknown, Input>,
-  target: Schema<Output, unknown>
+  from: SchemaLike<unknown, Input>,
+  target: SchemaLike<Output, unknown>
 ): (data: Input) => Output;
 export function decoder<
-  Schemas extends readonly [Schema<any, any>, ...Schema<any, any>[]]
+  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
   ...schemas: Schemas
 ): (data: ExtractFirstInput<Schemas>) => ExtractLastOutput<Schemas>;
 
 export function asyncDecoder<Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): (data: Input) => Promise<Output>;
 export function asyncDecoder<Output, Input>(
-  from: Schema<unknown, Input>,
-  target: Schema<Output, unknown>
+  from: SchemaLike<unknown, Input>,
+  target: SchemaLike<Output, unknown>
 ): (data: Input) => Promise<Output>;
 export function decoder<
-  Schemas extends readonly [Schema<any, any>, ...Schema<any, any>[]]
+  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
   ...schemas: Schemas
 ): (data: ExtractFirstInput<Schemas>) => Promise<ExtractLastOutput<Schemas>>;
 
 export function encoder<Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): (data: Output) => Input;
 export function encoder<Output, Input>(
-  from: Schema<Output, unknown>,
-  target: Schema<unknown, Input>
+  from: SchemaLike<Output, unknown>,
+  target: SchemaLike<unknown, Input>
 ): (data: Output) => Input;
 export function encoder<
-  Schemas extends readonly [Schema<any, any>, ...Schema<any, any>[]]
+  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
   ...schemas: Schemas
 ): (data: ExtractFirstOutput<Schemas>) => ExtractLastInput<Schemas>;
 
 export function asyncEncoder<Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): (data: Output) => Promise<Input>;
 export function asyncEncoder<Output, Input>(
-  from: Schema<Output, unknown>,
-  target: Schema<unknown, Input>
+  from: SchemaLike<Output, unknown>,
+  target: SchemaLike<unknown, Input>
 ): (data: Output) => Promise<Input>;
 export function asyncEncoder<
-  Schemas extends readonly [Schema<any, any>, ...Schema<any, any>[]]
+  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
   ...schemas: Schemas
 ): (data: ExtractFirstOutput<Schemas>) => Promise<ExtractLastInput<Schemas>>;
 
 export function assert<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   data: unknown
 ): asserts data is Input;
 export function assert<Output, Input>(
   data: unknown,
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): asserts data is Input;
 
 export function is<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   data: unknown
 ): data is Input;
 export function is<Output, Input>(
   data: unknown,
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): data is Input;
 
 export function tuple<Output, Input extends unknown[]>(
   definer: (s: {
     item: <ItemOutput>(
       inputIndex: number,
-      schema: Schema<ItemOutput, unknown>
+      schema: SchemaLike<ItemOutput, unknown>
     ) => ItemOutput;
     tag: (inputIndex: number, value: unknown) => void;
   }) => Output
@@ -680,7 +689,7 @@ export function optional<
   Input,
   Or extends Output | undefined = undefined
 >(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   or?: (() => Or) | Or,
   // To make .with work
   _?: never
@@ -694,46 +703,46 @@ export function nullable<
   Input,
   Or extends Output | null = null
 >(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   or?: (() => Or) | Or,
   // To make .with work
   _?: never
 ): Schema<Or extends null ? Output | null : Output, Input | null>;
 
 export const nullish: <Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ) => Schema<Output | undefined | null, Input | undefined | null>;
 
 export type Class<T> = new (...args: readonly any[]) => T;
 export const instance: <T>(class_: Class<T>) => Schema<T, T>;
 
 export const array: <Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ) => Schema<Output[], Input[]>;
 
 export const compactColumns: <Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ) => Schema<Output[][], Input[][]>;
 
 export const record: <Output, Input>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ) => Schema<Record<string, Output>, Record<string, Input>>;
 
 type ObjectCtx<Input extends Record<string, unknown>> = {
   field: <FieldOutput>(
     name: string,
-    schema: Schema<FieldOutput, unknown>
+    schema: SchemaLike<FieldOutput, unknown>
   ) => FieldOutput;
   fieldOr: <FieldOutput>(
     name: string,
-    schema: Schema<FieldOutput, unknown>,
+    schema: SchemaLike<FieldOutput, unknown>,
     or: FieldOutput
   ) => FieldOutput;
   tag: <TagName extends keyof Input>(
     name: TagName,
     value: Input[TagName]
   ) => void;
-  flatten: <FieldOutput>(schema: Schema<FieldOutput, unknown>) => FieldOutput;
+  flatten: <FieldOutput>(schema: SchemaLike<FieldOutput, unknown>) => FieldOutput;
   nested: (name: string) => ObjectCtx<Record<string, unknown>>;
 };
 
@@ -742,16 +751,16 @@ export function object<Output, Input extends Record<string, unknown>>(
 ): Schema<Output, Input>;
 
 export function strip<Output, Input extends Record<string, unknown>>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): Schema<Output, Input>;
 export function deepStrip<Output, Input extends Record<string, unknown>>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): Schema<Output, Input>;
 export function strict<Output, Input extends Record<string, unknown>>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): Schema<Output, Input>;
 export function deepStrict<Output, Input extends Record<string, unknown>>(
-  schema: Schema<Output, Input>
+  schema: SchemaLike<Output, Input>
 ): Schema<Output, Input>;
 
 type Merge<A, B> = Flatten<
@@ -763,7 +772,7 @@ export function merge<
   I1,
   O2 extends Record<string, unknown>,
   I2
->(schema1: Schema<O1, I1>, schema2: Schema<O2, I2>): Schema<
+>(schema1: SchemaLike<O1, I1>, schema2: SchemaLike<O2, I2>): Schema<
   Merge<O1, O2>,
   Merge<I1, I2>
 >;
@@ -796,23 +805,23 @@ export type Meta<Output> = {
 };
 
 export function meta<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   meta: Meta<Output>
 ): Schema<Output, Input>;
 
-export function toExpression(schema: Schema<unknown>): string;
+export function toExpression(schema: SchemaLike<unknown, unknown>): string;
 export function noValidation<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   value: boolean
 ): Schema<Output, Input>;
 
 export function asyncDecoderAssert<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   assertFn: (value: Output) => Promise<void>
 ): Schema<Output, Input>;
 
 export function refine<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   refineCheck: (value: Output) => boolean,
   refineOptions?: {
     error?: string;
@@ -821,28 +830,28 @@ export function refine<Output, Input>(
 ): Schema<Output, Input>;
 
 export const min: <Output extends string | number | unknown[], Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   length: number,
   message?: string
 ) => Schema<Output, Input>;
 export const max: <Output extends string | number | unknown[], Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   length: number,
   message?: string
 ) => Schema<Output, Input>;
 export const length: <Output extends string | unknown[], Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   length: number,
   message?: string
 ) => Schema<Output, Input>;
 
 export const pattern: <Input>(
-  schema: Schema<string, Input>,
+  schema: SchemaLike<string, Input>,
   re: RegExp,
   message?: string
 ) => Schema<string, Input>;
 export const trim: <Input>(
-  schema: Schema<string, Input>
+  schema: SchemaLike<string, Input>
 ) => Schema<string, Input>;
 
 export type UnknownKeys = "strip" | "strict";
@@ -855,7 +864,7 @@ export type GlobalConfigOverride = {
 export function global(globalConfigOverride: GlobalConfigOverride): void;
 
 export function shape<Shape = unknown, Output = unknown, Input = unknown>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   shaper: (value: Output) => Shape
 ): Schema<Shape, Input>;
 
@@ -865,14 +874,14 @@ export function to<
   TargetInput = unknown,
   TargetOutput = unknown
 >(
-  schema: Schema<Output, Input>,
-  target: Schema<TargetOutput, TargetInput>,
+  schema: SchemaLike<Output, Input>,
+  target: SchemaLike<TargetOutput, TargetInput>,
   decode?: ((value: Output) => TargetInput) | undefined,
   encode?: (value: TargetOutput) => Output
 ): Schema<TargetOutput, Input>;
 
 export function toJSONSchema<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   options?: {
     target?: "draft-07" | "draft-2020-12" | "openapi-3.0";
   }
@@ -881,7 +890,7 @@ export function fromJSONSchema<Output extends JSON>(
   jsonSchema: JSONSchema7
 ): Schema<Output, JSON>;
 export function extendJSONSchema<Output, Input>(
-  schema: Schema<Output, Input>,
+  schema: SchemaLike<Output, Input>,
   jsonSchema: JSONSchema7
 ): Schema<Output, Input>;
 /** Enables `~standard.jsonSchema`; its input/output throw before this is called. */

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -403,7 +403,11 @@ type ExtractLastInput<T extends readonly Schema<any, any>[]> =
     ? SingleInput
     : never;
 
-export type UnknownToOutput<T> = T extends Schema<infer Output, unknown>
+// Match the `~standard` marker instead of the full `Schema<…>` shape for the
+// same instantiation-cost reason as `Output<T>` above.
+export type UnknownToOutput<T> = T extends {
+  readonly ["~standard"]: { readonly types?: { readonly output: infer Output } };
+}
   ? Output
   : T extends (...args: any[]) => any
   ? T
@@ -413,7 +417,9 @@ export type UnknownToOutput<T> = T extends Schema<infer Output, unknown>
   ? ResolveObject<{ [K in keyof T]: UnknownToOutput<T[K]> }>
   : T;
 
-export type UnknownToInput<T> = T extends Schema<unknown, infer Input>
+export type UnknownToInput<T> = T extends {
+  readonly ["~standard"]: { readonly types?: { readonly input: infer Input } };
+}
   ? Input
   : T extends (...args: any[]) => any
   ? T

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -119,7 +119,7 @@ test("identity claimed but the operation doesn't actually compile to identity", 
         output: string
     -   instantiations: 254
     -   bundleBytes: 3856
-    +   instantiations: 5949
+    +   instantiations: 5181
     +   bundleBytes: 4366
       jsonSchema:
     -   input: '{ type: "string" }'

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -120,7 +120,7 @@ test("identity claimed but the operation doesn't actually compile to identity", 
     -   instantiations: 254
     -   bundleBytes: 3856
     +   instantiations: 5181
-    +   bundleBytes: 4366
+    +   bundleBytes: 4367
       jsonSchema:
     -   input: '{ type: "string" }'
     -   output: '{ type: "string" }'


### PR DESCRIPTION
## Summary

Introduces a lightweight `SchemaLike<Output, Input>` type that matches only the `~standard` marker instead of the full `Schema<…>` shape. This dramatically reduces per-call TypeScript instantiation costs across the public API while maintaining full type safety.

## Key Changes

- **New `SchemaLike` type**: A minimal structural type matching `{ readonly ["~standard"]: { readonly types?: { readonly output: Output; readonly input: Input } } }` that captures schema type information without the 14-member union and `with` overload complexity.

- **Updated utility types**: `ExtractFirstInput`, `ExtractFirstOutput`, `ExtractLastOutput`, and `ExtractLastInput` now operate on `SchemaLike` arrays instead of `Schema` arrays.

- **Optimized `UnknownToOutput` and `UnknownToInput`**: Changed from matching the full `Schema<…>` shape to matching the `~standard` marker, reducing instantiation cost per the existing pattern used in `Output<T>`.

- **Public API parameter updates**: All public functions (`parser`, `decoder`, `encoder`, `assert`, `is`, `optional`, `nullable`, `array`, `record`, `merge`, `brand`, `reverse`, `refine`, `meta`, `toExpression`, etc.) now accept `SchemaLike` parameters instead of `Schema` parameters, while still returning full `Schema` types.

- **Spec updates**: Instantiation counts improved dramatically across test cases:
  - `object1`: 13,963 → 1,225 instantiations (91% reduction)
  - `object5`: 34,079 → 2,281 instantiations (93% reduction)
  - `merge`: 39,269 → 5,630 instantiations (86% reduction)
  - `tuple2`: 19,179 → 1,168 instantiations (94% reduction)
  - `union2`: 19,217 → 1,083 instantiations (94% reduction)

## Implementation Details

The `SchemaLike` type is a structural match on the `~standard` symbol that schemas already carry, avoiding the need to match against the full `Schema` union type. This follows the same instantiation-cost optimization pattern already used in `Output<T>` and `Input<T>` utility types. The change is transparent to users—all existing code continues to work, and the actual `Schema` objects satisfy the `SchemaLike` constraint through structural typing.

https://claude.ai/code/session_019LC29fqnyNgTP2AbACWpFY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TypeScript APIs now accept a broader range of standard-compatible schemas across common builders, helpers, and inference utilities.
  * Improved type compatibility when composing, transforming, and extending schemas.

* **Performance**
  * Updated TypeScript complexity metrics show substantially fewer type instantiations across object, tuple, merge, and union scenarios, supporting faster compilation.

* **Tests**
  * Updated an expected diagnostic snapshot to reflect the latest compiler output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->