### PR TITLE
Refactor union dispatch to use reservation-based target assignment

### DIFF
--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -855,7 +855,7 @@ type Schema = S.Infer<typeof schema>; // "Win" | "Draw" | "Loss"
 
 ### Decoding into / out of a union
 
-When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, each variant is resolved on its own (two variants can even land on the same target). The target doesn't have to be a union either — a single schema works the same way.
+Converting between unions (via `S.to`, or implicitly by reversing the schema) maps each **source** case to one **target** case. Same-type matches win and are exclusive — e.g. for a `string` source and a `string | number` target, `string` binds `string`, never coerced to `number`, and that `string` target is now spoken for. Source cases left without a same-type match are resolved against the targets that are still free: a `null` or `undefined` source bridges to the opposite nullish target (`null` ↔ `undefined`) when one is present, otherwise Sury falls back to coercing across types. If no target is left for a source case, the conversion errors.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -855,7 +855,7 @@ type Schema = S.Infer<typeof schema>; // "Win" | "Draw" | "Loss"
 
 ### Decoding into / out of a union
 
-When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant — **targets are not consumed**, so several source variants may resolve to the same target, and a variant with no tier-1/tier-2 match still falls through to tier 3 (it does not error just because another variant already matched that target). The target does not have to be a union: a single schema behaves like a one-variant target union.
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, each variant is resolved on its own (two variants can even land on the same target). The target doesn't have to be a union either — a single schema works the same way.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 
@@ -892,14 +892,14 @@ S.union([S.string.with(S.to, S.number), S.string]);
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-**Source unions resolve each variant independently.** `S.optional(schema)` (and ReScript's `S.option`) is sugar for a union with `undefined`, so `S.string.with(S.to, S.optional(S.string))` reverses to a source union `[string, undefined]` over a single `string` target on encode:
+**Optionals follow the same rules.** `S.optional` is a union with the "missing" case, so `S.string.with(S.to, S.optional(S.string))` converts each case on its own:
 
-- `"abc"` → `"abc"` (tier 1: `string` matches the `string` target, identity)
-- `undefined` → `"undefined"` (tier 3: no `undefined`/`null` target, so the `undefined` literal is stringified)
+- `"abc"` → `"abc"` (a present value stays as-is)
+- `undefined` → `"undefined"` (no `undefined` target, so it falls back to a string)
 
-Note that the `undefined` variant does **not** error even though the `string` target was already matched by the `string` variant — there is no target consumption. On parse the asymmetry shows up the other way: every input string matches the `string` member via tier 1, so the `undefined` member is unreachable and `"undefined"` parses to `"undefined"`, never `undefined`.
+If the target offers a `null` (or `undefined`) case, the missing value maps to that instead of a string.
 
-<!-- FIXME: encoding `undefined` to the string "undefined" here is surprising — arguably the `undefined` source variant should fail with an invalid-type error once the `string` target is taken. Documented as-is to match current behavior; revisit before stabilizing union encoding. -->
+<!-- FIXME: encoding `undefined` to the string "undefined" is surprising — arguably it should error once `string` is already matched. Documented as-is to match current behavior; see the regression test in S_to_test.res. -->
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -892,14 +892,7 @@ S.union([S.string.with(S.to, S.number), S.string]);
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-**Optionals follow the same rules.** `S.optional` is a union with the "missing" case, so `S.string.with(S.to, S.optional(S.string))` converts each case on its own:
-
-- `"abc"` → `"abc"` (a present value stays as-is)
-- `undefined` → `"undefined"` (no `undefined` target, so it falls back to a string)
-
-If the target offers a `null` (or `undefined`) case, the missing value maps to that instead of a string.
-
-<!-- FIXME: encoding `undefined` to the string "undefined" is surprising — arguably it should error once `string` is already matched. Documented as-is to match current behavior; see the regression test in S_to_test.res. -->
+**Optionals are unions too.** `S.optional` adds the missing (`undefined`) case, so when you convert an optional into a type that has a `null` or `undefined` case, the missing value bridges to it instead of being coerced.
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -855,13 +855,13 @@ type Schema = S.Infer<typeof schema>; // "Win" | "Draw" | "Loss"
 
 ### Decoding into / out of a union
 
-Converting between unions (via `S.to`, or implicitly by reversing the schema) maps each **source** case to one **target** case. Same-type matches win and are exclusive — e.g. for a `string` source and a `string | number` target, `string` binds `string`, never coerced to `number`, and that `string` target is now spoken for. Source cases left without a same-type match are resolved against the targets that are still free: a `null` or `undefined` source bridges to the opposite nullish target (`null` ↔ `undefined`) when one is present, otherwise Sury falls back to coercing across types. If no target is left for a source case, the conversion errors.
+Converting between unions (via `S.to`, or implicitly by reversing the schema) maps each **source** case to exactly one **target** case. Sury applies three rules across all source cases — tier 1 first, then tier 2, then tier 3 — and **reserves** a target as soon as a case binds to it, so no other case can reuse it (tiers 1 and 2 reserve; tier 3 does not):
 
-If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
+1. **Same-type match (tier 1).** A source case that has a target of the same type binds to it directly and is never coerced. With several same-type targets, an exact value/format match (a specific string literal, `Int32`, …) wins over a catch-all, in target order. The matched target is reserved. If same-type targets exist but none accept the value, the conversion errors — it never falls through to coercion.
+2. **Nullish bridge (tier 2).** A remaining `null` or `undefined` source case maps to the opposite nullish target (`null` ↔ `undefined`) when one is still free, and reserves it.
+3. **Coercion (tier 3).** Each still-unmatched source case is tried against the remaining free targets in target order, converting across types: `number`/`bigint` → `string` via `"" + i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-literal matches like `"null" → null`, and more. Coercion does not reserve, so several source cases may coerce into the same target.
 
-1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then any remaining catch-all same-tag variants. Variants with a different tag are never tried from here — if every branch in the group fails, the match errors.
-2. **Nullish bridge.** Used only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
-3. **Fallback.** Used only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `number`/`bigint` → `string` via `"" + i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-const matches like `"null" → null`, and more.
+If no target is left for a source case, the conversion errors. If the source type isn't known ahead of time (e.g. `S.unknown`), the type-based rules are skipped and each target is simply tried in order until one accepts the value.
 
 **Worked example** — `S.union([S.bigint, S.number, null]).with(S.to, S.union([S.string, undefined]))`:
 
@@ -873,16 +873,16 @@ Forward:
 
 Reverse (via `S.encoder`):
 
-- `"null"` → `null` (tier 3: stringified-const literal match)
-- `undefined` → `null` (tier 2: nullish bridge)
+- `undefined` → `null` (tier 2: nullish bridge — reserves the `null` target)
 - `"123"` → `123n` (tier 3: bigint attempted first by target order; parse succeeds)
 - `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to number)
-- `"abc"` → error (tier 3: no variant's decoder succeeds)
+- `"abc"` → error (tier 3: no remaining target accepts it)
+- `"null"` → error (tier 3: the `null` target is reserved by the `undefined` → `null` bridge; on its own `"null"` would coerce to `null`)
 
-**Identity wins over coercion.** For `S.union([S.string, S.bigint]).with(S.to, S.union([S.number, S.string]))`:
+**Direct matches are exclusive.** For `S.union([S.string, S.bigint]).with(S.to, S.union([S.number, S.string]))`:
 
-- `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `number` even though a `number` target exists)
-- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" + i`)
+- `"123"` → `"123"` (tier 1: `string` binds the `string` target directly, never coerced to `number`)
+- `123n` → error (tier 1 reserves `string` for the `string` case; with no `bigint → number` coercion, `bigint` has no target left)
 
 To opt into `string → number` when a `string` target also exists, write the transform into a variant explicitly:
 
@@ -890,7 +890,7 @@ To opt into `string → number` when a `string` target also exists, write the tr
 S.union([S.string.with(S.to, S.number), S.string]);
 ```
 
-The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+The transformed variant is value/format-refined relative to the catch-all `string`, so it matches first within tier 1.
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -892,8 +892,6 @@ S.union([S.string.with(S.to, S.number), S.string]);
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-**Optionals are unions too.** `S.optional` adds the missing (`undefined`) case, so when you convert an optional into a type that has a `null` or `undefined` case, the missing value bridges to it instead of being coerced.
-
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 
 ## Records

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -855,7 +855,7 @@ type Schema = S.Infer<typeof schema>; // "Win" | "Draw" | "Loss"
 
 ### Decoding into / out of a union
 
-When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant.
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant — **targets are not consumed**, so several source variants may resolve to the same target, and a variant with no tier-1/tier-2 match still falls through to tier 3 (it does not error just because another variant already matched that target). The target does not have to be a union: a single schema behaves like a one-variant target union.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 
@@ -891,6 +891,15 @@ S.union([S.string.with(S.to, S.number), S.string]);
 ```
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+
+**Source unions resolve each variant independently.** `S.optional(schema)` (and ReScript's `S.option`) is sugar for a union with `undefined`, so `S.string.with(S.to, S.optional(S.string))` reverses to a source union `[string, undefined]` over a single `string` target on encode:
+
+- `"abc"` → `"abc"` (tier 1: `string` matches the `string` target, identity)
+- `undefined` → `"undefined"` (tier 3: no `undefined`/`null` target, so the `undefined` literal is stringified)
+
+Note that the `undefined` variant does **not** error even though the `string` target was already matched by the `string` variant — there is no target consumption. On parse the asymmetry shows up the other way: every input string matches the `string` member via tier 1, so the `undefined` member is unreachable and `"undefined"` parses to `"undefined"`, never `undefined`.
+
+<!-- FIXME: encoding `undefined` to the string "undefined" here is surprising — arguably the `undefined` source variant should fail with an invalid-type error once the `string` target is taken. Documented as-is to match current behavior; revisit before stabilizing union encoding. -->
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -959,8 +959,6 @@ S.union([S.string->S.to(S.float), S.string])
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-**Optionals are unions too.** `S.option` adds the missing (`undefined`) case, so when you convert an optional into a type that has a `null` or `undefined` case, the missing value bridges to it — `S.option(S.string)->S.to(S.null(S.string))` maps `None` ↔ `null`.
-
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 
 ### **`array`**

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -922,13 +922,13 @@ let schema = S.enum([Win, Draw, Loss])
 
 #### Decoding into / out of a union
 
-Converting between unions (via `S.to`, or implicitly by reversing the schema) maps each **source** case to one **target** case. Same-type matches win and are exclusive — e.g. with a `string` source and a `string`/`float` target union, `string` binds `string`, never coerced to `float`, and that `string` target is now spoken for. Source cases left without a same-type match are resolved against the targets that are still free: a `null` or `undefined` source bridges to the opposite nullish target (`null` ↔ `undefined`) when one is present, otherwise Sury falls back to coercing across types. If no target is left for a source case, the conversion errors.
+Converting between unions (via `S.to`, or implicitly by reversing the schema) maps each **source** case to exactly one **target** case. Sury applies three rules across all source cases — tier 1 first, then tier 2, then tier 3 — and **reserves** a target as soon as a case binds to it, so no other case can reuse it (tiers 1 and 2 reserve; tier 3 does not):
 
-If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
+1. **Same-type match (tier 1).** A source case that has a target of the same type binds to it directly and is never coerced. With several same-type targets, an exact value/format match (a specific string literal, `Int32`, …) wins over a catch-all, in target order. The matched target is reserved. If same-type targets exist but none accept the value, the conversion errors — it never falls through to coercion.
+2. **Nullish bridge (tier 2).** A remaining `null` or `undefined` source case maps to the opposite nullish target (`null` ↔ `undefined`) when one is still free, and reserves it.
+3. **Coercion (tier 3).** Each still-unmatched source case is tried against the remaining free targets in target order, converting across types: `int`/`bigint` → `string` via `"" ++ i`, `string` → `float` via `Float.fromString`, `string` → `bigint` via `BigInt.fromString`, stringified-literal matches like `"null" → null`, and more. Coercion does not reserve, so several source cases may coerce into the same target.
 
-1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then any remaining catch-all same-tag variants. Variants with a different tag are never tried from here — if every branch in the group fails, the match errors.
-2. **Nullish bridge.** Used only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
-3. **Fallback.** Used only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `int`/`bigint` → `string` via `"" ++ i`, `string` → `float` via `Float.fromString`, `string` → `bigint` via `BigInt.fromString`, stringified-const matches like `"null" → null`, and more.
+If no target is left for a source case, the conversion errors. If the source type isn't known ahead of time (e.g. `S.unknown`), the type-based rules are skipped and each target is simply tried in order until one accepts the value.
 
 **Worked example** — `S.union([S.bigint, S.float, S.nullLiteral])->S.to(S.union([S.string, S.unit]))`:
 
@@ -940,16 +940,16 @@ Forward:
 
 Reverse (via `S.decodeOrThrow(~from=schema, ~to=S.unknown)`):
 
-- `"null"` → `null` (tier 3: stringified-const literal match)
-- `undefined` → `null` (tier 2: nullish bridge)
+- `undefined` → `null` (tier 2: nullish bridge — reserves the `null` target)
 - `"123"` → `123n` (tier 3: bigint attempted first by target order; parse succeeds)
 - `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to float)
-- `"abc"` → error (tier 3: no variant's decoder succeeds)
+- `"abc"` → error (tier 3: no remaining target accepts it)
+- `"null"` → error (tier 3: the `null` target is reserved by the `undefined` → `null` bridge; on its own `"null"` would coerce to `null`)
 
-**Identity wins over coercion.** For `S.union([S.string, S.bigint])->S.to(S.union([S.float, S.string]))`:
+**Direct matches are exclusive.** For `S.union([S.string, S.bigint])->S.to(S.union([S.float, S.string]))`:
 
-- `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `float` even though a `float` target exists)
-- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" ++ i`)
+- `"123"` → `"123"` (tier 1: `string` binds the `string` target directly, never coerced to `float`)
+- `123n` → error (tier 1 reserves `string` for the `string` case; with no `bigint → float` coercion, `bigint` has no target left)
 
 To opt into `string → float` when a `string` target also exists, write the transform into a variant explicitly:
 
@@ -957,7 +957,7 @@ To opt into `string → float` when a `string` target also exists, write the tra
 S.union([S.string->S.to(S.float), S.string])
 ```
 
-The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+The transformed variant is value/format-refined relative to the catch-all `string`, so it matches first within tier 1.
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -922,7 +922,7 @@ let schema = S.enum([Win, Draw, Loss])
 
 #### Decoding into / out of a union
 
-When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant.
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant — **targets are not consumed**, so several source variants may resolve to the same target, and a variant with no tier-1/tier-2 match still falls through to tier 3 (it does not error just because another variant already matched that target). The target does not have to be a union: a single schema behaves like a one-variant target union.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 
@@ -958,6 +958,15 @@ S.union([S.string->S.to(S.float), S.string])
 ```
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+
+**Source unions resolve each variant independently.** Wrapping a schema in `S.option` is sugar for `S.union([item, S.unit])`, so `S.string->S.to(S.option(S.string))` reverses to a source union `[string, unit]` over a single `string` target on encode:
+
+- `Some("abc")` → `"abc"` (tier 1: `string` matches the `string` target, identity)
+- `None` → `"undefined"` (tier 3: no `undefined`/`null` target, so the `unit` literal is stringified)
+
+Note that the `None`/`undefined` variant does **not** error even though the `string` target was already matched by the `Some`/`string` variant — there is no target consumption. On parse the asymmetry shows up the other way: every input string matches the `string` member via tier 1, so the `unit` member is unreachable and `"undefined"` parses to `Some("undefined")`, never `None`.
+
+<!-- FIXME: encoding `None` to the string "undefined" here is surprising — arguably the `unit` source variant should fail with an invalid-type error once the `string` target is taken. Documented as-is to match current behavior; revisit before stabilizing union encoding. -->
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -922,7 +922,7 @@ let schema = S.enum([Win, Draw, Loss])
 
 #### Decoding into / out of a union
 
-When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, each variant is resolved on its own (two variants can even land on the same target). The target doesn't have to be a union either — a single schema works the same way.
+Converting between unions (via `S.to`, or implicitly by reversing the schema) maps each **source** case to one **target** case. Same-type matches win and are exclusive — e.g. with a `string` source and a `string`/`float` target union, `string` binds `string`, never coerced to `float`, and that `string` target is now spoken for. Source cases left without a same-type match are resolved against the targets that are still free: a `null` or `undefined` source bridges to the opposite nullish target (`null` ↔ `undefined`) when one is present, otherwise Sury falls back to coercing across types. If no target is left for a source case, the conversion errors.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -959,14 +959,7 @@ S.union([S.string->S.to(S.float), S.string])
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-**Optionals follow the same rules.** `S.option` is a union with the "missing" case, so `S.string->S.to(S.option(S.string))` converts each case on its own:
-
-- `Some("abc")` → `"abc"` (a present value stays as-is)
-- `None` → `"undefined"` (no `undefined` target, so it falls back to a string)
-
-If the target offers a `null` (or `undefined`) case, the missing value maps to that instead of a string — `S.option(S.string)->S.to(S.null(S.string))` maps `None` ↔ `null`.
-
-<!-- FIXME: encoding `None` to the string "undefined" is surprising — arguably it should error once `string` is already matched. Documented as-is to match current behavior; see the regression test in S_to_test.res. -->
+**Optionals are unions too.** `S.option` adds the missing (`undefined`) case, so when you convert an optional into a type that has a `null` or `undefined` case, the missing value bridges to it — `S.option(S.string)->S.to(S.null(S.string))` maps `None` ↔ `null`.
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -922,7 +922,7 @@ let schema = S.enum([Win, Draw, Loss])
 
 #### Decoding into / out of a union
 
-When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant — **targets are not consumed**, so several source variants may resolve to the same target, and a variant with no tier-1/tier-2 match still falls through to tier 3 (it does not error just because another variant already matched that target). The target does not have to be a union: a single schema behaves like a one-variant target union.
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, each variant is resolved on its own (two variants can even land on the same target). The target doesn't have to be a union either — a single schema works the same way.
 
 If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 
@@ -959,14 +959,14 @@ S.union([S.string->S.to(S.float), S.string])
 
 The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
 
-**Source unions resolve each variant independently.** Wrapping a schema in `S.option` is sugar for `S.union([item, S.unit])`, so `S.string->S.to(S.option(S.string))` reverses to a source union `[string, unit]` over a single `string` target on encode:
+**Optionals follow the same rules.** `S.option` is a union with the "missing" case, so `S.string->S.to(S.option(S.string))` converts each case on its own:
 
-- `Some("abc")` → `"abc"` (tier 1: `string` matches the `string` target, identity)
-- `None` → `"undefined"` (tier 3: no `undefined`/`null` target, so the `unit` literal is stringified)
+- `Some("abc")` → `"abc"` (a present value stays as-is)
+- `None` → `"undefined"` (no `undefined` target, so it falls back to a string)
 
-Note that the `None`/`undefined` variant does **not** error even though the `string` target was already matched by the `Some`/`string` variant — there is no target consumption. On parse the asymmetry shows up the other way: every input string matches the `string` member via tier 1, so the `unit` member is unreachable and `"undefined"` parses to `Some("undefined")`, never `None`.
+If the target offers a `null` (or `undefined`) case, the missing value maps to that instead of a string — `S.option(S.string)->S.to(S.null(S.string))` maps `None` ↔ `null`.
 
-<!-- FIXME: encoding `None` to the string "undefined" here is surprising — arguably the `unit` source variant should fail with an invalid-type error once the `string` target is taken. Documented as-is to match current behavior; revisit before stabilizing union encoding. -->
+<!-- FIXME: encoding `None` to the string "undefined" is surprising — arguably it should error once `string` is already matched. Documented as-is to match current behavior; see the regression test in S_to_test.res. -->
 
 > 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -1175,6 +1175,7 @@ module Builder = {
     let _notVarAtParent = () => {
       let val = %raw(`this`)
       let parent = val.parent->X.Option.getUnsafe
+
       // A re-readable field access (`parent[key]`). Its decl hoists onto the
       // parent, which outlives this field's own segment — field vals are often
       // materialized late (e.g. completeObjectVal's optional-field check), after
@@ -1372,27 +1373,28 @@ module Builder = {
       ~extraPath=Path.empty,
       ~reasonOverride=?,
       ~includeInput=true,
-    ) => (~input: val) => {
-      let expected = switch expected {
-      | Some(e) => e
-      | None => input.expected
+    ) =>
+      (~input: val) => {
+        let expected = switch expected {
+        | Some(e) => e
+        | None => input.expected
+        }
+        let received = input->receivedSchema
+        let path = if extraPath === Path.empty {
+          input.path
+        } else {
+          input.path->Path.concat(extraPath)
+        }
+        value =>
+          makeInvalidInputDetails(
+            ~expected,
+            ~received,
+            ~path,
+            ~input=value,
+            ~includeInput,
+            ~reasonOverride?,
+          )
       }
-      let received = input->receivedSchema
-      let path = if extraPath === Path.empty {
-        input.path
-      } else {
-        input.path->Path.concat(extraPath)
-      }
-      value =>
-        makeInvalidInputDetails(
-          ~expected,
-          ~received,
-          ~path,
-          ~input=value,
-          ~includeInput,
-          ~reasonOverride?,
-        )
-    }
 
     // Pass this as `fail` on every check that wants "expected X, received Y"
     // error semantics. Stable reference → adjacent checks fuse.
@@ -1453,8 +1455,7 @@ module Builder = {
           i := i.contents + 1
           // Extend the fused cond while the next check shares this `fail`.
           while i.contents < len && (checks->Array.getUnsafe(i.contents)).fail === fail {
-            cond :=
-              cond.contents ++ "&&" ++ (checks->Array.getUnsafe(i.contents)).cond(~inputVar)
+            cond := cond.contents ++ "&&" ++ (checks->Array.getUnsafe(i.contents)).cond(~inputVar)
             i := i.contents + 1
           }
           out :=
@@ -1863,7 +1864,6 @@ module Builder = {
         })
       }
     }
-
   }
 
   let noopOperation = i => i->Obj.magic
@@ -1909,6 +1909,7 @@ let numberDecoder = Builder.make((~input) => {
 
     let output = input->B.next(outputVar, ~schema=input.expected)
     output.var = B._var
+
     // Own the `+input` coercion (decl included) in codeFromPrev so it's
     // non-hoistable: feeding a union dispatch (e.g. str->to(option(int))) can't
     // lift the type-narrow check below above its `let v0=+i`.
@@ -2432,8 +2433,7 @@ and reverse = (schema: internal) => {
       | None => %raw(`delete mut.default`)
       }
       switch mut.items {
-      | Some(items) =>
-        mut.items = Some(items->Array.map(reverse))
+      | Some(items) => mut.items = Some(items->Array.map(reverse))
 
       | None => ()
       }
@@ -2572,11 +2572,10 @@ external getDecoder2: (~s1: internal, ~s2: internal, ~flag: flag=?) => 'a => 'b 
 external getDecoder3: (~s1: internal, ~s2: internal, ~s3: internal, ~flag: flag=?) => 'a => 'b =
   "getDecoder"
 
-
 let nestedLoc = "BS_PRIVATE_NESTED_SOME_NONE"
 
-  @unboxed
-  type itemCode = Single(string) | Multiple(array<string>)
+@unboxed
+type itemCode = Single(string) | Multiple(array<string>)
 
 let rec neverBuilderFn = (~input) => {
   let output = input->B.refine(~expected=never_())
@@ -2589,17 +2588,17 @@ and never_ = () =>
   })
 
 let nestedOptionParser = Builder.make((~input) => {
-      let nextSchema = input.expected.to->X.Option.getUnsafe
-      input->B.next(
-        `{${nestedLoc}:${(
-            (input.expected->getOutputSchema).properties
-            ->X.Option.getUnsafe
-            ->Dict.getUnsafe(nestedLoc)
-          ).const->Obj.magic}}`,
-        ~schema=nextSchema,
-        ~expected=nextSchema,
-      )
-    })
+  let nextSchema = input.expected.to->X.Option.getUnsafe
+  input->B.next(
+    `{${nestedLoc}:${(
+        (input.expected->getOutputSchema).properties
+        ->X.Option.getUnsafe
+        ->Dict.getUnsafe(nestedLoc)
+      ).const->Obj.magic}}`,
+    ~schema=nextSchema,
+    ~expected=nextSchema,
+  )
+})
 
 let instanceDecoder = Builder.make((~input) => {
   let inputTagFlag = input.schema.tag->TagFlag.get
@@ -3032,7 +3031,7 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
         if (
           isJsonParent &&
           schema.tag === unionTag &&
-            schema.has->X.Option.getUnsafe->Dict.getUnsafe((undefinedTag :> string))
+          schema.has->X.Option.getUnsafe->Dict.getUnsafe((undefinedTag :> string))
         ) {
           itemInput.inline = `(${itemInput.inline}??null)`
         }
@@ -3095,183 +3094,213 @@ and objectDecoder: Builder.t = (~input as unknownInput) => {
 }
 
 and dictFactory = item => {
-    let item = item->castToInternal
-    let mut = base(
-      objectTag,
-      ~selfReverse=item->Obj.magic->Stdlib.Dict.getUnsafe(reversedKey) === item->Obj.magic,
-    )
-    mut.properties = Some(X.Object.immutableEmpty)
-    mut.additionalItems = Some(Schema(item->castToPublic))
-    mut.decoder = objectDecoder
-    mut->castToPublic
-  }
+  let item = item->castToInternal
+  let mut = base(
+    objectTag,
+    ~selfReverse=item->Obj.magic->Stdlib.Dict.getUnsafe(reversedKey) === item->Obj.magic,
+  )
+  mut.properties = Some(X.Object.immutableEmpty)
+  mut.additionalItems = Some(Schema(item->castToPublic))
+  mut.decoder = objectDecoder
+  mut->castToPublic
+}
 
 and unionToKey = (schema: internal): string =>
-    schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.instance)
-      ? (schema.class->Obj.magic)["name"]
-      : (schema.tag :> string)
+  schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.instance)
+    ? (schema.class->Obj.magic)["name"]
+    : (schema.tag :> string)
 
 and unionIsPriority = (tagFlag, byKey: dict<array<unknown>>) => {
-    (tagFlag->Flag.unsafeHas(TagFlag.array->Flag.with(TagFlag.instance)) &&
-      byKey->Stdlib.Dict.has((objectTag: tag :> string))) ||
-      (tagFlag->Flag.unsafeHas(TagFlag.nan) && byKey->Stdlib.Dict.has((numberTag: tag :> string)))
-  }
+  (tagFlag->Flag.unsafeHas(TagFlag.array->Flag.with(TagFlag.instance)) &&
+    byKey->Stdlib.Dict.has((objectTag: tag :> string))) ||
+    (tagFlag->Flag.unsafeHas(TagFlag.nan) && byKey->Stdlib.Dict.has((numberTag: tag :> string)))
+}
 
-  // Whether decoding a value already known to be of the schema type
-  // is a noop — no transformation anywhere in the schema tree.
-  // Recursive refs are conservatively treated as transforming
+// Whether decoding a value already known to be of the schema type
+// is a noop — no transformation anywhere in the schema tree.
+// Recursive refs are conservatively treated as transforming
 and unionIsSelfDecodeNoop = (schema: internal) => {
-    schema.to === None &&
-    schema.parser === None &&
-    !(schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
-    switch schema.anyOf {
-    | Some(anyOf) => anyOf->Array.every(unionIsSelfDecodeNoop)
-    | None => true
-    } &&
-    switch schema.items {
-    | Some(items) => items->Array.every(unionIsSelfDecodeNoop)
-    | None => true
-    } &&
-    switch schema.properties {
-    | Some(properties) => properties->Stdlib.Dict.valuesToArray->Array.every(unionIsSelfDecodeNoop)
-    | None => true
-    } &&
-    switch schema.additionalItems {
-    | Some(Schema(s)) => s->castToInternal->unionIsSelfDecodeNoop
-    | _ => true
-    }
+  schema.to === None &&
+  schema.parser === None &&
+  !(schema.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
+  switch schema.anyOf {
+  | Some(anyOf) => anyOf->Array.every(unionIsSelfDecodeNoop)
+  | None => true
+  } &&
+  switch schema.items {
+  | Some(items) => items->Array.every(unionIsSelfDecodeNoop)
+  | None => true
+  } &&
+  switch schema.properties {
+  | Some(properties) => properties->Stdlib.Dict.valuesToArray->Array.every(unionIsSelfDecodeNoop)
+  | None => true
+  } &&
+  switch schema.additionalItems {
+  | Some(Schema(s)) => s->castToInternal->unionIsSelfDecodeNoop
+  | _ => true
   }
+}
 
 and unionIsWiderSchema = (~schemaAnyOf, ~inputAnyOf) => {
-    inputAnyOf->Array.everyWithIndex((inputSchema, idx) => {
-      switch schemaAnyOf->X.Array.getUnsafeOption(idx) {
-      | Some(schema) =>
-        !(
-          inputSchema.tag
-          ->TagFlag.get
-          ->Flag.unsafeHas(
-            TagFlag.array
-            ->Flag.with(TagFlag.instance)
-            ->Flag.with(TagFlag.ref)
-            ->Flag.with(TagFlag.union)
-            ->Flag.with(TagFlag.object),
-          )
-        ) &&
-        inputSchema.tag === schema.tag &&
-        inputSchema.const === schema.const &&
-        inputSchema.to === None
-      | None => false
-      }
-    })
+  inputAnyOf->Array.everyWithIndex((inputSchema, idx) => {
+    switch schemaAnyOf->X.Array.getUnsafeOption(idx) {
+    | Some(schema) =>
+      !(
+        inputSchema.tag
+        ->TagFlag.get
+        ->Flag.unsafeHas(
+          TagFlag.array
+          ->Flag.with(TagFlag.instance)
+          ->Flag.with(TagFlag.ref)
+          ->Flag.with(TagFlag.union)
+          ->Flag.with(TagFlag.object),
+        )
+      ) &&
+      inputSchema.tag === schema.tag &&
+      inputSchema.const === schema.const &&
+      inputSchema.to === None
+    | None => false
+    }
+  })
+}
+
+// The union's own `.to` chain which is applied per case during decoding.
+// None when the union has a custom parser owning the `.to` conversion
+and unionGetToPerCase = (schema: internal) =>
+  switch schema {
+  | {parser: ?None, to} => Some(to)
+  | _ => None
   }
 
-  // The union's own `.to` chain which is applied per case during decoding.
-  // None when the union has a custom parser owning the `.to` conversion
-and unionGetToPerCase = (schema: internal) =>
-    switch schema {
-    | {parser: ?None, to} => Some(to)
-    | _ => None
-    }
-
-  // Whether a union-typed input can be decoded by dispatching
-  // over its variants with `.to(target)` appended to each
+// Whether a union-typed input can be decoded by dispatching
+// over its variants with `.to(target)` appended to each
 and unionCanDispatchPerVariant = (~inputAnyOf, ~target: internal) =>
-    // S.json and recursive targets keep their dedicated union-input handling
-    !((target->getOutputSchema).tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
-    !(
-      target.tag === unionTag &&
+  // S.json and recursive targets keep their dedicated union-input handling
+  !((target->getOutputSchema).tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)) &&
+  !(
+    target.tag === unionTag &&
       target.anyOf
       ->X.Option.getUnsafe
       ->Array.some(v => v.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref))
-    ) &&
-    // Variants with transformations or recursive refs (option machinery,
-    // transformed unions) aren't supported per-variant yet
-    !(
-      inputAnyOf->Array.some(v =>
-        v.to !== None || v.parser !== None || v.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)
-      )
+  ) &&
+  // Variants with transformations or recursive refs (option machinery,
+  // transformed unions) aren't supported per-variant yet
+  !(
+    inputAnyOf->Array.some(v =>
+      v.to !== None || v.parser !== None || v.tag->TagFlag.get->Flag.unsafeHas(TagFlag.ref)
     )
+  )
 
-  // Re-drives the source union with `.to(target)` appended, so its decoder
-  // dispatches per variant and each variant converts to the target
-  // independently (the documented per-source-variant algorithm)
+// Re-drives the source union with `.to(target)` appended, so its decoder
+// dispatches per variant and each variant converts to the target
+// independently (the documented per-source-variant algorithm)
 and unionPerVariantVal = (~input: val, ~target) =>
-    input->B.refine(
-      ~schema=unknown,
-      ~expected=input.schema->updateOutput(mut => mut.to = Some(target))->castToInternal,
-    )
+  input->B.refine(
+    ~schema=unknown,
+    ~expected=input.schema->updateOutput(mut => mut.to = Some(target))->castToInternal,
+  )
 
-  // A variant participates in reservation only when its tag + const fully
-  // discriminate it (primitives, literals, null/undefined/NaN) AND it passes
-  // its value through unchanged. Structural variants — objects, instances,
-  // arrays, refs, nested unions — can't be matched statically, and transforming
-  // variants (their own `.to`/parser/serializer) aren't identity matches; both
-  // keep the full target and dispatch at runtime.
+// A variant participates in reservation only when its tag + const fully
+// discriminate it (primitives, literals, null/undefined/NaN) AND it passes
+// its value through unchanged. Structural variants — objects, instances,
+// arrays, refs, nested unions — can't be matched statically, and transforming
+// variants (their own `.to`/parser/serializer) aren't identity matches; both
+// keep the full target and dispatch at runtime.
 and unionReservable = (schema: internal) =>
-    schema.to === None &&
-    schema.parser === None &&
-    schema.serializer === None &&
-    !(
-      schema.tag
-      ->TagFlag.get
-      ->Flag.unsafeHas(
-        TagFlag.object
-        ->Flag.with(TagFlag.instance)
-        ->Flag.with(TagFlag.array)
-        ->Flag.with(TagFlag.ref)
-        ->Flag.with(TagFlag.union),
-      )
+  schema.to === None &&
+  schema.parser === None &&
+  schema.serializer === None &&
+  !(
+    schema.tag
+    ->TagFlag.get
+    ->Flag.unsafeHas(
+      TagFlag.object
+      ->Flag.with(TagFlag.instance)
+      ->Flag.with(TagFlag.array)
+      ->Flag.with(TagFlag.ref)
+      ->Flag.with(TagFlag.union),
     )
+  )
 
-  // Resolves which target each source variant converts to, with reservation.
-  // Walks reservable variants tier 1 (same-type) then tier 2 (nullish bridge) —
-  // both claim their target so no other variant can reuse it — then tier 3
-  // (coercion) shares whatever targets remain free. A reservable variant with no
-  // target left is mapped to `never` and fails. Non-reservable variants keep the
-  // full target. Returned array is aligned with `sources`.
+// Resolves which target each source variant converts to, with reservation.
+// Walks reservable variants tier 1 (same-type) then tier 2 (nullish bridge) —
+// both claim their target so no other variant can reuse it — then tier 3
+// (coercion) shares whatever targets remain free. A reservable variant with no
+// target left is mapped to `never` and fails. Non-reservable variants keep the
+// full target. Returned array is aligned with `sources`.
 and unionAssignTargets = (~sources: array<internal>, ~target: internal): array<internal> => {
-    let targetCases = switch target.anyOf {
-    | Some(anyOf) if target.tag === unionTag => anyOf
-    | _ => [target]
-    }
-    let sourceLen = sources->Array.length
-    let targetLen = targetCases->Array.length
+  let targetCases = switch target.anyOf {
+  | Some(anyOf) if target.tag === unionTag => anyOf
+  | _ => [target]
+  }
+  let sourceLen = sources->Array.length
+  let targetLen = targetCases->Array.length
 
-    let reserved = []
-    let assigned: array<option<internal>> = []
-    for _ in 0 to targetLen - 1 {
-      reserved->Array.push(false)->ignore
-    }
-    for _ in 0 to sourceLen - 1 {
-      assigned->Array.push(None)->ignore
-    }
+  let reserved = []
+  let assigned: array<option<internal>> = []
+  for _ in 0 to targetLen - 1 {
+    reserved->Array.push(false)->ignore
+  }
+  for _ in 0 to sourceLen - 1 {
+    assigned->Array.push(None)->ignore
+  }
 
-    let claim = (si, ti) => {
-      reserved->Array.setUnsafe(ti, true)
-      assigned->Array.setUnsafe(si, Some(targetCases->Array.getUnsafe(ti)))
-    }
+  let claim = (si, ti) => {
+    reserved->Array.setUnsafe(ti, true)
+    assigned->Array.setUnsafe(si, Some(targetCases->Array.getUnsafe(ti)))
+  }
 
-    // Pass 1: tier 1 — same-type match (exact const preferred), reserves it.
-    for si in 0 to sourceLen - 1 {
-      let s = sources->Array.getUnsafe(si)
-      if unionReservable(s) {
-        let sKey = unionToKey(s)
-        let chosen = ref(-1)
+  // Pass 1: tier 1 — same-type match (exact const preferred), reserves it.
+  for si in 0 to sourceLen - 1 {
+    let s = sources->Array.getUnsafe(si)
+    if unionReservable(s) {
+      let sKey = unionToKey(s)
+      let chosen = ref(-1)
+      for ti in 0 to targetLen - 1 {
+        if chosen.contents === -1 && !(reserved->Array.getUnsafe(ti)) {
+          let t = targetCases->Array.getUnsafe(ti)
+          if unionToKey(t) === sKey && t.const === s.const {
+            chosen := ti
+          }
+        }
+      }
+      if chosen.contents === -1 {
         for ti in 0 to targetLen - 1 {
           if chosen.contents === -1 && !(reserved->Array.getUnsafe(ti)) {
-            let t = targetCases->Array.getUnsafe(ti)
-            if unionToKey(t) === sKey && t.const === s.const {
+            if unionToKey(targetCases->Array.getUnsafe(ti)) === sKey {
               chosen := ti
             }
           }
         }
-        if chosen.contents === -1 {
-          for ti in 0 to targetLen - 1 {
-            if chosen.contents === -1 && !(reserved->Array.getUnsafe(ti)) {
-              if unionToKey(targetCases->Array.getUnsafe(ti)) === sKey {
-                chosen := ti
-              }
-            }
+      }
+      if chosen.contents !== -1 {
+        claim(si, chosen.contents)
+      }
+    }
+  }
+
+  // Pass 2: tier 2 — nullish bridge to the opposite nullish target, reserves it.
+  for si in 0 to sourceLen - 1 {
+    switch assigned->Array.getUnsafe(si) {
+    | Some(_) => ()
+    | None =>
+      let sTag = (sources->Array.getUnsafe(si)).tag
+      let oppositeTag = if sTag === nullTag {
+        undefinedTag
+      } else if sTag === undefinedTag {
+        nullTag
+      } else {
+        sTag
+      }
+      if oppositeTag !== sTag {
+        let chosen = ref(-1)
+        for ti in 0 to targetLen - 1 {
+          if (
+            chosen.contents === -1 &&
+            !(reserved->Array.getUnsafe(ti)) &&
+            (targetCases->Array.getUnsafe(ti)).tag === oppositeTag
+          ) {
+            chosen := ti
           }
         }
         if chosen.contents !== -1 {
@@ -3279,891 +3308,872 @@ and unionAssignTargets = (~sources: array<internal>, ~target: internal): array<i
         }
       }
     }
-
-    // Pass 2: tier 2 — nullish bridge to the opposite nullish target, reserves it.
-    for si in 0 to sourceLen - 1 {
-      switch assigned->Array.getUnsafe(si) {
-      | Some(_) => ()
-      | None =>
-        let sTag = (sources->Array.getUnsafe(si)).tag
-        let oppositeTag = if sTag === nullTag {
-          undefinedTag
-        } else if sTag === undefinedTag {
-          nullTag
-        } else {
-          sTag
-        }
-        if oppositeTag !== sTag {
-          let chosen = ref(-1)
-          for ti in 0 to targetLen - 1 {
-            if (
-              chosen.contents === -1 &&
-              !(reserved->Array.getUnsafe(ti)) &&
-              (targetCases->Array.getUnsafe(ti)).tag === oppositeTag
-            ) {
-              chosen := ti
-            }
-          }
-          if chosen.contents !== -1 {
-            claim(si, chosen.contents)
-          }
-        }
-      }
-    }
-
-    // Pass 3: tier 3 — reservable variants coerce over the remaining free
-    // targets (no reservation); non-reservable variants keep the full target.
-    let free = []
-    for ti in 0 to targetLen - 1 {
-      if !(reserved->Array.getUnsafe(ti)) {
-        free->Array.push(targetCases->Array.getUnsafe(ti))->ignore
-      }
-    }
-    let freeSchema = if free->Array.length === targetLen {
-      target
-    } else {
-      switch free {
-      | [single] => single
-      | [] => never_()
-      | cases => unionFactory(cases->Obj.magic)->castToInternal
-      }
-    }
-    for si in 0 to sourceLen - 1 {
-      switch assigned->Array.getUnsafe(si) {
-      | Some(_) => ()
-      | None =>
-        assigned->Array.setUnsafe(
-          si,
-          Some(unionReservable(sources->Array.getUnsafe(si)) ? freeSchema : target),
-        )
-      }
-    }
-
-    assigned->Array.map(opt =>
-      switch opt {
-      | Some(t) => t
-      | None => never_()
-      }
-    )
   }
 
-  // The canonical type-only schema a variant's dispatch discriminant validates
-  // against (its tag, ignoring const/structure), used to narrow the input val
-  // before the variant's own decoder runs.
-and unionTypeValidationSchema = (~tagFlag: flag, ~schema: internal): internal =>
-    if tagFlag->Flag.unsafeHas(TagFlag.null) {
-      nullLiteral()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
-      unit()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
-      dictFactory(unknown->castToPublic)->castToInternal
-    } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
-      array(unknown->castToPublic)->castToInternal
-    } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-      instance(schema.class)->castToInternal
-    } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
-      nan()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.string) {
-      string()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
-      float()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.boolean) {
-      bool()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.bigint) {
-      bigint()
-    } else if tagFlag->Flag.unsafeHas(TagFlag.symbol) {
-      symbol()
-    } else {
-      unknown
+  // Pass 3: tier 3 — reservable variants coerce over the remaining free
+  // targets (no reservation); non-reservable variants keep the full target.
+  let free = []
+  for ti in 0 to targetLen - 1 {
+    if !(reserved->Array.getUnsafe(ti)) {
+      free->Array.push(targetCases->Array.getUnsafe(ti))->ignore
     }
-
-  // Tier 1: for a typed const input, variants with a matching const are tried
-  // before catch-all and differently-const'ed variants.
-and unionPrioritizeConst = (~inputSchema: internal, ~schemas: array<internal>): array<internal> =>
-    if inputSchema->isLiteral {
-      let matching = []
-      let rest = []
-      for idx in 0 to schemas->Array.length - 1 {
-        let schema = schemas->Array.getUnsafe(idx)
-        if schema->isLiteral && schema.const === inputSchema.const {
-          matching->Array.push(schema)->ignore
-        } else {
-          rest->Array.push(schema)->ignore
-        }
-      }
-      matching->Array.concat(rest)
-    } else {
-      schemas
+  }
+  let freeSchema = if free->Array.length === targetLen {
+    target
+  } else {
+    switch free {
+    | [single] => single
+    | [] => never_()
+    | cases => unionFactory(cases->Obj.magic)->castToInternal
     }
-
-  // Tier narrowing: when the input is a known single type, returns the union
-  // key the dispatch can jump straight to — the matching same-type variant, or
-  // the opposite nullish variant for a null/undefined bridge. "" means no
-  // narrowing (input is a union/ref/unknown, or no variant matches).
-and unionActiveKey = (~inputSchema: internal, ~inputTagFlag: flag, ~schemas: array<internal>): string =>
-    if (
-      inputTagFlag->Flag.unsafeHas(
-        TagFlag.union->Flag.with(TagFlag.ref)->Flag.with(TagFlag.unknown),
+  }
+  for si in 0 to sourceLen - 1 {
+    switch assigned->Array.getUnsafe(si) {
+    | Some(_) => ()
+    | None =>
+      assigned->Array.setUnsafe(
+        si,
+        Some(unionReservable(sources->Array.getUnsafe(si)) ? freeSchema : target),
       )
-    ) {
-      ""
-    } else {
-      let sourceKey = unionToKey(inputSchema)
-      let activeKey = ref("")
-      let hasNull = ref(false)
-      let hasUndefined = ref(false)
-      let len = schemas->Array.length
-      let i = ref(0)
-      while activeKey.contents === "" && i.contents < len {
-        let s = schemas->Array.getUnsafe(i.contents)
-        if unionToKey(s) === sourceKey {
-          activeKey := sourceKey
-        } else if s.tag === nullTag {
-          hasNull := true
-        } else if s.tag === undefinedTag {
-          hasUndefined := true
-        }
-        i := i.contents + 1
-      }
-      if activeKey.contents === "" {
-        if inputTagFlag->Flag.unsafeHas(TagFlag.undefined) && hasNull.contents {
-          activeKey := (nullTag :> string)
-        } else if inputTagFlag->Flag.unsafeHas(TagFlag.null) && hasUndefined.contents {
-          activeKey := (undefinedTag :> string)
-        }
-      }
-      activeKey.contents
-    }
-
-  // Whether the input val can be returned untouched instead of building a
-  // dispatch: it is already the union type (trusted self-decode with no
-  // transforming variant), or a narrower union the wider target accepts as-is,
-  // or an already-produced output. Preserving this keeps generated code minimal.
-and unionIsPassthrough = (
-    ~input: val,
-    ~selfSchema: internal,
-    ~schemas: array<internal>,
-    ~initialInputTagFlag: flag,
-    ~toPerCase: option<internal>,
-  ): bool =>
-    (input.schema === selfSchema &&
-    toPerCase === None &&
-    schemas->Array.every(unionIsSelfDecodeNoop)) ||
-    (initialInputTagFlag->Flag.unsafeHas(TagFlag.union) &&
-      unionIsWiderSchema(~schemaAnyOf=schemas, ~inputAnyOf=input.schema.anyOf->X.Option.getUnsafe) &&
-      toPerCase === None) ||
-    (input.isOutput->Option.getUnsafe && input.expected === input.schema)
-
-  // Applied by the parse loop when a union-typed val
-  // meets a different expected schema
-and unionEncoder: encoder = (~input: val, ~target: internal) => {
-    let inputAnyOf = input.schema.anyOf->X.Option.getUnsafe
-    if (
-      target.tag === unionTag &&
-      unionGetToPerCase(target) === None &&
-      unionIsWiderSchema(~schemaAnyOf=target.anyOf->X.Option.getUnsafe, ~inputAnyOf)
-    ) {
-      // The target union decoder passes a narrower union input through as-is
-      input
-    } else if unionCanDispatchPerVariant(~inputAnyOf, ~target) {
-      unionPerVariantVal(~input, ~target)
-    } else {
-      input
     }
   }
+
+  assigned->Array.map(opt =>
+    switch opt {
+    | Some(t) => t
+    | None => never_()
+    }
+  )
+}
+
+// The canonical type-only schema a variant's dispatch discriminant validates
+// against (its tag, ignoring const/structure), used to narrow the input val
+// before the variant's own decoder runs.
+and unionTypeValidationSchema = (~tagFlag: flag, ~schema: internal): internal =>
+  if tagFlag->Flag.unsafeHas(TagFlag.null) {
+    nullLiteral()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
+    unit()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
+    dictFactory(unknown->castToPublic)->castToInternal
+  } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
+    array(unknown->castToPublic)->castToInternal
+  } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
+    instance(schema.class)->castToInternal
+  } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
+    nan()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.string) {
+    string()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
+    float()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.boolean) {
+    bool()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.bigint) {
+    bigint()
+  } else if tagFlag->Flag.unsafeHas(TagFlag.symbol) {
+    symbol()
+  } else {
+    unknown
+  }
+
+// Tier 1: for a typed const input, variants with a matching const are tried
+// before catch-all and differently-const'ed variants.
+and unionPrioritizeConst = (~inputSchema: internal, ~schemas: array<internal>): array<internal> =>
+  if inputSchema->isLiteral {
+    let matching = []
+    let rest = []
+    for idx in 0 to schemas->Array.length - 1 {
+      let schema = schemas->Array.getUnsafe(idx)
+      if schema->isLiteral && schema.const === inputSchema.const {
+        matching->Array.push(schema)->ignore
+      } else {
+        rest->Array.push(schema)->ignore
+      }
+    }
+    matching->Array.concat(rest)
+  } else {
+    schemas
+  }
+
+// Tier narrowing: when the input is a known single type, returns the union
+// key the dispatch can jump straight to — the matching same-type variant, or
+// the opposite nullish variant for a null/undefined bridge. "" means no
+// narrowing (input is a union/ref/unknown, or no variant matches).
+and unionActiveKey = (
+  ~inputSchema: internal,
+  ~inputTagFlag: flag,
+  ~schemas: array<internal>,
+): string =>
+  if (
+    inputTagFlag->Flag.unsafeHas(TagFlag.union->Flag.with(TagFlag.ref)->Flag.with(TagFlag.unknown))
+  ) {
+    ""
+  } else {
+    let sourceKey = unionToKey(inputSchema)
+    let activeKey = ref("")
+    let hasNull = ref(false)
+    let hasUndefined = ref(false)
+    let len = schemas->Array.length
+    let i = ref(0)
+    while activeKey.contents === "" && i.contents < len {
+      let s = schemas->Array.getUnsafe(i.contents)
+      if unionToKey(s) === sourceKey {
+        activeKey := sourceKey
+      } else if s.tag === nullTag {
+        hasNull := true
+      } else if s.tag === undefinedTag {
+        hasUndefined := true
+      }
+      i := i.contents + 1
+    }
+    if activeKey.contents === "" {
+      if inputTagFlag->Flag.unsafeHas(TagFlag.undefined) && hasNull.contents {
+        activeKey := (nullTag :> string)
+      } else if inputTagFlag->Flag.unsafeHas(TagFlag.null) && hasUndefined.contents {
+        activeKey := (undefinedTag :> string)
+      }
+    }
+    activeKey.contents
+  }
+
+// Whether the input val can be returned untouched instead of building a
+// dispatch: it is already the union type (trusted self-decode with no
+// transforming variant), or a narrower union the wider target accepts as-is,
+// or an already-produced output. Preserving this keeps generated code minimal.
+and unionIsPassthrough = (
+  ~input: val,
+  ~selfSchema: internal,
+  ~schemas: array<internal>,
+  ~initialInputTagFlag: flag,
+  ~toPerCase: option<internal>,
+): bool =>
+  (input.schema === selfSchema &&
+  toPerCase === None &&
+  schemas->Array.every(unionIsSelfDecodeNoop)) ||
+  initialInputTagFlag->Flag.unsafeHas(TagFlag.union) &&
+  unionIsWiderSchema(~schemaAnyOf=schemas, ~inputAnyOf=input.schema.anyOf->X.Option.getUnsafe) &&
+  toPerCase === None ||
+  (input.isOutput->Option.getUnsafe && input.expected === input.schema)
+
+// Applied by the parse loop when a union-typed val
+// meets a different expected schema
+and unionEncoder: encoder = (~input: val, ~target: internal) => {
+  let inputAnyOf = input.schema.anyOf->X.Option.getUnsafe
+  if (
+    target.tag === unionTag &&
+    unionGetToPerCase(target) === None &&
+    unionIsWiderSchema(~schemaAnyOf=target.anyOf->X.Option.getUnsafe, ~inputAnyOf)
+  ) {
+    // The target union decoder passes a narrower union input through as-is
+    input
+  } else if unionCanDispatchPerVariant(~inputAnyOf, ~target) {
+    unionPerVariantVal(~input, ~target)
+  } else {
+    input
+  }
+}
 
 and unionDecoder: Builder.t = (~input) => {
-    let selfSchema = input.expected
-    let schemas = selfSchema.anyOf->X.Option.getUnsafe
-    let initialInputTagFlag = input.schema.tag->TagFlag.get
+  let selfSchema = input.expected
+  let schemas = selfSchema.anyOf->X.Option.getUnsafe
+  let initialInputTagFlag = input.schema.tag->TagFlag.get
 
-    let toPerCase = unionGetToPerCase(selfSchema)
+  let toPerCase = unionGetToPerCase(selfSchema)
 
-    if unionIsPassthrough(~input, ~selfSchema, ~schemas, ~initialInputTagFlag, ~toPerCase) {
-      input
-    } else {
-      if (
-        initialInputTagFlag->Flag.unsafeHas(TagFlag.union) ||
-          (input.schema.encoder === None && initialInputTagFlag->Flag.unsafeHas(TagFlag.ref))
-      ) {
-        input.schema = unknown
+  if unionIsPassthrough(~input, ~selfSchema, ~schemas, ~initialInputTagFlag, ~toPerCase) {
+    input
+  } else {
+    unionEmit(~input, ~selfSchema, ~schemas, ~initialInputTagFlag, ~toPerCase)
+  }
+}
+
+// The emitter: consumes the resolved plan (input narrowed by unionActiveKey,
+// target reservation applied) and generates the dispatch codegen — the
+// per-schema optimizer (discriminant grouping, deopt detection, hoistable
+// conditions). Separated from unionDecoder so the decoder reads as
+// passthrough -> resolve -> emit.
+and unionEmit = (
+  ~input: val,
+  ~selfSchema: internal,
+  ~schemas: array<internal>,
+  ~initialInputTagFlag: flag,
+  ~toPerCase: option<internal>,
+): val => {
+  if (
+    initialInputTagFlag->Flag.unsafeHas(TagFlag.union) ||
+      (input.schema.encoder === None && initialInputTagFlag->Flag.unsafeHas(TagFlag.ref))
+  ) {
+    input.schema = unknown
+  }
+
+  let activeKey = unionActiveKey(
+    ~inputSchema=input.schema,
+    ~inputTagFlag=initialInputTagFlag,
+    ~schemas,
+  )
+
+  let initialInline = input.inline
+
+  let fail = caught => {
+    `${input->B.embed(
+        (
+          _ => {
+            let args = %raw(`arguments`)
+            B.throw(
+              B.makeInvalidInputDetails(
+                ~path=input.path,
+                ~expected=selfSchema,
+                ~received=unknown->castToPublic,
+                ~input=args->Array.getUnsafe(0),
+                ~includeInput=true,
+                ~unionErrors=?args->Array.length > 1
+                  ? Some(args->X.Array.fromArguments->Array.slice(~start=1))
+                  : None,
+              ),
+            )
+          }
+        )->X.Function.toExpression,
+      )}(${input.var()}${caught})`
+  }
+
+  // Create a copy of the input val, so we can mutate it
+  // It's still the same value though, until mutated
+  let output = input->B.refine
+  let outputAnyOf = []
+
+  // Set when a single-case block fails at codegen time, so the caller
+  // can drop the block and pass the embedded error along instead of
+  // emitting a guaranteed runtime throw
+  let staticBlockFailure = ref("")
+
+  let getArrItemsCode = (arr: array<unknown>, ~isDeopt) => {
+    let typeValidationInput = arr->Array.getUnsafe(0)->(Obj.magic: unknown => val)
+    let typeValidationOutput = arr->Array.getUnsafe(1)->(Obj.magic: unknown => val)
+
+    let itemStart = ref("")
+    let itemEnd = ref("")
+    let itemNextElse = ref(false)
+    let itemNoop = ref("")
+    let caught = ref("")
+
+    // Accumulate schemas code by refinement (discriminant)
+    // so if we have two schemas with the same discriminant
+    // We can generate a single switch statement
+    // with try/catch blocks for each item
+    // If we come across an item without a discriminant
+    // we need to dump all accumulated schemas in try block
+    // and have the item without discriminant as catch all
+    // If we come across an item without a discriminant
+    // and without any code, it means that this item is always valid
+    // and we should exit early
+    let byDiscriminant = ref(dict{})
+
+    let preItems = 2
+    let itemIdx = ref(preItems)
+    let lastIdx = arr->Array.length - 1
+    while itemIdx.contents <= lastIdx {
+      // Copy it one more time, since every case decoder
+      // might mutate the input
+      let input = typeValidationOutput->B.Val.scope
+      input.isUnion = Some(true)
+      input.hasTransform = typeValidationOutput.hasTransform
+      input.isOutput = Some(false)
+      input.expected =
+        arr->Stdlib.Array.getUnsafe(itemIdx.contents)->(Obj.magic: unknown => internal)
+
+      let isLast = itemIdx.contents === lastIdx
+      let isFirst = itemIdx.contents === preItems
+      let isOnlyCase = isFirst && isLast
+      let withExhaustiveCheck = ref(!isOnlyCase)
+
+      let itemSkipped = ref(false)
+      let itemCode = ref("")
+      let itemCond = ref("")
+      try {
+        let itemOutput = input->parse
+        outputAnyOf->Array.push(itemOutput.schema->castToPublic)->ignore
+
+        itemCode := itemOutput->B.merge(~hoistCond=itemCond)
+
+        if itemOutput.hasTransform->X.Option.getUnsafe {
+          output.hasTransform = Some(true)
+          if itemOutput.flag->Flag.unsafeHas(ValFlag.async) {
+            output.flag = output.flag->Flag.with(ValFlag.async)
+          }
+          let itemVar = typeValidationInput.var()
+          if itemOutput.inline !== itemVar {
+            itemCode :=
+              itemCode.contents ++
+              // Need to allocate a var here, so we don't mutate the input object field
+              `${itemVar}=${itemOutput.inline}`
+          }
+        }
+      } catch {
+      | _ => {
+          let errorVar = input->B.embed(%raw(`exn`)->InternalError.getOrRethrow)
+          caught := `${caught.contents},${errorVar}`
+          if isDeopt && isOnlyCase {
+            staticBlockFailure := errorVar
+            itemSkipped := true
+          } else if isLast {
+            withExhaustiveCheck := false
+            itemCode := (isDeopt ? "throw " ++ errorVar : fail(caught.contents))
+          } else {
+            // The case is guaranteed to fail at runtime, so skip its code
+            // and keep the embedded error for the exhaustive failure args
+            itemSkipped := true
+          }
+        }
+      }
+      let itemCond = itemCond.contents
+      let itemCode = itemCode.contents
+
+      // Accumulate item parser when it has a discriminant
+      if !itemSkipped.contents && itemCond->X.String.unsafeToBool {
+        if itemCode->X.String.unsafeToBool {
+          switch byDiscriminant.contents->X.Dict.getUnsafeOption(itemCond) {
+          | Some(Multiple(arr)) => arr->Array.push(itemCode)->ignore
+          | Some(Single(code)) =>
+            byDiscriminant.contents->Dict.set(itemCond, Multiple([code, itemCode]))
+          | None => byDiscriminant.contents->Dict.set(itemCond, Single(itemCode))
+          }
+        } else {
+          // We have a condition but without additional parsing logic
+          // So we accumulate it in case it's needed for a refinement later
+          itemNoop := (
+              itemNoop.contents->X.String.unsafeToBool
+                ? `${itemNoop.contents}||${itemCond}`
+                : itemCond
+            )
+        }
       }
 
-      let activeKey = unionActiveKey(
-        ~inputSchema=input.schema,
-        ~inputTagFlag=initialInputTagFlag,
-        ~schemas,
-      )
-
-      let initialInline = input.inline
-
-      let fail = caught => {
-        `${input->B.embed(
-            (
-              _ => {
-                let args = %raw(`arguments`)
-                B.throw(
-                  B.makeInvalidInputDetails(
-                    ~path=input.path,
-                    ~expected=selfSchema,
-                    ~received=unknown->castToPublic,
-                    ~input=args->Array.getUnsafe(0),
-                    ~includeInput=true,
-                    ~unionErrors=?args->Array.length > 1
-                      ? Some(args->X.Array.fromArguments->Array.slice(~start=1))
-                      : None,
-                  ),
-                )
-              }
-            )->X.Function.toExpression,
-          )}(${input.var()}${caught})`
-      }
-
-      // Create a copy of the input val, so we can mutate it
-      // It's still the same value though, until mutated
-      let output = input->B.refine
-      let outputAnyOf = []
-
-      // Set when a single-case block fails at codegen time, so the caller
-      // can drop the block and pass the embedded error along instead of
-      // emitting a guaranteed runtime throw
-      let staticBlockFailure = ref("")
-
-      let getArrItemsCode = (arr: array<unknown>, ~isDeopt) => {
-        let typeValidationInput = arr->Array.getUnsafe(0)->(Obj.magic: unknown => val)
-        let typeValidationOutput = arr->Array.getUnsafe(1)->(Obj.magic: unknown => val)
-
-        let itemStart = ref("")
-        let itemEnd = ref("")
-        let itemNextElse = ref(false)
-        let itemNoop = ref("")
-        let caught = ref("")
-
-        // Accumulate schemas code by refinement (discriminant)
-        // so if we have two schemas with the same discriminant
-        // We can generate a single switch statement
-        // with try/catch blocks for each item
-        // If we come across an item without a discriminant
-        // we need to dump all accumulated schemas in try block
-        // and have the item without discriminant as catch all
-        // If we come across an item without a discriminant
-        // and without any code, it means that this item is always valid
-        // and we should exit early
-        let byDiscriminant = ref(dict{})
-
-        let preItems = 2
-        let itemIdx = ref(preItems)
-        let lastIdx = arr->Array.length - 1
-        while itemIdx.contents <= lastIdx {
-          // Copy it one more time, since every case decoder
-          // might mutate the input
-          let input = typeValidationOutput->B.Val.scope
-          input.isUnion = Some(true)
-          input.hasTransform = typeValidationOutput.hasTransform
-          input.isOutput = Some(false)
-          input.expected =
-            arr->Stdlib.Array.getUnsafe(itemIdx.contents)->(Obj.magic: unknown => internal)
-
-          let isLast = itemIdx.contents === lastIdx
-          let isFirst = itemIdx.contents === preItems
-          let isOnlyCase = isFirst && isLast
-          let withExhaustiveCheck = ref(!isOnlyCase)
-
-          let itemSkipped = ref(false)
-          let itemCode = ref("")
-          let itemCond = ref("")
-          try {
-            let itemOutput = input->parse
-            outputAnyOf->Array.push(itemOutput.schema->castToPublic)->ignore
-
-            itemCode := itemOutput->B.merge(~hoistCond=itemCond)
-
-            if itemOutput.hasTransform->X.Option.getUnsafe {
-              output.hasTransform = Some(true)
-              if itemOutput.flag->Flag.unsafeHas(ValFlag.async) {
-                output.flag = output.flag->Flag.with(ValFlag.async)
-              }
-              let itemVar = typeValidationInput.var()
-              if itemOutput.inline !== itemVar {
-                itemCode :=
-                  itemCode.contents ++
-                  // Need to allocate a var here, so we don't mutate the input object field
-                  `${itemVar}=${itemOutput.inline}`
-              }
-            }
-          } catch {
-          | _ => {
-              let errorVar = input->B.embed(%raw(`exn`)->InternalError.getOrRethrow)
+      // Allocate all accumulated discriminants
+      // If we have an item without a discriminant
+      // and need to deopt. Or we are at the last item
+      if !itemSkipped.contents && (itemCond->X.String.unsafeToBool->not || isLast) {
+        let accedDiscriminants = byDiscriminant.contents->Dict.keysToArray
+        for idx in 0 to accedDiscriminants->Array.length - 1 {
+          let discrim = accedDiscriminants->Array.getUnsafe(idx)
+          let if_ = itemNextElse.contents ? "else if" : "if"
+          itemStart := itemStart.contents ++ if_ ++ `(${discrim}){`
+          switch byDiscriminant.contents->Dict.getUnsafe(discrim) {
+          | Single(code) => itemStart := itemStart.contents ++ code ++ "}"
+          | Multiple(arr) =>
+            let caught = ref("")
+            for idx in 0 to arr->Array.length - 1 {
+              let code = arr->Array.getUnsafe(idx)
+              let errorVar = `e` ++ idx->X.Int.unsafeToString
+              itemStart := itemStart.contents ++ `try{${code}}catch(${errorVar}){`
               caught := `${caught.contents},${errorVar}`
-              if isDeopt && isOnlyCase {
-                staticBlockFailure := errorVar
-                itemSkipped := true
-              } else if isLast {
-                withExhaustiveCheck := false
-                itemCode := (isDeopt ? "throw " ++ errorVar : fail(caught.contents))
-              } else {
-                // The case is guaranteed to fail at runtime, so skip its code
-                // and keep the embedded error for the exhaustive failure args
-                itemSkipped := true
-              }
             }
+            itemStart :=
+              itemStart.contents ++
+              fail(caught.contents) ++
+              String.repeat("}", arr->Array.length) ++ "}"
           }
-          let itemCond = itemCond.contents
-          let itemCode = itemCode.contents
-
-          // Accumulate item parser when it has a discriminant
-          if !itemSkipped.contents && itemCond->X.String.unsafeToBool {
-            if itemCode->X.String.unsafeToBool {
-              switch byDiscriminant.contents->X.Dict.getUnsafeOption(itemCond) {
-              | Some(Multiple(arr)) => arr->Array.push(itemCode)->ignore
-              | Some(Single(code)) =>
-                byDiscriminant.contents->Dict.set(itemCond, Multiple([code, itemCode]))
-              | None => byDiscriminant.contents->Dict.set(itemCond, Single(itemCode))
-              }
-            } else {
-              // We have a condition but without additional parsing logic
-              // So we accumulate it in case it's needed for a refinement later
-              itemNoop := (
-                  itemNoop.contents->X.String.unsafeToBool
-                    ? `${itemNoop.contents}||${itemCond}`
-                    : itemCond
-                )
-            }
-          }
-
-          // Allocate all accumulated discriminants
-          // If we have an item without a discriminant
-          // and need to deopt. Or we are at the last item
-          if !itemSkipped.contents && (itemCond->X.String.unsafeToBool->not || isLast) {
-            let accedDiscriminants = byDiscriminant.contents->Dict.keysToArray
-            for idx in 0 to accedDiscriminants->Array.length - 1 {
-              let discrim = accedDiscriminants->Array.getUnsafe(idx)
-              let if_ = itemNextElse.contents ? "else if" : "if"
-              itemStart := itemStart.contents ++ if_ ++ `(${discrim}){`
-              switch byDiscriminant.contents->Dict.getUnsafe(discrim) {
-              | Single(code) => itemStart := itemStart.contents ++ code ++ "}"
-              | Multiple(arr) =>
-                let caught = ref("")
-                for idx in 0 to arr->Array.length - 1 {
-                  let code = arr->Array.getUnsafe(idx)
-                  let errorVar = `e` ++ idx->X.Int.unsafeToString
-                  itemStart := itemStart.contents ++ `try{${code}}catch(${errorVar}){`
-                  caught := `${caught.contents},${errorVar}`
-                }
-                itemStart :=
-                  itemStart.contents ++
-                  fail(caught.contents) ++
-                  String.repeat("}", arr->Array.length) ++ "}"
-              }
-              itemNextElse := true
-            }
-            byDiscriminant.contents = dict{}
-          }
-
-          if !itemSkipped.contents && itemCond->X.String.unsafeToBool->not {
-            if itemCode->X.String.unsafeToBool->not {
-              // If we don't have a condition (discriminant)
-              // and additional parsing logic,
-              // it means that this item is always passes
-              // so we can remove preceding accumulated refinements
-              // and exit early even if there are other items
-              itemNoop := ""
-              itemIdx := lastIdx
-              withExhaustiveCheck := false
-            } else {
-              // The item without refinement should switch to deopt mode
-              // Since there might be validation in the body
-              if itemNoop.contents->X.String.unsafeToBool {
-                let if_ = itemNextElse.contents ? "else if" : "if"
-                itemStart := itemStart.contents ++ if_ ++ `(!(${itemNoop.contents})){`
-                itemEnd := "}" ++ itemEnd.contents
-                itemNoop := ""
-                itemNextElse := false
-              }
-              if isLast && (isDeopt || !withExhaustiveCheck.contents || isFirst) {
-                // For the last item don't add try/catch
-                itemStart :=
-                  itemStart.contents ++ `${itemNextElse.contents ? "else{" : ""}${itemCode}`
-                itemEnd := (itemNextElse.contents ? "}" : "") ++ itemEnd.contents
-              } else {
-                let errorVar = `e` ++ (itemIdx.contents - preItems)->X.Int.unsafeToString
-                itemStart :=
-                  itemStart.contents ++
-                  `${itemNextElse.contents ? "else{" : ""}try{${itemCode}}catch(${errorVar}){`
-                itemEnd := (itemNextElse.contents ? "}" : "") ++ "}" ++ itemEnd.contents
-                caught := `${caught.contents},${errorVar}`
-                itemNextElse := false
-              }
-            }
-          }
-          if isLast {
-            if itemNoop.contents->X.String.unsafeToBool {
-              if (
-                itemStart.contents->X.String.unsafeToBool ||
-                // Skipped cases have their errors embedded,
-                // which the hoisted check below can't reference
-                caught.contents->X.String.unsafeToBool
-              ) {
-                let if_ = itemNextElse.contents ? "else if" : "if"
-                itemStart :=
-                  itemStart.contents ++ if_ ++ `(!(${itemNoop.contents})){${fail(caught.contents)}}`
-              } else {
-                typeValidationOutput->B.pushCheck({
-                  cond: (~inputVar as _) => `(${itemNoop.contents})`,
-                  fail: B.failInvalidType,
-                })
-              }
-            } else if withExhaustiveCheck.contents {
-              let errorCode = fail(caught.contents)
-              itemStart :=
-                itemStart.contents ++ (itemNextElse.contents ? `else{${errorCode}}` : errorCode)
-            }
-          }
-
-          itemIdx := itemIdx.contents->X.Int.plus(1)
+          itemNextElse := true
         }
-
-        itemStart.contents ++ itemEnd.contents
+        byDiscriminant.contents = dict{}
       }
 
-      let start = ref("")
-      let end = ref("")
-      let caught = ref("")
-      // If we got a case which always passes,
-      // we can exit early
-      let exit = ref(false)
-
-      let lastIdx = schemas->Array.length - 1
-      let byKey: ref<dict<array<unknown>>> = ref(dict{})
-      let keys = ref([])
-
-      // FIXME: minimal fix — applies the union's refiner/inputRefiner per
-      // surviving case (previously dropped when the union has `.to`). The
-      // emit shape isn't ideal; fold this into the shared refiner pipeline
-      // post-release.
-      let appendUnionRefiners = {
-        let unionRefiner = selfSchema.refiner
-        let unionInputRefiner = selfSchema.inputRefiner
-        // Call each source refiner at most once so its predicate is embedded
-        // in `input.global.embeded` once and every case references the same
-        // `e[N]`. `B.embed` is append-only, so a per-case call would duplicate.
-        let cachedRefinerChecks = ref(None)
-        let cachedInputRefinerChecks = ref(None)
-        let attach = (current, source, cache) =>
-          switch source {
-          | None => current
-          | Some(fn) =>
-            let getCached = (~input) =>
-              switch cache.contents {
-              | Some(checks) => checks
-              | None =>
-                let checks = fn(~input)
-                cache := Some(checks)
-                checks
-              }
-            switch current {
-            | None => Some(getCached)
-            | Some(existing) =>
-              Some(
-                (~input) => {
-                  let arr = existing(~input)
-                  let next = getCached(~input)
-                  for i in 0 to next->Array.length - 1 {
-                    arr->Array.push(next->Array.getUnsafe(i))->ignore
-                  }
-                  arr
-                },
-              )
-            }
-          }
-        (mut: internal) => {
-          switch attach(mut.refiner, unionRefiner, cachedRefinerChecks) {
-          | Some(r) => mut.refiner = Some(r)
-          | None => ()
-          }
-          switch attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks) {
-          | Some(r) => mut.inputRefiner = Some(r)
-          | None => ()
-          }
-        }
-      }
-
-      let schemas = unionPrioritizeConst(~inputSchema=input.schema, ~schemas)
-
-      // Reservation only applies when the variants are genuine alternative
-      // sources (input type not statically narrowed to one). When `activeKey`
-      // is set the input is a known single type decoded into the union, so the
-      // active variant converts to the full target as before.
-      let assignedTargets = switch toPerCase {
-      | Some(target) if activeKey === "" => Some(unionAssignTargets(~sources=schemas, ~target))
-      | _ => None
-      }
-
-      for idx in 0 to lastIdx {
-        let schema = switch (toPerCase, assignedTargets) {
-        | (Some(target), assignedTargets) =>
-          updateOutput(schemas->Array.getUnsafe(idx), mut => {
-            appendUnionRefiners(mut)
-            mut.to = Some(
-              switch assignedTargets {
-              | Some(targets) => targets->Array.getUnsafe(idx)
-              | None => target
-              },
-            )
-          })->castToInternal
-        | (None, _) => schemas->Array.getUnsafe(idx)
-        }
-        let tag = schema.tag
-        let tagFlag = TagFlag.get(tag)
-        let key = unionToKey(schema)
-
-        if activeKey !== "" && activeKey !== key {
-          // not in active tier — skip
-          ()
-        } else if (
-          tagFlag->Flag.unsafeHas(TagFlag.undefined) &&
-            selfSchema->Obj.magic->Stdlib.Dict.has("fromDefault")
-        ) {
-          // skip it
-          ()
+      if !itemSkipped.contents && itemCond->X.String.unsafeToBool->not {
+        if itemCode->X.String.unsafeToBool->not {
+          // If we don't have a condition (discriminant)
+          // and additional parsing logic,
+          // it means that this item is always passes
+          // so we can remove preceding accumulated refinements
+          // and exit early even if there are other items
+          itemNoop := ""
+          itemIdx := lastIdx
+          withExhaustiveCheck := false
         } else {
-          let initialArr = byKey.contents->X.Dict.getUnsafeOption(key)
-          switch initialArr {
-          | Some(arr) =>
-            if (
-              tagFlag->Flag.unsafeHas(TagFlag.object) &&
-                schema.properties->X.Option.getUnsafe->Stdlib.Dict.has(nestedLoc)
-            ) {
-              // This is a special case for https://github.com/DZakh/sury/issues/150
-              // When nested option goes together with an empty object schema
-              // Since we put None case check second, we need to change priority here.
-              arr
-              ->Stdlib.Array.splice(
-                ~start=arr->Stdlib.Array.length - 1,
-                ~remove=0,
-                ~insert=[schema->(Obj.magic: internal => unknown)],
-              )
-              ->ignore
-            } else if (
-              // TODO: Is this check needed?
-              // There can only be one valid. Dedupe
-              !(
-                tagFlag->Flag.unsafeHas(
-                  TagFlag.undefined->Flag.with(TagFlag.null)->Flag.with(TagFlag.nan),
-                )
-              )
-            ) {
-              arr->Array.push(schema->(Obj.magic: internal => unknown))->ignore
-            }
+          // The item without refinement should switch to deopt mode
+          // Since there might be validation in the body
+          if itemNoop.contents->X.String.unsafeToBool {
+            let if_ = itemNextElse.contents ? "else if" : "if"
+            itemStart := itemStart.contents ++ if_ ++ `(!(${itemNoop.contents})){`
+            itemEnd := "}" ++ itemEnd.contents
+            itemNoop := ""
+            itemNextElse := false
+          }
+          if isLast && (isDeopt || !withExhaustiveCheck.contents || isFirst) {
+            // For the last item don't add try/catch
+            itemStart := itemStart.contents ++ `${itemNextElse.contents ? "else{" : ""}${itemCode}`
+            itemEnd := (itemNextElse.contents ? "}" : "") ++ itemEnd.contents
+          } else {
+            let errorVar = `e` ++ (itemIdx.contents - preItems)->X.Int.unsafeToString
+            itemStart :=
+              itemStart.contents ++
+              `${itemNextElse.contents ? "else{" : ""}try{${itemCode}}catch(${errorVar}){`
+            itemEnd := (itemNextElse.contents ? "}" : "") ++ "}" ++ itemEnd.contents
+            caught := `${caught.contents},${errorVar}`
+            itemNextElse := false
+          }
+        }
+      }
+      if isLast {
+        if itemNoop.contents->X.String.unsafeToBool {
+          if (
+            itemStart.contents->X.String.unsafeToBool ||
+              // Skipped cases have their errors embedded,
+              // which the hoisted check below can't reference
+              caught.contents->X.String.unsafeToBool
+          ) {
+            let if_ = itemNextElse.contents ? "else if" : "if"
+            itemStart :=
+              itemStart.contents ++ if_ ++ `(!(${itemNoop.contents})){${fail(caught.contents)}}`
+          } else {
+            typeValidationOutput->B.pushCheck({
+              cond: (~inputVar as _) => `(${itemNoop.contents})`,
+              fail: B.failInvalidType,
+            })
+          }
+        } else if withExhaustiveCheck.contents {
+          let errorCode = fail(caught.contents)
+          itemStart :=
+            itemStart.contents ++ (itemNextElse.contents ? `else{${errorCode}}` : errorCode)
+        }
+      }
+
+      itemIdx := itemIdx.contents->X.Int.plus(1)
+    }
+
+    itemStart.contents ++ itemEnd.contents
+  }
+
+  let start = ref("")
+  let end = ref("")
+  let caught = ref("")
+  // If we got a case which always passes,
+  // we can exit early
+  let exit = ref(false)
+
+  let lastIdx = schemas->Array.length - 1
+  let byKey: ref<dict<array<unknown>>> = ref(dict{})
+  let keys = ref([])
+
+  // FIXME: minimal fix — applies the union's refiner/inputRefiner per
+  // surviving case (previously dropped when the union has `.to`). The
+  // emit shape isn't ideal; fold this into the shared refiner pipeline
+  // post-release.
+  let appendUnionRefiners = {
+    let unionRefiner = selfSchema.refiner
+    let unionInputRefiner = selfSchema.inputRefiner
+    // Call each source refiner at most once so its predicate is embedded
+    // in `input.global.embeded` once and every case references the same
+    // `e[N]`. `B.embed` is append-only, so a per-case call would duplicate.
+    let cachedRefinerChecks = ref(None)
+    let cachedInputRefinerChecks = ref(None)
+    let attach = (current, source, cache) =>
+      switch source {
+      | None => current
+      | Some(fn) =>
+        let getCached = (~input) =>
+          switch cache.contents {
+          | Some(checks) => checks
           | None =>
-            // Recreate input val for every schema
-            // since we will mutate it
-            let typeValidationInput = input->B.Val.scope
-            typeValidationInput.expected = unionTypeValidationSchema(~tagFlag, ~schema)
-
-            let typeValidationOutput = try {
-              typeValidationInput->parse
-            } catch {
-            | _ => {
-                // Discard any checks parse managed to push before throwing,
-                // so the deopt path doesn't see leftover partial state.
-                typeValidationInput.checks = None
-                typeValidationInput
-              }
-            }
-
-            if unionIsPriority(tagFlag, byKey.contents) {
-              // Not the fastest way, but it's the simplest way
-              // to make sure NaN is checked before number
-              // And instance and array checked before object
-              keys.contents->Array.unshift(key)->ignore
-            } else {
-              keys.contents->Array.push(key)->ignore
-            }
-            byKey.contents->Dict.set(
-              key,
-              [
-                typeValidationInput->(Obj.magic: val => unknown),
-                typeValidationOutput->(Obj.magic: val => unknown),
-                schema->(Obj.magic: internal => unknown),
-              ],
-            )
-
-            let shouldDeopt = ref(true)
-            let valRef = ref(Some(typeValidationOutput))
-            while valRef.contents !== None && shouldDeopt.contents {
-              let v = valRef.contents->X.Option.getUnsafe
-              valRef := v.prev
-              // Deopt to a try/catch block unless every level's checks are
-              // hoistable into the dispatch condition (same rule as merge).
-              shouldDeopt := !(v.checks->X.Option.unsafeToBool && v->B.isHoistable)
-            }
-
-            if shouldDeopt.contents {
-              for keyIdx in 0 to keys.contents->Stdlib.Array.length - 1 {
-                let key = keys.contents->Stdlib.Array.getUnsafe(keyIdx)
-                if !exit.contents {
-                  let arr = byKey.contents->Stdlib.Dict.getUnsafe(key)
-                  let typeValidationOutput =
-                    arr->Stdlib.Array.getUnsafe(1)->(Obj.magic: unknown => val)
-                  let itemsCode = getArrItemsCode(arr, ~isDeopt=true)
-                  let blockCode = typeValidationOutput->B.merge ++ itemsCode
-
-                  let embeddedError = staticBlockFailure.contents
-                  if embeddedError->X.String.unsafeToBool {
-                    staticBlockFailure := ""
-                    if blockCode->X.String.unsafeToBool {
-                      // Type validation code is still relevant — restore the throw
-                      let errorVar = `e` ++ (idx + keyIdx)->X.Int.unsafeToString
-                      start :=
-                        start.contents ++ `try{${blockCode}throw ${embeddedError}}catch(${errorVar}){`
-                      end := "}" ++ end.contents
-                      caught := `${caught.contents},${errorVar}`
-                    } else {
-                      // The block always fails — drop it
-                      // and pass the embedded error along
-                      caught := `${caught.contents},${embeddedError}`
-                    }
-                  } else if blockCode->X.String.unsafeToBool {
-                    let errorVar = `e` ++ (idx + keyIdx)->X.Int.unsafeToString
-                    start := start.contents ++ `try{${blockCode}}catch(${errorVar}){`
-                    end := "}" ++ end.contents
-                    caught := `${caught.contents},${errorVar}`
-                  } else {
-                    exit := true
-                  }
-                }
-              }
-
-              byKey := dict{}
-              keys := []
-            }
+            let checks = fn(~input)
+            cache := Some(checks)
+            checks
           }
-        }
-      }
-
-      let byKey = byKey.contents
-      let keys = keys.contents
-
-      if !exit.contents {
-        let nextElse = ref(false)
-        let noop = ref("")
-
-        for idx in 0 to keys->Array.length - 1 {
-          let arr = byKey->Dict.getUnsafe(keys->Array.getUnsafe(idx))
-          let typeValidationOutput = arr->Stdlib.Array.getUnsafe(1)->(Obj.magic: unknown => val)
-          let firstSchema = arr->Stdlib.Array.getUnsafe(2)->(Obj.magic: unknown => internal)
-
-          let itemsCode = getArrItemsCode(arr, ~isDeopt=false)
-
-          let blockCond = ref("")
-          let blockCode = typeValidationOutput->B.merge(~hoistCond=blockCond) ++ itemsCode
-          let blockCond = blockCond.contents
-
-          if blockCode->X.String.unsafeToBool || unionIsPriority(firstSchema.tag->TagFlag.get, byKey) {
-            let if_ = nextElse.contents ? "else if" : "if"
-            start := start.contents ++ if_ ++ `(${blockCond}){${blockCode}}`
-            nextElse := true
-          } else {
-            noop := (
-                noop.contents->X.String.unsafeToBool ? `${noop.contents}||${blockCond}` : blockCond
-              )
-          }
-        }
-
-        let errorCode = fail(caught.contents)
-        start :=
-          start.contents ++ if noop.contents->X.String.unsafeToBool {
-            let if_ = nextElse.contents ? "else if" : "if"
-            if_ ++ `(!(${noop.contents})){${errorCode}}`
-          } else if nextElse.contents {
-            `else{${errorCode}}`
-          } else if end.contents === "" {
-            // The bare fail call might be followed by more code, eg `return`
-            errorCode ++ ";"
-          } else {
-            errorCode
-          }
-      }
-
-      output.codeFromPrev = output.codeFromPrev ++ start.contents ++ end.contents
-
-      // In case if input.var was called, but output.var wasn't
-      if input.inline !== output.inline {
-        output.inline = input.inline
-      }
-
-      let o = if output.flag->Flag.unsafeHas(ValFlag.async) {
-        output.inline = `Promise.resolve(${output.inline})`
-        output.var = B._notVar
-        output
-      } else if output.var === B._var {
-        // TODO: Think how to make it more robust
-        // Recreate to not break the logic to determine
-        // whether the output is changed
-
-        // Use output.b instead of b because of mergeWithCatch
-        // Should refactor mergeWithCatch to make it simpler
-        // All of this is a hack to make mergeWithCatch think that there are no changes. eg S.array(S.option(item))
-        if (
-          input.codeFromPrev === "" &&
-          output.codeFromPrev === "" &&
-          initialInline === "i"
-        ) {
-          // FIXME: Might not be not needed
-          input.hoistedDecls = ""
-          input.var = B._notVar
-          input.inline = initialInline
-          input
-        } else {
-          output
-        }
-      } else {
-        output
-      }
-
-      // Build the output schema from collected case output schemas
-      o.schema = if outputAnyOf->Stdlib.Array.length->X.Int.unsafeToBool {
-        unionFactory(outputAnyOf)->castToInternal
-      } else {
-        never_()
-      }
-      o.expected = switch toPerCase {
-      | Some(to) => {
-          o.isOutput = Some(true)
-          to->getOutputSchema
-        }
-      | _ => selfSchema
-      }
-
-      o
-    }
-  }
-and unionFactory: 'a 'b. array<t<'a>> => t<'b> = schemas => {
-    let schemas: array<internal> = schemas->Obj.magic
-    // TODO:
-    // 1. Fitler out items without parser
-    // 2. Remove duplicate schemas
-    // 3. Spread Union and JSON if they are not transformed
-    // 4. Provide correct `has` value for Union and JSON
-    switch schemas {
-    | [] => InternalError.panic("S.union requires at least one item")
-    | [schema] => schema->castToPublic
-    | _ =>
-      let has = dict{}
-      let anyOf = X.Set.make()
-
-      for idx in 0 to schemas->Array.length - 1 {
-        let schema = schemas->Array.getUnsafe(idx)
-
-        // Check if the union is not transformed
-        if schema.tag === unionTag && schema.to === None {
-          schema.anyOf
-          ->X.Option.getUnsafe
-          ->Array.forEach(item => {
-            anyOf->X.Set.add(item)
-          })
-          let _ = has->X.Dict.mixin(schema.has->X.Option.getUnsafe)
-        } else {
-          anyOf->X.Set.add(schema)
-          has->setHas(schema.tag)
-        }
-      }
-      let mut = base(unionTag, ~selfReverse=false)
-      mut.anyOf = Some(anyOf->X.Set.toArray)
-      mut.decoder = unionDecoder
-      mut.encoder = Some(unionEncoder)
-      mut.has = Some(has)
-      mut->castToPublic
-    }
-  }
-
-and nestedNone = () => {
-      let itemSchema = Literal.parse(0)
-      // FIXME: dict{}
-      let properties = dict{}
-      properties->Dict.set(nestedLoc, itemSchema)
-      {
-        tag: objectTag,
-        required: [nestedLoc],
-        properties,
-        additionalItems: Strip,
-        decoder: objectDecoder,
-        // TODO: Support this as a default coercion
-        serializer: Builder.make((~input) => {
-          let nextSchema = input.expected.to->X.Option.getUnsafe
-          input->B.nextConst(~schema=nextSchema, ~expected=nextSchema)
-          // FIXME: Need to set isOutput?
-        }),
-      }
-    }
-
-and nestedOption = item => {
-      item
-      ->updateOutput(mut => {
-        mut.to = Some(nestedNone())
-        mut.parser = Some(nestedOptionParser)
-      })
-      ->castToInternal
-    }
-
-and optionFactory = (item, ~unit=unit()->castToPublic) => {
-    let item = item->castToInternal
-
-    switch item->getOutputSchema {
-    | {tag: Undefined} => unionFactory([unit->castToUnknown, item->nestedOption->castToPublic])
-    | {tag: Union, ?anyOf, ?has} =>
-      item->updateOutput(mut => {
-        let schemas = anyOf->X.Option.getUnsafe
-        let mutHas = has->X.Option.getUnsafe->X.Dict.copy
-
-        let newAnyOf = []
-        for idx in 0 to schemas->Stdlib.Array.length - 1 {
-          let schema = schemas->Array.getUnsafe(idx)
-          newAnyOf
-          ->Array.push(
-            switch schema->getOutputSchema {
-            | {tag: Undefined} => {
-                mutHas->Dict.set(((unit->castToInternal).tag: tag :> string), true)
-                newAnyOf->Array.push(unit->castToInternal)->ignore
-                schema->nestedOption
+        switch current {
+        | None => Some(getCached)
+        | Some(existing) =>
+          Some(
+            (~input) => {
+              let arr = existing(~input)
+              let next = getCached(~input)
+              for i in 0 to next->Array.length - 1 {
+                arr->Array.push(next->Array.getUnsafe(i))->ignore
               }
-            | {properties} =>
-              switch properties->X.Dict.getUnsafeOption(nestedLoc) {
-              | Some(nestedSchema) =>
-                schema
-                ->updateOutput(mut => {
-                  // FIXME: dict{}
-                  let properties = dict{}
-                  properties->Dict.set(
-                    nestedLoc,
-                    {
-                      ...nestedSchema,
-                      const: nestedSchema.const->Obj.magic->X.Int.plus(1)->Obj.magic,
-                    },
-                  )
-                  mut.properties = Some(properties)
-                })
-                ->castToInternal
-              | None => schema
-              }
-            | _ => schema
+              arr
             },
           )
-          ->ignore
         }
-
-        if newAnyOf->Array.length === schemas->Array.length {
-          mutHas->Dict.set(((unit->castToInternal).tag: tag :> string), true)
-          newAnyOf->Array.push(unit->castToInternal)->ignore
-        }
-
-        mut.anyOf = Some(newAnyOf)
-        mut.has = Some(mutHas)
-      })
-    | _ => unionFactory([item->castToPublic, unit->castToUnknown])
+      }
+    (mut: internal) => {
+      switch attach(mut.refiner, unionRefiner, cachedRefinerChecks) {
+      | Some(r) => mut.refiner = Some(r)
+      | None => ()
+      }
+      switch attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks) {
+      | Some(r) => mut.inputRefiner = Some(r)
+      | None => ()
+      }
     }
   }
+
+  let schemas = unionPrioritizeConst(~inputSchema=input.schema, ~schemas)
+
+  // Reservation only applies when the variants are genuine alternative
+  // sources (input type not statically narrowed to one). When `activeKey`
+  // is set the input is a known single type decoded into the union, so the
+  // active variant converts to the full target as before.
+  let assignedTargets = switch toPerCase {
+  | Some(target) if activeKey === "" => Some(unionAssignTargets(~sources=schemas, ~target))
+  | _ => None
+  }
+
+  for idx in 0 to lastIdx {
+    let schema = switch (toPerCase, assignedTargets) {
+    | (Some(target), assignedTargets) =>
+      updateOutput(schemas->Array.getUnsafe(idx), mut => {
+        appendUnionRefiners(mut)
+        mut.to = Some(
+          switch assignedTargets {
+          | Some(targets) => targets->Array.getUnsafe(idx)
+          | None => target
+          },
+        )
+      })->castToInternal
+    | (None, _) => schemas->Array.getUnsafe(idx)
+    }
+    let tag = schema.tag
+    let tagFlag = TagFlag.get(tag)
+    let key = unionToKey(schema)
+
+    if activeKey !== "" && activeKey !== key {
+      // not in active tier — skip
+      ()
+    } else if (
+      tagFlag->Flag.unsafeHas(TagFlag.undefined) &&
+        selfSchema->Obj.magic->Stdlib.Dict.has("fromDefault")
+    ) {
+      // skip it
+      ()
+    } else {
+      let initialArr = byKey.contents->X.Dict.getUnsafeOption(key)
+      switch initialArr {
+      | Some(arr) =>
+        if (
+          tagFlag->Flag.unsafeHas(TagFlag.object) &&
+            schema.properties->X.Option.getUnsafe->Stdlib.Dict.has(nestedLoc)
+        ) {
+          // This is a special case for https://github.com/DZakh/sury/issues/150
+          // When nested option goes together with an empty object schema
+          // Since we put None case check second, we need to change priority here.
+          arr
+          ->Stdlib.Array.splice(
+            ~start=arr->Stdlib.Array.length - 1,
+            ~remove=0,
+            ~insert=[schema->(Obj.magic: internal => unknown)],
+          )
+          ->ignore
+        } else if (
+          // TODO: Is this check needed?
+          // There can only be one valid. Dedupe
+          !(
+            tagFlag->Flag.unsafeHas(
+              TagFlag.undefined->Flag.with(TagFlag.null)->Flag.with(TagFlag.nan),
+            )
+          )
+        ) {
+          arr->Array.push(schema->(Obj.magic: internal => unknown))->ignore
+        }
+      | None =>
+        // Recreate input val for every schema
+        // since we will mutate it
+        let typeValidationInput = input->B.Val.scope
+        typeValidationInput.expected = unionTypeValidationSchema(~tagFlag, ~schema)
+
+        let typeValidationOutput = try {
+          typeValidationInput->parse
+        } catch {
+        | _ => {
+            // Discard any checks parse managed to push before throwing,
+            // so the deopt path doesn't see leftover partial state.
+            typeValidationInput.checks = None
+            typeValidationInput
+          }
+        }
+
+        if unionIsPriority(tagFlag, byKey.contents) {
+          // Not the fastest way, but it's the simplest way
+          // to make sure NaN is checked before number
+          // And instance and array checked before object
+          keys.contents->Array.unshift(key)->ignore
+        } else {
+          keys.contents->Array.push(key)->ignore
+        }
+        byKey.contents->Dict.set(
+          key,
+          [
+            typeValidationInput->(Obj.magic: val => unknown),
+            typeValidationOutput->(Obj.magic: val => unknown),
+            schema->(Obj.magic: internal => unknown),
+          ],
+        )
+
+        let shouldDeopt = ref(true)
+        let valRef = ref(Some(typeValidationOutput))
+        while valRef.contents !== None && shouldDeopt.contents {
+          let v = valRef.contents->X.Option.getUnsafe
+          valRef := v.prev
+          // Deopt to a try/catch block unless every level's checks are
+          // hoistable into the dispatch condition (same rule as merge).
+          shouldDeopt := !(v.checks->X.Option.unsafeToBool && v->B.isHoistable)
+        }
+
+        if shouldDeopt.contents {
+          for keyIdx in 0 to keys.contents->Stdlib.Array.length - 1 {
+            let key = keys.contents->Stdlib.Array.getUnsafe(keyIdx)
+            if !exit.contents {
+              let arr = byKey.contents->Stdlib.Dict.getUnsafe(key)
+              let typeValidationOutput = arr->Stdlib.Array.getUnsafe(1)->(Obj.magic: unknown => val)
+              let itemsCode = getArrItemsCode(arr, ~isDeopt=true)
+              let blockCode = typeValidationOutput->B.merge ++ itemsCode
+
+              let embeddedError = staticBlockFailure.contents
+              if embeddedError->X.String.unsafeToBool {
+                staticBlockFailure := ""
+                if blockCode->X.String.unsafeToBool {
+                  // Type validation code is still relevant — restore the throw
+                  let errorVar = `e` ++ (idx + keyIdx)->X.Int.unsafeToString
+                  start :=
+                    start.contents ++ `try{${blockCode}throw ${embeddedError}}catch(${errorVar}){`
+                  end := "}" ++ end.contents
+                  caught := `${caught.contents},${errorVar}`
+                } else {
+                  // The block always fails — drop it
+                  // and pass the embedded error along
+                  caught := `${caught.contents},${embeddedError}`
+                }
+              } else if blockCode->X.String.unsafeToBool {
+                let errorVar = `e` ++ (idx + keyIdx)->X.Int.unsafeToString
+                start := start.contents ++ `try{${blockCode}}catch(${errorVar}){`
+                end := "}" ++ end.contents
+                caught := `${caught.contents},${errorVar}`
+              } else {
+                exit := true
+              }
+            }
+          }
+
+          byKey := dict{}
+          keys := []
+        }
+      }
+    }
+  }
+
+  let byKey = byKey.contents
+  let keys = keys.contents
+
+  if !exit.contents {
+    let nextElse = ref(false)
+    let noop = ref("")
+
+    for idx in 0 to keys->Array.length - 1 {
+      let arr = byKey->Dict.getUnsafe(keys->Array.getUnsafe(idx))
+      let typeValidationOutput = arr->Stdlib.Array.getUnsafe(1)->(Obj.magic: unknown => val)
+      let firstSchema = arr->Stdlib.Array.getUnsafe(2)->(Obj.magic: unknown => internal)
+
+      let itemsCode = getArrItemsCode(arr, ~isDeopt=false)
+
+      let blockCond = ref("")
+      let blockCode = typeValidationOutput->B.merge(~hoistCond=blockCond) ++ itemsCode
+      let blockCond = blockCond.contents
+
+      if blockCode->X.String.unsafeToBool || unionIsPriority(firstSchema.tag->TagFlag.get, byKey) {
+        let if_ = nextElse.contents ? "else if" : "if"
+        start := start.contents ++ if_ ++ `(${blockCond}){${blockCode}}`
+        nextElse := true
+      } else {
+        noop := (
+            noop.contents->X.String.unsafeToBool ? `${noop.contents}||${blockCond}` : blockCond
+          )
+      }
+    }
+
+    let errorCode = fail(caught.contents)
+    start :=
+      start.contents ++ if noop.contents->X.String.unsafeToBool {
+        let if_ = nextElse.contents ? "else if" : "if"
+        if_ ++ `(!(${noop.contents})){${errorCode}}`
+      } else if nextElse.contents {
+        `else{${errorCode}}`
+      } else if end.contents === "" {
+        // The bare fail call might be followed by more code, eg `return`
+        errorCode ++ ";"
+      } else {
+        errorCode
+      }
+  }
+
+  output.codeFromPrev = output.codeFromPrev ++ start.contents ++ end.contents
+
+  // In case if input.var was called, but output.var wasn't
+  if input.inline !== output.inline {
+    output.inline = input.inline
+  }
+
+  let o = if output.flag->Flag.unsafeHas(ValFlag.async) {
+    output.inline = `Promise.resolve(${output.inline})`
+    output.var = B._notVar
+    output
+  } else if output.var === B._var {
+    // TODO: Think how to make it more robust
+    // Recreate to not break the logic to determine
+    // whether the output is changed
+
+    // Use output.b instead of b because of mergeWithCatch
+    // Should refactor mergeWithCatch to make it simpler
+    // All of this is a hack to make mergeWithCatch think that there are no changes. eg S.array(S.option(item))
+    if input.codeFromPrev === "" && output.codeFromPrev === "" && initialInline === "i" {
+      // FIXME: Might not be not needed
+      input.hoistedDecls = ""
+      input.var = B._notVar
+      input.inline = initialInline
+      input
+    } else {
+      output
+    }
+  } else {
+    output
+  }
+
+  // Build the output schema from collected case output schemas
+  o.schema = if outputAnyOf->Stdlib.Array.length->X.Int.unsafeToBool {
+    unionFactory(outputAnyOf)->castToInternal
+  } else {
+    never_()
+  }
+  o.expected = switch toPerCase {
+  | Some(to) => {
+      o.isOutput = Some(true)
+      to->getOutputSchema
+    }
+  | _ => selfSchema
+  }
+
+  o
+}
+and unionFactory: 'a 'b. array<t<'a>> => t<'b> = schemas => {
+  let schemas: array<internal> = schemas->Obj.magic
+  // TODO:
+  // 1. Fitler out items without parser
+  // 2. Remove duplicate schemas
+  // 3. Spread Union and JSON if they are not transformed
+  // 4. Provide correct `has` value for Union and JSON
+  switch schemas {
+  | [] => InternalError.panic("S.union requires at least one item")
+  | [schema] => schema->castToPublic
+  | _ =>
+    let has = dict{}
+    let anyOf = X.Set.make()
+
+    for idx in 0 to schemas->Array.length - 1 {
+      let schema = schemas->Array.getUnsafe(idx)
+
+      // Check if the union is not transformed
+      if schema.tag === unionTag && schema.to === None {
+        schema.anyOf
+        ->X.Option.getUnsafe
+        ->Array.forEach(item => {
+          anyOf->X.Set.add(item)
+        })
+        let _ = has->X.Dict.mixin(schema.has->X.Option.getUnsafe)
+      } else {
+        anyOf->X.Set.add(schema)
+        has->setHas(schema.tag)
+      }
+    }
+    let mut = base(unionTag, ~selfReverse=false)
+    mut.anyOf = Some(anyOf->X.Set.toArray)
+    mut.decoder = unionDecoder
+    mut.encoder = Some(unionEncoder)
+    mut.has = Some(has)
+    mut->castToPublic
+  }
+}
+
+and nestedNone = () => {
+  let itemSchema = Literal.parse(0)
+  // FIXME: dict{}
+  let properties = dict{}
+  properties->Dict.set(nestedLoc, itemSchema)
+  {
+    tag: objectTag,
+    required: [nestedLoc],
+    properties,
+    additionalItems: Strip,
+    decoder: objectDecoder,
+    // TODO: Support this as a default coercion
+    serializer: Builder.make((~input) => {
+      let nextSchema = input.expected.to->X.Option.getUnsafe
+      input->B.nextConst(~schema=nextSchema, ~expected=nextSchema)
+      // FIXME: Need to set isOutput?
+    }),
+  }
+}
+
+and nestedOption = item => {
+  item
+  ->updateOutput(mut => {
+    mut.to = Some(nestedNone())
+    mut.parser = Some(nestedOptionParser)
+  })
+  ->castToInternal
+}
+
+and optionFactory = (item, ~unit=unit()->castToPublic) => {
+  let item = item->castToInternal
+
+  switch item->getOutputSchema {
+  | {tag: Undefined} => unionFactory([unit->castToUnknown, item->nestedOption->castToPublic])
+  | {tag: Union, ?anyOf, ?has} =>
+    item->updateOutput(mut => {
+      let schemas = anyOf->X.Option.getUnsafe
+      let mutHas = has->X.Option.getUnsafe->X.Dict.copy
+
+      let newAnyOf = []
+      for idx in 0 to schemas->Stdlib.Array.length - 1 {
+        let schema = schemas->Array.getUnsafe(idx)
+        newAnyOf
+        ->Array.push(
+          switch schema->getOutputSchema {
+          | {tag: Undefined} => {
+              mutHas->Dict.set(((unit->castToInternal).tag: tag :> string), true)
+              newAnyOf->Array.push(unit->castToInternal)->ignore
+              schema->nestedOption
+            }
+          | {properties} =>
+            switch properties->X.Dict.getUnsafeOption(nestedLoc) {
+            | Some(nestedSchema) =>
+              schema
+              ->updateOutput(mut => {
+                // FIXME: dict{}
+                let properties = dict{}
+                properties->Dict.set(
+                  nestedLoc,
+                  {
+                    ...nestedSchema,
+                    const: nestedSchema.const->Obj.magic->X.Int.plus(1)->Obj.magic,
+                  },
+                )
+                mut.properties = Some(properties)
+              })
+              ->castToInternal
+            | None => schema
+            }
+          | _ => schema
+          },
+        )
+        ->ignore
+      }
+
+      if newAnyOf->Array.length === schemas->Array.length {
+        mutHas->Dict.set(((unit->castToInternal).tag: tag :> string), true)
+        newAnyOf->Array.push(unit->castToInternal)->ignore
+      }
+
+      mut.anyOf = Some(newAnyOf)
+      mut.has = Some(mutHas)
+    })
+  | _ => unionFactory([item->castToPublic, unit->castToUnknown])
+  }
+}
 
 and option = item => item->optionFactory(~unit=unit()->castToPublic)
 
@@ -4193,6 +4203,7 @@ and valGet = (parent: val, location) => {
         switch parent.schema.additionalItems->X.Option.getUnsafe {
         | Schema(s) =>
           let s = s->castToInternal
+
           // A `dict<V>` read by a fixed key may be absent (dicts have no required
           // keys), so model it as `option<V>` and let the union coercion handle a
           // missing key uniformly. Scoped to dict parents (objectTag) with a
@@ -4354,8 +4365,6 @@ let recursiveDecoder = Builder.make((~input) => {
 
   output
 })
-
-
 
 X.Object.defineProperty(
   %raw(`sp`),
@@ -4734,7 +4743,8 @@ module Option = {
             | _ =>
               let error = %raw(`exn`)->InternalError.getOrRethrow
               InternalError.panic(
-                `Invalid default for ${mut->castToPublic
+                `Invalid default for ${mut
+                  ->castToPublic
                   ->toExpression}: ${(error->Obj.magic)["message"]}`,
               )
             }
@@ -4791,7 +4801,6 @@ module Option = {
   let getOrWith = (schema, defalutCb) =>
     schema->getWithDefault(Callback(defalutCb->(Obj.magic: (unit => 'a) => unit => unknown)))
 }
-
 
 module Object = {
   type rec s = {
@@ -5806,11 +5815,7 @@ module Schema = {
     // FIXME: TODO: something with flattened
     switch from->X.Array.getUnsafeOption(idx) {
     | Some(key) =>
-      getValByFrom(
-        ~input=input.vals->X.Option.getUnsafe->Dict.getUnsafe(key),
-        ~from,
-        ~idx=idx + 1,
-      )
+      getValByFrom(~input=input.vals->X.Option.getUnsafe->Dict.getUnsafe(key), ~from, ~idx=idx + 1)
     | None => input
     }
   }
@@ -5844,10 +5849,7 @@ module Schema = {
               let location = keys->Array.getUnsafe(idx)
               output->B.Val.Object.add(
                 ~location,
-                getShapedParserOutput(
-                  ~input,
-                  ~targetSchema=properties->Dict.getUnsafe(location),
-                ),
+                getShapedParserOutput(~input, ~targetSchema=properties->Dict.getUnsafe(location)),
               )
             }
           }
@@ -5936,10 +5938,7 @@ module Schema = {
     | {vals} => {
         let keys = vals->Dict.keysToArray
         for idx in 0 to keys->Array.length - 1 {
-          prepareShapedSerializerAcc(
-            ~acc,
-            ~input=vals->Dict.getUnsafe(keys->Array.getUnsafe(idx)),
-          )
+          prepareShapedSerializerAcc(~acc, ~input=vals->Dict.getUnsafe(keys->Array.getUnsafe(idx)))
         }
       }
     | _ => ()
@@ -5984,10 +5983,7 @@ module Schema = {
 
         switch resolvedTargetSchema {
         | {items}
-          if !(
-            acc === None &&
-              resolvedTargetSchema.additionalItems->typeof === objectTag
-          ) =>
+          if !(acc === None && resolvedTargetSchema.additionalItems->typeof === objectTag) =>
           for idx in 0 to items->Array.length - 1 {
             let location = idx->Int.toString
             v->B.Val.Object.add(
@@ -6006,10 +6002,7 @@ module Schema = {
             )
           }
         | {properties, ?flattened}
-          if !(
-            acc === None &&
-              resolvedTargetSchema.additionalItems->typeof === objectTag
-          ) => {
+          if !(acc === None && resolvedTargetSchema.additionalItems->typeof === objectTag) => {
             switch (flattened, acc) {
             | (Some(flattenedSchemas), Some({flattened: flattenedAcc})) =>
               flattenedAcc->Array.forEachWithIndex((acc, idx) => {
@@ -6318,6 +6311,7 @@ let compactColumnsDecoder = (~input) => {
 
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
+
         // Row accumulator: declared at the head of its own segment, before the
         // `for` below that fills it.
         output.codeFromPrev = `let ${outputVar}=new Array(Math.max(${lengthCode.contents}));`
@@ -6409,6 +6403,7 @@ let compactColumnsDecoder = (~input) => {
 
         let output = input->B.next(outputVar, ~schema=outputSchema, ~expected=outputSchema)
         output.var = B._var
+
         // Columnar accumulator: declared before the `for` that fills it.
         output.codeFromPrev = `let ${outputVar}=[${initialArraysCode.contents}];`
         let loopBody = perFieldCode.contents ++ settingCode.contents
@@ -7100,7 +7095,9 @@ let js_merge = (s1, s2) => {
     let mut = base(objectTag, ~selfReverse=false)
 
     // TODO: Merge to required fields
-    mut.required = Some(properties->(Obj.magic: dict<t<unknown>> => dict<internal>)->Dict.keysToArray)
+    mut.required = Some(
+      properties->(Obj.magic: dict<t<unknown>> => dict<internal>)->Dict.keysToArray,
+    )
     mut.properties = Some(properties->(Obj.magic: dict<t<unknown>> => dict<internal>))
     mut.additionalItems = Some(additionalItems1)
     mut.decoder = objectDecoder
@@ -7343,9 +7340,7 @@ module RescriptJSONSchema = {
           | Undefined(_) if (parent->castToInternal).tag === objectTag => ()
           | _ => {
               items
-              ->Array.push(
-                Schema(internalToJSONSchema(childSchema, ~parent=schema, ~path, ~defs)),
-              )
+              ->Array.push(Schema(internalToJSONSchema(childSchema, ~parent=schema, ~path, ~defs)))
               ->ignore
               switch childSchema->castToInternal->isLiteral {
               | true =>

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3201,6 +3201,152 @@ and unionPerVariantVal = (~input: val, ~target) =>
       ~expected=input.schema->updateOutput(mut => mut.to = Some(target))->castToInternal,
     )
 
+  // A variant participates in reservation only when its tag + const fully
+  // discriminate it (primitives, literals, null/undefined/NaN) AND it passes
+  // its value through unchanged. Structural variants — objects, instances,
+  // arrays, refs, nested unions — can't be matched statically, and transforming
+  // variants (their own `.to`/parser/serializer) aren't identity matches; both
+  // keep the full target and dispatch at runtime.
+and unionReservable = (schema: internal) =>
+    schema.to === None &&
+    schema.parser === None &&
+    schema.serializer === None &&
+    !(
+      schema.tag
+      ->TagFlag.get
+      ->Flag.unsafeHas(
+        TagFlag.object
+        ->Flag.with(TagFlag.instance)
+        ->Flag.with(TagFlag.array)
+        ->Flag.with(TagFlag.ref)
+        ->Flag.with(TagFlag.union),
+      )
+    )
+
+  // Resolves which target each source variant converts to, with reservation.
+  // Walks reservable variants tier 1 (same-type) then tier 2 (nullish bridge) —
+  // both claim their target so no other variant can reuse it — then tier 3
+  // (coercion) shares whatever targets remain free. A reservable variant with no
+  // target left is mapped to `never` and fails. Non-reservable variants keep the
+  // full target. Returned array is aligned with `sources`.
+and unionAssignTargets = (~sources: array<internal>, ~target: internal): array<internal> => {
+    let targetCases = switch target.anyOf {
+    | Some(anyOf) if target.tag === unionTag => anyOf
+    | _ => [target]
+    }
+    let sourceLen = sources->Array.length
+    let targetLen = targetCases->Array.length
+
+    let reserved = []
+    let assigned: array<option<internal>> = []
+    for _ in 0 to targetLen - 1 {
+      reserved->Array.push(false)->ignore
+    }
+    for _ in 0 to sourceLen - 1 {
+      assigned->Array.push(None)->ignore
+    }
+
+    let claim = (si, ti) => {
+      reserved->Array.setUnsafe(ti, true)
+      assigned->Array.setUnsafe(si, Some(targetCases->Array.getUnsafe(ti)))
+    }
+
+    // Pass 1: tier 1 — same-type match (exact const preferred), reserves it.
+    for si in 0 to sourceLen - 1 {
+      let s = sources->Array.getUnsafe(si)
+      if unionReservable(s) {
+        let sKey = unionToKey(s)
+        let chosen = ref(-1)
+        for ti in 0 to targetLen - 1 {
+          if chosen.contents === -1 && !(reserved->Array.getUnsafe(ti)) {
+            let t = targetCases->Array.getUnsafe(ti)
+            if unionToKey(t) === sKey && t.const === s.const {
+              chosen := ti
+            }
+          }
+        }
+        if chosen.contents === -1 {
+          for ti in 0 to targetLen - 1 {
+            if chosen.contents === -1 && !(reserved->Array.getUnsafe(ti)) {
+              if unionToKey(targetCases->Array.getUnsafe(ti)) === sKey {
+                chosen := ti
+              }
+            }
+          }
+        }
+        if chosen.contents !== -1 {
+          claim(si, chosen.contents)
+        }
+      }
+    }
+
+    // Pass 2: tier 2 — nullish bridge to the opposite nullish target, reserves it.
+    for si in 0 to sourceLen - 1 {
+      switch assigned->Array.getUnsafe(si) {
+      | Some(_) => ()
+      | None =>
+        let sTag = (sources->Array.getUnsafe(si)).tag
+        let oppositeTag = if sTag === nullTag {
+          undefinedTag
+        } else if sTag === undefinedTag {
+          nullTag
+        } else {
+          sTag
+        }
+        if oppositeTag !== sTag {
+          let chosen = ref(-1)
+          for ti in 0 to targetLen - 1 {
+            if (
+              chosen.contents === -1 &&
+              !(reserved->Array.getUnsafe(ti)) &&
+              (targetCases->Array.getUnsafe(ti)).tag === oppositeTag
+            ) {
+              chosen := ti
+            }
+          }
+          if chosen.contents !== -1 {
+            claim(si, chosen.contents)
+          }
+        }
+      }
+    }
+
+    // Pass 3: tier 3 — reservable variants coerce over the remaining free
+    // targets (no reservation); non-reservable variants keep the full target.
+    let free = []
+    for ti in 0 to targetLen - 1 {
+      if !(reserved->Array.getUnsafe(ti)) {
+        free->Array.push(targetCases->Array.getUnsafe(ti))->ignore
+      }
+    }
+    let freeSchema = if free->Array.length === targetLen {
+      target
+    } else {
+      switch free {
+      | [single] => single
+      | [] => never_()
+      | cases => unionFactory(cases->Obj.magic)->castToInternal
+      }
+    }
+    for si in 0 to sourceLen - 1 {
+      switch assigned->Array.getUnsafe(si) {
+      | Some(_) => ()
+      | None =>
+        assigned->Array.setUnsafe(
+          si,
+          Some(unionReservable(sources->Array.getUnsafe(si)) ? freeSchema : target),
+        )
+      }
+    }
+
+    assigned->Array.map(opt =>
+      switch opt {
+      | Some(t) => t
+      | None => never_()
+      }
+    )
+  }
+
   // Applied by the parse loop when a union-typed val
   // meets a different expected schema
 and unionEncoder: encoder = (~input: val, ~target: internal) => {
@@ -3591,14 +3737,28 @@ and unionDecoder: Builder.t = (~input) => {
         schemas
       }
 
+      // Reservation only applies when the variants are genuine alternative
+      // sources (input type not statically narrowed to one). When `activeKey`
+      // is set the input is a known single type decoded into the union, so the
+      // active variant converts to the full target as before.
+      let assignedTargets = switch toPerCase {
+      | Some(target) if activeKey === "" => Some(unionAssignTargets(~sources=schemas, ~target))
+      | _ => None
+      }
+
       for idx in 0 to lastIdx {
-        let schema = switch toPerCase {
-        | Some(target) =>
+        let schema = switch (toPerCase, assignedTargets) {
+        | (Some(target), assignedTargets) =>
           updateOutput(schemas->Array.getUnsafe(idx), mut => {
             appendUnionRefiners(mut)
-            mut.to = Some(target)
+            mut.to = Some(
+              switch assignedTargets {
+              | Some(targets) => targets->Array.getUnsafe(idx)
+              | None => target
+              },
+            )
           })->castToInternal
-        | _ => schemas->Array.getUnsafe(idx)
+        | (None, _) => schemas->Array.getUnsafe(idx)
         }
         let tag = schema.tag
         let tagFlag = TagFlag.get(tag)

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3435,6 +3435,25 @@ and unionActiveKey = (~inputSchema: internal, ~inputTagFlag: flag, ~schemas: arr
       activeKey.contents
     }
 
+  // Whether the input val can be returned untouched instead of building a
+  // dispatch: it is already the union type (trusted self-decode with no
+  // transforming variant), or a narrower union the wider target accepts as-is,
+  // or an already-produced output. Preserving this keeps generated code minimal.
+and unionIsPassthrough = (
+    ~input: val,
+    ~selfSchema: internal,
+    ~schemas: array<internal>,
+    ~initialInputTagFlag: flag,
+    ~toPerCase: option<internal>,
+  ): bool =>
+    (input.schema === selfSchema &&
+    toPerCase === None &&
+    schemas->Array.every(unionIsSelfDecodeNoop)) ||
+    (initialInputTagFlag->Flag.unsafeHas(TagFlag.union) &&
+      unionIsWiderSchema(~schemaAnyOf=schemas, ~inputAnyOf=input.schema.anyOf->X.Option.getUnsafe) &&
+      toPerCase === None) ||
+    (input.isOutput->Option.getUnsafe && input.expected === input.schema)
+
   // Applied by the parse loop when a union-typed val
   // meets a different expected schema
 and unionEncoder: encoder = (~input: val, ~target: internal) => {
@@ -3460,17 +3479,7 @@ and unionDecoder: Builder.t = (~input) => {
 
     let toPerCase = unionGetToPerCase(selfSchema)
 
-    if (
-      // The input val is already of the union type (trusted self-decode).
-      // Only allowed when no variant transforms the value
-      (input.schema === selfSchema && toPerCase === None && schemas->Array.every(unionIsSelfDecodeNoop)) ||
-      (initialInputTagFlag->Flag.unsafeHas(TagFlag.union) &&
-      unionIsWiderSchema(
-        ~schemaAnyOf=schemas,
-        ~inputAnyOf=input.schema.anyOf->X.Option.getUnsafe,
-      ) &&
-      toPerCase === None) || (input.isOutput->Option.getUnsafe && input.expected === input.schema)
-    ) {
+    if unionIsPassthrough(~input, ~selfSchema, ~schemas, ~initialInputTagFlag, ~toPerCase) {
       input
     } else {
       if (

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3487,6 +3487,29 @@ and unionDecoder: Builder.t = (~input) => {
   }
 }
 
+// Generates the exhaustive union invalid-type error: throws with `selfSchema`
+// as the expected type and any accumulated per-case errors (`caught`).
+and unionFail = (~input: val, ~selfSchema: internal, ~caught: string): string =>
+  `${input->B.embed(
+      (
+        _ => {
+          let args = %raw(`arguments`)
+          B.throw(
+            B.makeInvalidInputDetails(
+              ~path=input.path,
+              ~expected=selfSchema,
+              ~received=unknown->castToPublic,
+              ~input=args->Array.getUnsafe(0),
+              ~includeInput=true,
+              ~unionErrors=?args->Array.length > 1
+                ? Some(args->X.Array.fromArguments->Array.slice(~start=1))
+                : None,
+            ),
+          )
+        }
+      )->X.Function.toExpression,
+    )}(${input.var()}${caught})`
+
 // The emitter: consumes the resolved plan (input narrowed by unionActiveKey,
 // target reservation applied) and generates the dispatch codegen — the
 // per-schema optimizer (discriminant grouping, deopt detection, hoistable
@@ -3514,27 +3537,7 @@ and unionEmit = (
 
   let initialInline = input.inline
 
-  let fail = caught => {
-    `${input->B.embed(
-        (
-          _ => {
-            let args = %raw(`arguments`)
-            B.throw(
-              B.makeInvalidInputDetails(
-                ~path=input.path,
-                ~expected=selfSchema,
-                ~received=unknown->castToPublic,
-                ~input=args->Array.getUnsafe(0),
-                ~includeInput=true,
-                ~unionErrors=?args->Array.length > 1
-                  ? Some(args->X.Array.fromArguments->Array.slice(~start=1))
-                  : None,
-              ),
-            )
-          }
-        )->X.Function.toExpression,
-      )}(${input.var()}${caught})`
-  }
+  let fail = caught => unionFail(~input, ~selfSchema, ~caught)
 
   // Create a copy of the input val, so we can mutate it
   // It's still the same value though, until mutated

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3347,6 +3347,36 @@ and unionAssignTargets = (~sources: array<internal>, ~target: internal): array<i
     )
   }
 
+  // The canonical type-only schema a variant's dispatch discriminant validates
+  // against (its tag, ignoring const/structure), used to narrow the input val
+  // before the variant's own decoder runs.
+and unionTypeValidationSchema = (~tagFlag: flag, ~schema: internal): internal =>
+    if tagFlag->Flag.unsafeHas(TagFlag.null) {
+      nullLiteral()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
+      unit()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
+      dictFactory(unknown->castToPublic)->castToInternal
+    } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
+      array(unknown->castToPublic)->castToInternal
+    } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
+      instance(schema.class)->castToInternal
+    } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
+      nan()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.string) {
+      string()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
+      float()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.boolean) {
+      bool()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.bigint) {
+      bigint()
+    } else if tagFlag->Flag.unsafeHas(TagFlag.symbol) {
+      symbol()
+    } else {
+      unknown
+    }
+
   // Tier 1: for a typed const input, variants with a matching const are tried
   // before catch-all and differently-const'ed variants.
 and unionPrioritizeConst = (~inputSchema: internal, ~schemas: array<internal>): array<internal> =>
@@ -3820,31 +3850,7 @@ and unionDecoder: Builder.t = (~input) => {
             // Recreate input val for every schema
             // since we will mutate it
             let typeValidationInput = input->B.Val.scope
-            typeValidationInput.expected = if tagFlag->Flag.unsafeHas(TagFlag.null) {
-              nullLiteral()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.undefined) {
-              unit()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.object) {
-              dictFactory(unknown->castToPublic)->castToInternal
-            } else if tagFlag->Flag.unsafeHas(TagFlag.array) {
-              array(unknown->castToPublic)->castToInternal
-            } else if tagFlag->Flag.unsafeHas(TagFlag.instance) {
-              instance(schema.class)->castToInternal
-            } else if tagFlag->Flag.unsafeHas(TagFlag.nan) {
-              nan()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.string) {
-              string()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.number) {
-              float()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.boolean) {
-              bool()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.bigint) {
-              bigint()
-            } else if tagFlag->Flag.unsafeHas(TagFlag.symbol) {
-              symbol()
-            } else {
-              unknown
-            }
+            typeValidationInput.expected = unionTypeValidationSchema(~tagFlag, ~schema)
 
             let typeValidationOutput = try {
               typeValidationInput->parse

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3487,6 +3487,56 @@ and unionDecoder: Builder.t = (~input) => {
   }
 }
 
+// Builds a mutator that folds the union's own refiner/inputRefiner onto each
+// surviving case's schema (so they run per case when the union has a `.to`).
+// Each source refiner is embedded at most once and shared by every case.
+and unionRefinerAttacher = (~selfSchema: internal): (internal => unit) => {
+  let unionRefiner = selfSchema.refiner
+  let unionInputRefiner = selfSchema.inputRefiner
+  // Call each source refiner at most once so its predicate is embedded
+  // in `input.global.embeded` once and every case references the same
+  // `e[N]`. `B.embed` is append-only, so a per-case call would duplicate.
+  let cachedRefinerChecks = ref(None)
+  let cachedInputRefinerChecks = ref(None)
+  let attach = (current, source, cache) =>
+    switch source {
+    | None => current
+    | Some(fn) =>
+      let getCached = (~input) =>
+        switch cache.contents {
+        | Some(checks) => checks
+        | None =>
+          let checks = fn(~input)
+          cache := Some(checks)
+          checks
+        }
+      switch current {
+      | None => Some(getCached)
+      | Some(existing) =>
+        Some(
+          (~input) => {
+            let arr = existing(~input)
+            let next = getCached(~input)
+            for i in 0 to next->Array.length - 1 {
+              arr->Array.push(next->Array.getUnsafe(i))->ignore
+            }
+            arr
+          },
+        )
+      }
+    }
+  (mut: internal) => {
+    switch attach(mut.refiner, unionRefiner, cachedRefinerChecks) {
+    | Some(r) => mut.refiner = Some(r)
+    | None => ()
+    }
+    switch attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks) {
+    | Some(r) => mut.inputRefiner = Some(r)
+    | None => ()
+    }
+  }
+}
+
 // Generates the exhaustive union invalid-type error: throws with `selfSchema`
 // as the expected type and any accumulated per-case errors (`caught`).
 and unionFail = (~input: val, ~selfSchema: internal, ~caught: string): string =>
@@ -3760,52 +3810,7 @@ and unionEmit = (
   // surviving case (previously dropped when the union has `.to`). The
   // emit shape isn't ideal; fold this into the shared refiner pipeline
   // post-release.
-  let appendUnionRefiners = {
-    let unionRefiner = selfSchema.refiner
-    let unionInputRefiner = selfSchema.inputRefiner
-    // Call each source refiner at most once so its predicate is embedded
-    // in `input.global.embeded` once and every case references the same
-    // `e[N]`. `B.embed` is append-only, so a per-case call would duplicate.
-    let cachedRefinerChecks = ref(None)
-    let cachedInputRefinerChecks = ref(None)
-    let attach = (current, source, cache) =>
-      switch source {
-      | None => current
-      | Some(fn) =>
-        let getCached = (~input) =>
-          switch cache.contents {
-          | Some(checks) => checks
-          | None =>
-            let checks = fn(~input)
-            cache := Some(checks)
-            checks
-          }
-        switch current {
-        | None => Some(getCached)
-        | Some(existing) =>
-          Some(
-            (~input) => {
-              let arr = existing(~input)
-              let next = getCached(~input)
-              for i in 0 to next->Array.length - 1 {
-                arr->Array.push(next->Array.getUnsafe(i))->ignore
-              }
-              arr
-            },
-          )
-        }
-      }
-    (mut: internal) => {
-      switch attach(mut.refiner, unionRefiner, cachedRefinerChecks) {
-      | Some(r) => mut.refiner = Some(r)
-      | None => ()
-      }
-      switch attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks) {
-      | Some(r) => mut.inputRefiner = Some(r)
-      | None => ()
-      }
-    }
-  }
+  let appendUnionRefiners = unionRefinerAttacher(~selfSchema)
 
   let schemas = unionPrioritizeConst(~inputSchema=input.schema, ~schemas)
 

--- a/packages/sury/src/Sury.res
+++ b/packages/sury/src/Sury.res
@@ -3347,6 +3347,64 @@ and unionAssignTargets = (~sources: array<internal>, ~target: internal): array<i
     )
   }
 
+  // Tier 1: for a typed const input, variants with a matching const are tried
+  // before catch-all and differently-const'ed variants.
+and unionPrioritizeConst = (~inputSchema: internal, ~schemas: array<internal>): array<internal> =>
+    if inputSchema->isLiteral {
+      let matching = []
+      let rest = []
+      for idx in 0 to schemas->Array.length - 1 {
+        let schema = schemas->Array.getUnsafe(idx)
+        if schema->isLiteral && schema.const === inputSchema.const {
+          matching->Array.push(schema)->ignore
+        } else {
+          rest->Array.push(schema)->ignore
+        }
+      }
+      matching->Array.concat(rest)
+    } else {
+      schemas
+    }
+
+  // Tier narrowing: when the input is a known single type, returns the union
+  // key the dispatch can jump straight to — the matching same-type variant, or
+  // the opposite nullish variant for a null/undefined bridge. "" means no
+  // narrowing (input is a union/ref/unknown, or no variant matches).
+and unionActiveKey = (~inputSchema: internal, ~inputTagFlag: flag, ~schemas: array<internal>): string =>
+    if (
+      inputTagFlag->Flag.unsafeHas(
+        TagFlag.union->Flag.with(TagFlag.ref)->Flag.with(TagFlag.unknown),
+      )
+    ) {
+      ""
+    } else {
+      let sourceKey = unionToKey(inputSchema)
+      let activeKey = ref("")
+      let hasNull = ref(false)
+      let hasUndefined = ref(false)
+      let len = schemas->Array.length
+      let i = ref(0)
+      while activeKey.contents === "" && i.contents < len {
+        let s = schemas->Array.getUnsafe(i.contents)
+        if unionToKey(s) === sourceKey {
+          activeKey := sourceKey
+        } else if s.tag === nullTag {
+          hasNull := true
+        } else if s.tag === undefinedTag {
+          hasUndefined := true
+        }
+        i := i.contents + 1
+      }
+      if activeKey.contents === "" {
+        if inputTagFlag->Flag.unsafeHas(TagFlag.undefined) && hasNull.contents {
+          activeKey := (nullTag :> string)
+        } else if inputTagFlag->Flag.unsafeHas(TagFlag.null) && hasUndefined.contents {
+          activeKey := (undefinedTag :> string)
+        }
+      }
+      activeKey.contents
+    }
+
   // Applied by the parse loop when a union-typed val
   // meets a different expected schema
 and unionEncoder: encoder = (~input: val, ~target: internal) => {
@@ -3392,39 +3450,11 @@ and unionDecoder: Builder.t = (~input) => {
         input.schema = unknown
       }
 
-      let activeKey = ref("")
-      if (
-        !(
-          initialInputTagFlag->Flag.unsafeHas(
-            TagFlag.union->Flag.with(TagFlag.ref)->Flag.with(TagFlag.unknown),
-          )
-        )
-      ) {
-        let sourceKey = unionToKey(input.schema)
-        let hasNull = ref(false)
-        let hasUndefined = ref(false)
-        let len = schemas->Array.length
-        let i = ref(0)
-        while activeKey.contents === "" && i.contents < len {
-          let s = schemas->Array.getUnsafe(i.contents)
-          if unionToKey(s) === sourceKey {
-            activeKey := sourceKey
-          } else if s.tag === nullTag {
-            hasNull := true
-          } else if s.tag === undefinedTag {
-            hasUndefined := true
-          }
-          i := i.contents + 1
-        }
-        if activeKey.contents === "" {
-          if initialInputTagFlag->Flag.unsafeHas(TagFlag.undefined) && hasNull.contents {
-            activeKey := (nullTag :> string)
-          } else if initialInputTagFlag->Flag.unsafeHas(TagFlag.null) && hasUndefined.contents {
-            activeKey := (undefinedTag :> string)
-          }
-        }
-      }
-      let activeKey = activeKey.contents
+      let activeKey = unionActiveKey(
+        ~inputSchema=input.schema,
+        ~inputTagFlag=initialInputTagFlag,
+        ~schemas,
+      )
 
       let initialInline = input.inline
 
@@ -3719,23 +3749,7 @@ and unionDecoder: Builder.t = (~input) => {
         }
       }
 
-      // Tier 1: for a typed const input, variants with a matching const are
-      // tried before catch-all and differently-const'ed variants
-      let schemas = if input.schema->isLiteral {
-        let matching = []
-        let rest = []
-        for idx in 0 to lastIdx {
-          let schema = schemas->Array.getUnsafe(idx)
-          if schema->isLiteral && schema.const === input.schema.const {
-            matching->Array.push(schema)->ignore
-          } else {
-            rest->Array.push(schema)->ignore
-          }
-        }
-        matching->Array.concat(rest)
-      } else {
-        schemas
-      }
+      let schemas = unionPrioritizeConst(~inputSchema=input.schema, ~schemas)
 
       // Reservation only applies when the variants are genuine alternative
       // sources (input type not statically narrowed to one). When `activeKey`

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2164,6 +2164,16 @@ function unionActiveKey(inputSchema, inputTagFlag, schemas) {
   return activeKey;
 }
 
+function unionIsPassthrough(input, selfSchema, schemas, initialInputTagFlag, toPerCase) {
+  if (input.s === selfSchema && toPerCase === undefined && schemas.every(unionIsSelfDecodeNoop) || initialInputTagFlag & 256 && unionIsWiderSchema(schemas, input.s.anyOf) && toPerCase === undefined) {
+    return true;
+  } else if (input.io) {
+    return input.e === input.s;
+  } else {
+    return false;
+  }
+}
+
 function unionEncoder(input, target) {
   let inputAnyOf = input.s.anyOf;
   if (target.type === unionTag && unionGetToPerCase(target) === undefined && unionIsWiderSchema(target.anyOf, inputAnyOf) || !unionCanDispatchPerVariant(inputAnyOf, target)) {
@@ -2178,7 +2188,7 @@ function unionDecoder(input) {
   let schemas = selfSchema.anyOf;
   let initialInputTagFlag = flags[input.s.type];
   let toPerCase = unionGetToPerCase(selfSchema);
-  if (input.s === selfSchema && toPerCase === undefined && schemas.every(unionIsSelfDecodeNoop) || initialInputTagFlag & 256 && unionIsWiderSchema(schemas, input.s.anyOf) && toPerCase === undefined || input.io && input.e === input.s) {
+  if (unionIsPassthrough(input, selfSchema, schemas, initialInputTagFlag, toPerCase)) {
     return input;
   }
   if (initialInputTagFlag & 256 || input.s.encoder === undefined && initialInputTagFlag & 512) {
@@ -3687,68 +3697,46 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
   }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
   }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
   }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3848,46 +3836,12 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
     }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
+  });
 }
 
 function nested(fieldName) {
@@ -3956,18 +3910,14 @@ function nested(fieldName) {
   return ctx$1;
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function getShapedParserOutput(input, targetSchema) {
@@ -4009,14 +3959,74 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2190,353 +2190,354 @@ function unionDecoder(input) {
   let toPerCase = unionGetToPerCase(selfSchema);
   if (unionIsPassthrough(input, selfSchema, schemas, initialInputTagFlag, toPerCase)) {
     return input;
-  }
-  if (initialInputTagFlag & 256 || input.s.encoder === undefined && initialInputTagFlag & 512) {
-    input.s = unknown;
-  }
-  let activeKey = unionActiveKey(input.s, initialInputTagFlag, schemas);
-  let initialInline = input.i;
-  let fail = caught => embed(input, function () {
-    let args = arguments;
-    let errorDetails = makeInvalidInputDetails(selfSchema, unknown, input.path, args[0], true, args.length > 1 ? Array.from(args).slice(1) : undefined, undefined);
-    throw new SuryError(errorDetails);
-  }) + `(` + input.v() + caught + `)`;
-  let output = refine(input, undefined, undefined, undefined);
-  let outputAnyOf = [];
-  let staticBlockFailure = {
-    contents: ""
-  };
-  let getArrItemsCode = (arr, isDeopt) => {
-    let typeValidationInput = arr[0];
-    let typeValidationOutput = arr[1];
-    let itemStart = "";
-    let itemEnd = "";
-    let itemNextElse = false;
-    let itemNoop = {
+  } else {
+    if (initialInputTagFlag & 256 || input.s.encoder === undefined && initialInputTagFlag & 512) {
+      input.s = unknown;
+    }
+    let activeKey = unionActiveKey(input.s, initialInputTagFlag, schemas);
+    let initialInline = input.i;
+    let fail = caught => embed(input, function () {
+      let args = arguments;
+      let errorDetails = makeInvalidInputDetails(selfSchema, unknown, input.path, args[0], true, args.length > 1 ? Array.from(args).slice(1) : undefined, undefined);
+      throw new SuryError(errorDetails);
+    }) + `(` + input.v() + caught + `)`;
+    let output = refine(input, undefined, undefined, undefined);
+    let outputAnyOf = [];
+    let staticBlockFailure = {
       contents: ""
     };
-    let caught = "";
-    let byDiscriminant = {};
-    let itemIdx = 2;
-    let lastIdx = arr.length - 1 | 0;
-    while (itemIdx <= lastIdx) {
-      let input = scope(typeValidationOutput);
-      input.u = true;
-      input.t = typeValidationOutput.t;
-      input.io = false;
-      input.e = arr[itemIdx];
-      let isLast = itemIdx === lastIdx;
-      let isFirst = itemIdx === 2;
-      let isOnlyCase = isFirst && isLast;
-      let withExhaustiveCheck = !isOnlyCase;
-      let itemSkipped = false;
-      let itemCode = "";
-      let itemCond = {
+    let getArrItemsCode = (arr, isDeopt) => {
+      let typeValidationInput = arr[0];
+      let typeValidationOutput = arr[1];
+      let itemStart = "";
+      let itemEnd = "";
+      let itemNextElse = false;
+      let itemNoop = {
         contents: ""
       };
-      try {
-        let itemOutput = parse$1(input);
-        outputAnyOf.push(itemOutput.s);
-        itemCode = merge(itemOutput, itemCond);
-        if (itemOutput.t) {
-          output.t = true;
-          if (itemOutput.f & 1) {
-            output.f = output.f | 1;
-          }
-          let itemVar = typeValidationInput.v();
-          if (itemOutput.i !== itemVar) {
-            itemCode = itemCode + (itemVar + `=` + itemOutput.i);
-          }
-        }
-      } catch (exn) {
-        let errorVar = embed(input, getOrRethrow(exn));
-        caught = caught + `,` + errorVar;
-        if (isDeopt && isOnlyCase) {
-          staticBlockFailure.contents = errorVar;
-          itemSkipped = true;
-        } else if (isLast) {
-          withExhaustiveCheck = false;
-          itemCode = isDeopt ? "throw " + errorVar : fail(caught);
-        } else {
-          itemSkipped = true;
-        }
-      }
-      let itemCond$1 = itemCond.contents;
-      let itemCode$1 = itemCode;
-      if (!itemSkipped && itemCond$1) {
-        if (itemCode$1) {
-          let match = byDiscriminant[itemCond$1];
-          if (match !== undefined) {
-            if (typeof match === "string") {
-              byDiscriminant[itemCond$1] = [
-                match,
-                itemCode$1
-              ];
-            } else {
-              match.push(itemCode$1);
-            }
-          } else {
-            byDiscriminant[itemCond$1] = itemCode$1;
-          }
-        } else {
-          itemNoop.contents = itemNoop.contents ? itemNoop.contents + `||` + itemCond$1 : itemCond$1;
-        }
-      }
-      if (!itemSkipped && (!itemCond$1 || isLast)) {
-        let accedDiscriminants = Object.keys(byDiscriminant);
-        for (let idx = 0, idx_finish = accedDiscriminants.length; idx < idx_finish; ++idx) {
-          let discrim = accedDiscriminants[idx];
-          let if_ = itemNextElse ? "else if" : "if";
-          itemStart = itemStart + if_ + (`(` + discrim + `){`);
-          let code = byDiscriminant[discrim];
-          if (typeof code === "string") {
-            itemStart = itemStart + code + "}";
-          } else {
-            let caught$1 = "";
-            for (let idx$1 = 0, idx_finish$1 = code.length; idx$1 < idx_finish$1; ++idx$1) {
-              let code$1 = code[idx$1];
-              let errorVar$1 = `e` + idx$1;
-              itemStart = itemStart + (`try{` + code$1 + `}catch(` + errorVar$1 + `){`);
-              caught$1 = caught$1 + `,` + errorVar$1;
-            }
-            itemStart = itemStart + fail(caught$1) + "}".repeat(code.length) + "}";
-          }
-          itemNextElse = true;
-        }
-        byDiscriminant = {};
-      }
-      if (!itemSkipped && !itemCond$1) {
-        if (itemCode$1) {
-          if (itemNoop.contents) {
-            let if_$1 = itemNextElse ? "else if" : "if";
-            itemStart = itemStart + if_$1 + (`(!(` + itemNoop.contents + `)){`);
-            itemEnd = "}" + itemEnd;
-            itemNoop.contents = "";
-            itemNextElse = false;
-          }
-          if (isLast && (isDeopt || !withExhaustiveCheck || isFirst)) {
-            itemStart = itemStart + ((
-              itemNextElse ? "else{" : ""
-            ) + itemCode$1);
-            itemEnd = (
-              itemNextElse ? "}" : ""
-            ) + itemEnd;
-          } else {
-            let errorVar$2 = `e` + (itemIdx - 2 | 0);
-            itemStart = itemStart + ((
-              itemNextElse ? "else{" : ""
-            ) + `try{` + itemCode$1 + `}catch(` + errorVar$2 + `){`);
-            itemEnd = (
-              itemNextElse ? "}" : ""
-            ) + "}" + itemEnd;
-            caught = caught + `,` + errorVar$2;
-            itemNextElse = false;
-          }
-        } else {
-          itemNoop.contents = "";
-          itemIdx = lastIdx;
-          withExhaustiveCheck = false;
-        }
-      }
-      if (isLast) {
-        if (itemNoop.contents) {
-          if (itemStart || caught) {
-            let if_$2 = itemNextElse ? "else if" : "if";
-            itemStart = itemStart + if_$2 + (`(!(` + itemNoop.contents + `)){` + fail(caught) + `}`);
-          } else {
-            pushCheck(typeValidationOutput, {
-              c: param => `(` + itemNoop.contents + `)`,
-              f: failInvalidType
-            });
-          }
-        } else if (withExhaustiveCheck) {
-          let errorCode = fail(caught);
-          itemStart = itemStart + (
-            itemNextElse ? `else{` + errorCode + `}` : errorCode
-          );
-        }
-      }
-      itemIdx = itemIdx + 1;
-    };
-    return itemStart + itemEnd;
-  };
-  let start = "";
-  let end = "";
-  let caught = "";
-  let exit = false;
-  let lastIdx = schemas.length - 1 | 0;
-  let byKey = {};
-  let keys = [];
-  let unionRefiner = selfSchema.refiner;
-  let unionInputRefiner = selfSchema.inputRefiner;
-  let cachedRefinerChecks = {
-    contents: undefined
-  };
-  let cachedInputRefinerChecks = {
-    contents: undefined
-  };
-  let attach = (current, source, cache) => {
-    if (source === undefined) {
-      return current;
-    }
-    let getCached = input => {
-      let checks = cache.contents;
-      if (checks !== undefined) {
-        return checks;
-      }
-      let checks$1 = source(input);
-      cache.contents = checks$1;
-      return checks$1;
-    };
-    if (current !== undefined) {
-      return input => {
-        let arr = current(input);
-        let next = getCached(input);
-        for (let i = 0, i_finish = next.length; i < i_finish; ++i) {
-          arr.push(next[i]);
-        }
-        return arr;
-      };
-    } else {
-      return getCached;
-    }
-  };
-  let appendUnionRefiners = mut => {
-    let r = attach(mut.refiner, unionRefiner, cachedRefinerChecks);
-    if (r !== undefined) {
-      mut.refiner = r;
-    }
-    let r$1 = attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks);
-    if (r$1 !== undefined) {
-      mut.inputRefiner = r$1;
-      return;
-    }
-  };
-  let schemas$1 = unionPrioritizeConst(input.s, schemas);
-  let assignedTargets = toPerCase !== undefined && activeKey === "" ? unionAssignTargets(schemas$1, toPerCase) : undefined;
-  for (let idx = 0; idx <= lastIdx; ++idx) {
-    let schema = toPerCase !== undefined ? updateOutput(schemas$1[idx], mut => {
-        appendUnionRefiners(mut);
-        mut.to = assignedTargets !== undefined ? assignedTargets[idx] : toPerCase;
-      }) : schemas$1[idx];
-    let tag = schema.type;
-    let tagFlag = flags[tag];
-    let key = unionToKey(schema);
-    if ((activeKey === "" || activeKey === key) && !(tagFlag & 16 && "fromDefault" in selfSchema)) {
-      let initialArr = byKey[key];
-      if (initialArr !== undefined) {
-        if (tagFlag & 64 && nestedLoc in schema.properties) {
-          initialArr.splice(initialArr.length - 1 | 0, 0, schema);
-        } else if (!(tagFlag & 2096)) {
-          initialArr.push(schema);
-        }
-      } else {
-        let typeValidationInput = scope(input);
-        typeValidationInput.e = unionTypeValidationSchema(tagFlag, schema);
-        let typeValidationOutput;
-        try {
-          typeValidationOutput = parse$1(typeValidationInput);
-        } catch (exn) {
-          typeValidationInput.vc = undefined;
-          typeValidationOutput = typeValidationInput;
-        }
-        if (unionIsPriority(tagFlag, byKey)) {
-          keys.unshift(key);
-        } else {
-          keys.push(key);
-        }
-        byKey[key] = [
-          typeValidationInput,
-          typeValidationOutput,
-          schema
-        ];
-        let shouldDeopt = true;
-        let valRef = typeValidationOutput;
-        while (valRef !== undefined && shouldDeopt) {
-          let v = valRef;
-          valRef = v.prev;
-          shouldDeopt = !(v.vc && isHoistable(v));
+      let caught = "";
+      let byDiscriminant = {};
+      let itemIdx = 2;
+      let lastIdx = arr.length - 1 | 0;
+      while (itemIdx <= lastIdx) {
+        let input = scope(typeValidationOutput);
+        input.u = true;
+        input.t = typeValidationOutput.t;
+        input.io = false;
+        input.e = arr[itemIdx];
+        let isLast = itemIdx === lastIdx;
+        let isFirst = itemIdx === 2;
+        let isOnlyCase = isFirst && isLast;
+        let withExhaustiveCheck = !isOnlyCase;
+        let itemSkipped = false;
+        let itemCode = "";
+        let itemCond = {
+          contents: ""
         };
-        if (shouldDeopt) {
-          for (let keyIdx = 0, keyIdx_finish = keys.length; keyIdx < keyIdx_finish; ++keyIdx) {
-            let key$1 = keys[keyIdx];
-            if (!exit) {
-              let arr = byKey[key$1];
-              let typeValidationOutput$1 = arr[1];
-              let itemsCode = getArrItemsCode(arr, true);
-              let blockCode = merge(typeValidationOutput$1, undefined) + itemsCode;
-              let embeddedError = staticBlockFailure.contents;
-              if (embeddedError) {
-                staticBlockFailure.contents = "";
-                if (blockCode) {
-                  let errorVar = `e` + (idx + keyIdx | 0);
-                  start = start + (`try{` + blockCode + `throw ` + embeddedError + `}catch(` + errorVar + `){`);
-                  end = "}" + end;
-                  caught = caught + `,` + errorVar;
-                } else {
-                  caught = caught + `,` + embeddedError;
-                }
-              } else if (blockCode) {
-                let errorVar$1 = `e` + (idx + keyIdx | 0);
-                start = start + (`try{` + blockCode + `}catch(` + errorVar$1 + `){`);
-                end = "}" + end;
-                caught = caught + `,` + errorVar$1;
+        try {
+          let itemOutput = parse$1(input);
+          outputAnyOf.push(itemOutput.s);
+          itemCode = merge(itemOutput, itemCond);
+          if (itemOutput.t) {
+            output.t = true;
+            if (itemOutput.f & 1) {
+              output.f = output.f | 1;
+            }
+            let itemVar = typeValidationInput.v();
+            if (itemOutput.i !== itemVar) {
+              itemCode = itemCode + (itemVar + `=` + itemOutput.i);
+            }
+          }
+        } catch (exn) {
+          let errorVar = embed(input, getOrRethrow(exn));
+          caught = caught + `,` + errorVar;
+          if (isDeopt && isOnlyCase) {
+            staticBlockFailure.contents = errorVar;
+            itemSkipped = true;
+          } else if (isLast) {
+            withExhaustiveCheck = false;
+            itemCode = isDeopt ? "throw " + errorVar : fail(caught);
+          } else {
+            itemSkipped = true;
+          }
+        }
+        let itemCond$1 = itemCond.contents;
+        let itemCode$1 = itemCode;
+        if (!itemSkipped && itemCond$1) {
+          if (itemCode$1) {
+            let match = byDiscriminant[itemCond$1];
+            if (match !== undefined) {
+              if (typeof match === "string") {
+                byDiscriminant[itemCond$1] = [
+                  match,
+                  itemCode$1
+                ];
               } else {
-                exit = true;
+                match.push(itemCode$1);
+              }
+            } else {
+              byDiscriminant[itemCond$1] = itemCode$1;
+            }
+          } else {
+            itemNoop.contents = itemNoop.contents ? itemNoop.contents + `||` + itemCond$1 : itemCond$1;
+          }
+        }
+        if (!itemSkipped && (!itemCond$1 || isLast)) {
+          let accedDiscriminants = Object.keys(byDiscriminant);
+          for (let idx = 0, idx_finish = accedDiscriminants.length; idx < idx_finish; ++idx) {
+            let discrim = accedDiscriminants[idx];
+            let if_ = itemNextElse ? "else if" : "if";
+            itemStart = itemStart + if_ + (`(` + discrim + `){`);
+            let code = byDiscriminant[discrim];
+            if (typeof code === "string") {
+              itemStart = itemStart + code + "}";
+            } else {
+              let caught$1 = "";
+              for (let idx$1 = 0, idx_finish$1 = code.length; idx$1 < idx_finish$1; ++idx$1) {
+                let code$1 = code[idx$1];
+                let errorVar$1 = `e` + idx$1;
+                itemStart = itemStart + (`try{` + code$1 + `}catch(` + errorVar$1 + `){`);
+                caught$1 = caught$1 + `,` + errorVar$1;
+              }
+              itemStart = itemStart + fail(caught$1) + "}".repeat(code.length) + "}";
+            }
+            itemNextElse = true;
+          }
+          byDiscriminant = {};
+        }
+        if (!itemSkipped && !itemCond$1) {
+          if (itemCode$1) {
+            if (itemNoop.contents) {
+              let if_$1 = itemNextElse ? "else if" : "if";
+              itemStart = itemStart + if_$1 + (`(!(` + itemNoop.contents + `)){`);
+              itemEnd = "}" + itemEnd;
+              itemNoop.contents = "";
+              itemNextElse = false;
+            }
+            if (isLast && (isDeopt || !withExhaustiveCheck || isFirst)) {
+              itemStart = itemStart + ((
+                itemNextElse ? "else{" : ""
+              ) + itemCode$1);
+              itemEnd = (
+                itemNextElse ? "}" : ""
+              ) + itemEnd;
+            } else {
+              let errorVar$2 = `e` + (itemIdx - 2 | 0);
+              itemStart = itemStart + ((
+                itemNextElse ? "else{" : ""
+              ) + `try{` + itemCode$1 + `}catch(` + errorVar$2 + `){`);
+              itemEnd = (
+                itemNextElse ? "}" : ""
+              ) + "}" + itemEnd;
+              caught = caught + `,` + errorVar$2;
+              itemNextElse = false;
+            }
+          } else {
+            itemNoop.contents = "";
+            itemIdx = lastIdx;
+            withExhaustiveCheck = false;
+          }
+        }
+        if (isLast) {
+          if (itemNoop.contents) {
+            if (itemStart || caught) {
+              let if_$2 = itemNextElse ? "else if" : "if";
+              itemStart = itemStart + if_$2 + (`(!(` + itemNoop.contents + `)){` + fail(caught) + `}`);
+            } else {
+              pushCheck(typeValidationOutput, {
+                c: param => `(` + itemNoop.contents + `)`,
+                f: failInvalidType
+              });
+            }
+          } else if (withExhaustiveCheck) {
+            let errorCode = fail(caught);
+            itemStart = itemStart + (
+              itemNextElse ? `else{` + errorCode + `}` : errorCode
+            );
+          }
+        }
+        itemIdx = itemIdx + 1;
+      };
+      return itemStart + itemEnd;
+    };
+    let start = "";
+    let end = "";
+    let caught = "";
+    let exit = false;
+    let lastIdx = schemas.length - 1 | 0;
+    let byKey = {};
+    let keys = [];
+    let unionRefiner = selfSchema.refiner;
+    let unionInputRefiner = selfSchema.inputRefiner;
+    let cachedRefinerChecks = {
+      contents: undefined
+    };
+    let cachedInputRefinerChecks = {
+      contents: undefined
+    };
+    let attach = (current, source, cache) => {
+      if (source === undefined) {
+        return current;
+      }
+      let getCached = input => {
+        let checks = cache.contents;
+        if (checks !== undefined) {
+          return checks;
+        }
+        let checks$1 = source(input);
+        cache.contents = checks$1;
+        return checks$1;
+      };
+      if (current !== undefined) {
+        return input => {
+          let arr = current(input);
+          let next = getCached(input);
+          for (let i = 0, i_finish = next.length; i < i_finish; ++i) {
+            arr.push(next[i]);
+          }
+          return arr;
+        };
+      } else {
+        return getCached;
+      }
+    };
+    let appendUnionRefiners = mut => {
+      let r = attach(mut.refiner, unionRefiner, cachedRefinerChecks);
+      if (r !== undefined) {
+        mut.refiner = r;
+      }
+      let r$1 = attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks);
+      if (r$1 !== undefined) {
+        mut.inputRefiner = r$1;
+        return;
+      }
+    };
+    let schemas$1 = unionPrioritizeConst(input.s, schemas);
+    let assignedTargets = toPerCase !== undefined && activeKey === "" ? unionAssignTargets(schemas$1, toPerCase) : undefined;
+    for (let idx = 0; idx <= lastIdx; ++idx) {
+      let schema = toPerCase !== undefined ? updateOutput(schemas$1[idx], mut => {
+          appendUnionRefiners(mut);
+          mut.to = assignedTargets !== undefined ? assignedTargets[idx] : toPerCase;
+        }) : schemas$1[idx];
+      let tag = schema.type;
+      let tagFlag = flags[tag];
+      let key = unionToKey(schema);
+      if ((activeKey === "" || activeKey === key) && !(tagFlag & 16 && "fromDefault" in selfSchema)) {
+        let initialArr = byKey[key];
+        if (initialArr !== undefined) {
+          if (tagFlag & 64 && nestedLoc in schema.properties) {
+            initialArr.splice(initialArr.length - 1 | 0, 0, schema);
+          } else if (!(tagFlag & 2096)) {
+            initialArr.push(schema);
+          }
+        } else {
+          let typeValidationInput = scope(input);
+          typeValidationInput.e = unionTypeValidationSchema(tagFlag, schema);
+          let typeValidationOutput;
+          try {
+            typeValidationOutput = parse$1(typeValidationInput);
+          } catch (exn) {
+            typeValidationInput.vc = undefined;
+            typeValidationOutput = typeValidationInput;
+          }
+          if (unionIsPriority(tagFlag, byKey)) {
+            keys.unshift(key);
+          } else {
+            keys.push(key);
+          }
+          byKey[key] = [
+            typeValidationInput,
+            typeValidationOutput,
+            schema
+          ];
+          let shouldDeopt = true;
+          let valRef = typeValidationOutput;
+          while (valRef !== undefined && shouldDeopt) {
+            let v = valRef;
+            valRef = v.prev;
+            shouldDeopt = !(v.vc && isHoistable(v));
+          };
+          if (shouldDeopt) {
+            for (let keyIdx = 0, keyIdx_finish = keys.length; keyIdx < keyIdx_finish; ++keyIdx) {
+              let key$1 = keys[keyIdx];
+              if (!exit) {
+                let arr = byKey[key$1];
+                let typeValidationOutput$1 = arr[1];
+                let itemsCode = getArrItemsCode(arr, true);
+                let blockCode = merge(typeValidationOutput$1, undefined) + itemsCode;
+                let embeddedError = staticBlockFailure.contents;
+                if (embeddedError) {
+                  staticBlockFailure.contents = "";
+                  if (blockCode) {
+                    let errorVar = `e` + (idx + keyIdx | 0);
+                    start = start + (`try{` + blockCode + `throw ` + embeddedError + `}catch(` + errorVar + `){`);
+                    end = "}" + end;
+                    caught = caught + `,` + errorVar;
+                  } else {
+                    caught = caught + `,` + embeddedError;
+                  }
+                } else if (blockCode) {
+                  let errorVar$1 = `e` + (idx + keyIdx | 0);
+                  start = start + (`try{` + blockCode + `}catch(` + errorVar$1 + `){`);
+                  end = "}" + end;
+                  caught = caught + `,` + errorVar$1;
+                } else {
+                  exit = true;
+                }
               }
             }
+            byKey = {};
+            keys = [];
           }
-          byKey = {};
-          keys = [];
         }
       }
     }
-  }
-  let byKey$1 = byKey;
-  let keys$1 = keys;
-  if (!exit) {
-    let nextElse = false;
-    let noop = "";
-    for (let idx$1 = 0, idx_finish = keys$1.length; idx$1 < idx_finish; ++idx$1) {
-      let arr$1 = byKey$1[keys$1[idx$1]];
-      let typeValidationOutput$2 = arr$1[1];
-      let firstSchema = arr$1[2];
-      let itemsCode$1 = getArrItemsCode(arr$1, false);
-      let blockCond = {
-        contents: ""
-      };
-      let blockCode$1 = merge(typeValidationOutput$2, blockCond) + itemsCode$1;
-      let blockCond$1 = blockCond.contents;
-      if (blockCode$1 || unionIsPriority(flags[firstSchema.type], byKey$1)) {
-        let if_ = nextElse ? "else if" : "if";
-        start = start + if_ + (`(` + blockCond$1 + `){` + blockCode$1 + `}`);
-        nextElse = true;
-      } else {
-        noop = noop ? noop + `||` + blockCond$1 : blockCond$1;
+    let byKey$1 = byKey;
+    let keys$1 = keys;
+    if (!exit) {
+      let nextElse = false;
+      let noop = "";
+      for (let idx$1 = 0, idx_finish = keys$1.length; idx$1 < idx_finish; ++idx$1) {
+        let arr$1 = byKey$1[keys$1[idx$1]];
+        let typeValidationOutput$2 = arr$1[1];
+        let firstSchema = arr$1[2];
+        let itemsCode$1 = getArrItemsCode(arr$1, false);
+        let blockCond = {
+          contents: ""
+        };
+        let blockCode$1 = merge(typeValidationOutput$2, blockCond) + itemsCode$1;
+        let blockCond$1 = blockCond.contents;
+        if (blockCode$1 || unionIsPriority(flags[firstSchema.type], byKey$1)) {
+          let if_ = nextElse ? "else if" : "if";
+          start = start + if_ + (`(` + blockCond$1 + `){` + blockCode$1 + `}`);
+          nextElse = true;
+        } else {
+          noop = noop ? noop + `||` + blockCond$1 : blockCond$1;
+        }
       }
+      let errorCode = fail(caught);
+      let tmp;
+      if (noop) {
+        let if_$1 = nextElse ? "else if" : "if";
+        tmp = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
+      } else {
+        tmp = nextElse ? `else{` + errorCode + `}` : (
+            end === "" ? errorCode + ";" : errorCode
+          );
+      }
+      start = start + tmp;
     }
-    let errorCode = fail(caught);
-    let tmp;
-    if (noop) {
-      let if_$1 = nextElse ? "else if" : "if";
-      tmp = if_$1 + (`(!(` + noop + `)){` + errorCode + `}`);
-    } else {
-      tmp = nextElse ? `else{` + errorCode + `}` : (
-          end === "" ? errorCode + ";" : errorCode
-        );
+    output.cp = output.cp + start + end;
+    if (input.i !== output.i) {
+      output.i = input.i;
     }
-    start = start + tmp;
+    let o = output.f & 1 ? (output.i = `Promise.resolve(` + output.i + `)`, output.v = _notVar, output) : (
+        output.v === _var && input.cp === "" && output.cp === "" && initialInline === "i" ? (input.hd = "", input.v = _notVar, input.i = initialInline, input) : output
+      );
+    o.s = outputAnyOf.length ? unionFactory(outputAnyOf) : never_();
+    o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
+    return o;
   }
-  output.cp = output.cp + start + end;
-  if (input.i !== output.i) {
-    output.i = input.i;
-  }
-  let o = output.f & 1 ? (output.i = `Promise.resolve(` + output.i + `)`, output.v = _notVar, output) : (
-      output.v === _var && input.cp === "" && output.cp === "" && initialInline === "i" ? (input.hd = "", input.v = _notVar, input.i = initialInline, input) : output
-    );
-  o.s = outputAnyOf.length ? unionFactory(outputAnyOf) : never_();
-  o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
-  return o;
 }
 
 function unionFactory(schemas) {
@@ -3697,6 +3698,69 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== objectTag || definition === null) {
     return parse(definition);
@@ -3836,12 +3900,60 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
     }
-  });
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function nested(fieldName) {
@@ -3910,123 +4022,18 @@ function nested(fieldName) {
   return ctx$1;
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
 }
 
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shapedParser(input) {
@@ -4049,12 +4056,6 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return markOutput(output, input);
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2362,51 +2362,7 @@ function unionDecoder(input) {
     let lastIdx = schemas.length - 1 | 0;
     let byKey = {};
     let keys = [];
-    let unionRefiner = selfSchema.refiner;
-    let unionInputRefiner = selfSchema.inputRefiner;
-    let cachedRefinerChecks = {
-      contents: undefined
-    };
-    let cachedInputRefinerChecks = {
-      contents: undefined
-    };
-    let attach = (current, source, cache) => {
-      if (source === undefined) {
-        return current;
-      }
-      let getCached = input => {
-        let checks = cache.contents;
-        if (checks !== undefined) {
-          return checks;
-        }
-        let checks$1 = source(input);
-        cache.contents = checks$1;
-        return checks$1;
-      };
-      if (current !== undefined) {
-        return input => {
-          let arr = current(input);
-          let next = getCached(input);
-          for (let i = 0, i_finish = next.length; i < i_finish; ++i) {
-            arr.push(next[i]);
-          }
-          return arr;
-        };
-      } else {
-        return getCached;
-      }
-    };
-    let appendUnionRefiners = mut => {
-      let r = attach(mut.refiner, unionRefiner, cachedRefinerChecks);
-      if (r !== undefined) {
-        mut.refiner = r;
-      }
-      let r$1 = attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks);
-      if (r$1 !== undefined) {
-        mut.inputRefiner = r$1;
-        return;
-      }
-    };
+    let appendUnionRefiners = unionRefinerAttacher(selfSchema);
     let schemas$1 = unionPrioritizeConst(input.s, schemas);
     let assignedTargets = toPerCase !== undefined && activeKey === "" ? unionAssignTargets(schemas$1, toPerCase) : undefined;
     for (let idx = 0; idx <= lastIdx; ++idx) {
@@ -2533,6 +2489,54 @@ function unionDecoder(input) {
     o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
     return o;
   }
+}
+
+function unionRefinerAttacher(selfSchema) {
+  let unionRefiner = selfSchema.refiner;
+  let unionInputRefiner = selfSchema.inputRefiner;
+  let cachedRefinerChecks = {
+    contents: undefined
+  };
+  let cachedInputRefinerChecks = {
+    contents: undefined
+  };
+  let attach = (current, source, cache) => {
+    if (source === undefined) {
+      return current;
+    }
+    let getCached = input => {
+      let checks = cache.contents;
+      if (checks !== undefined) {
+        return checks;
+      }
+      let checks$1 = source(input);
+      cache.contents = checks$1;
+      return checks$1;
+    };
+    if (current !== undefined) {
+      return input => {
+        let arr = current(input);
+        let next = getCached(input);
+        for (let i = 0, i_finish = next.length; i < i_finish; ++i) {
+          arr.push(next[i]);
+        }
+        return arr;
+      };
+    } else {
+      return getCached;
+    }
+  };
+  return mut => {
+    let r = attach(mut.refiner, unionRefiner, cachedRefinerChecks);
+    if (r !== undefined) {
+      mut.refiner = r;
+    }
+    let r$1 = attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks);
+    if (r$1 !== undefined) {
+      mut.inputRefiner = r$1;
+      return;
+    }
+  };
 }
 
 function unionFail(input, selfSchema, caught) {
@@ -3701,133 +3705,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = `~` + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = optionFactory(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
-        throw new Error(`[Sury] ` + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
-    throw new Error(`[Sury] ` + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== objectTag || definition === null) {
     return parse(definition);
@@ -3868,6 +3745,125 @@ function traverseDefinition(definition, onNode) {
   mut$2.additionalItems = globalConfig.a;
   mut$2.decoder = objectDecoder;
   return mut$2;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3967,70 +3963,78 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = `~` + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
     }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = optionFactory(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
+        throw new Error(`[Sury] ` + message);
       }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
       }
-      accAtFrom = tmp;
+      return result;
     }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
+    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
+    throw new Error(`[Sury] ` + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
 }
 
 function shapedParser(input) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2088,6 +2088,54 @@ function unionAssignTargets(sources, target) {
   });
 }
 
+function unionPrioritizeConst(inputSchema, schemas) {
+  if (!(constField in inputSchema)) {
+    return schemas;
+  }
+  let matching = [];
+  let rest = [];
+  for (let idx = 0, idx_finish = schemas.length; idx < idx_finish; ++idx) {
+    let schema = schemas[idx];
+    if (constField in schema && schema.const === inputSchema.const) {
+      matching.push(schema);
+    } else {
+      rest.push(schema);
+    }
+  }
+  return matching.concat(rest);
+}
+
+function unionActiveKey(inputSchema, inputTagFlag, schemas) {
+  if (inputTagFlag & 769) {
+    return "";
+  }
+  let sourceKey = unionToKey(inputSchema);
+  let activeKey = "";
+  let hasNull = false;
+  let hasUndefined = false;
+  let len = schemas.length;
+  let i = 0;
+  while (activeKey === "" && i < len) {
+    let s = schemas[i];
+    if (unionToKey(s) === sourceKey) {
+      activeKey = sourceKey;
+    } else if (s.type === nullTag) {
+      hasNull = true;
+    } else if (s.type === undefinedTag) {
+      hasUndefined = true;
+    }
+    i = i + 1 | 0;
+  };
+  if (activeKey === "") {
+    if (inputTagFlag & 16 && hasNull) {
+      activeKey = nullTag;
+    } else if (inputTagFlag & 32 && hasUndefined) {
+      activeKey = undefinedTag;
+    }
+  }
+  return activeKey;
+}
+
 function unionEncoder(input, target) {
   let inputAnyOf = input.s.anyOf;
   if (target.type === unionTag && unionGetToPerCase(target) === undefined && unionIsWiderSchema(target.anyOf, inputAnyOf) || !unionCanDispatchPerVariant(inputAnyOf, target)) {
@@ -2108,33 +2156,7 @@ function unionDecoder(input) {
   if (initialInputTagFlag & 256 || input.s.encoder === undefined && initialInputTagFlag & 512) {
     input.s = unknown;
   }
-  let activeKey = "";
-  if (!(initialInputTagFlag & 769)) {
-    let sourceKey = unionToKey(input.s);
-    let hasNull = false;
-    let hasUndefined = false;
-    let len = schemas.length;
-    let i = 0;
-    while (activeKey === "" && i < len) {
-      let s = schemas[i];
-      if (unionToKey(s) === sourceKey) {
-        activeKey = sourceKey;
-      } else if (s.type === nullTag) {
-        hasNull = true;
-      } else if (s.type === undefinedTag) {
-        hasUndefined = true;
-      }
-      i = i + 1 | 0;
-    };
-    if (activeKey === "") {
-      if (initialInputTagFlag & 16 && hasNull) {
-        activeKey = nullTag;
-      } else if (initialInputTagFlag & 32 && hasUndefined) {
-        activeKey = undefinedTag;
-      }
-    }
-  }
-  let activeKey$1 = activeKey;
+  let activeKey = unionActiveKey(input.s, initialInputTagFlag, schemas);
   let initialInline = input.i;
   let fail = caught => embed(input, function () {
     let args = arguments;
@@ -2352,38 +2374,23 @@ function unionDecoder(input) {
       return;
     }
   };
-  let schemas$1;
-  if (constField in input.s) {
-    let matching = [];
-    let rest = [];
-    for (let idx = 0; idx <= lastIdx; ++idx) {
-      let schema = schemas[idx];
-      if (constField in schema && schema.const === input.s.const) {
-        matching.push(schema);
-      } else {
-        rest.push(schema);
-      }
-    }
-    schemas$1 = matching.concat(rest);
-  } else {
-    schemas$1 = schemas;
-  }
-  let assignedTargets = toPerCase !== undefined && activeKey$1 === "" ? unionAssignTargets(schemas$1, toPerCase) : undefined;
-  for (let idx$1 = 0; idx$1 <= lastIdx; ++idx$1) {
-    let schema$1 = toPerCase !== undefined ? updateOutput(schemas$1[idx$1], mut => {
+  let schemas$1 = unionPrioritizeConst(input.s, schemas);
+  let assignedTargets = toPerCase !== undefined && activeKey === "" ? unionAssignTargets(schemas$1, toPerCase) : undefined;
+  for (let idx = 0; idx <= lastIdx; ++idx) {
+    let schema = toPerCase !== undefined ? updateOutput(schemas$1[idx], mut => {
         appendUnionRefiners(mut);
-        mut.to = assignedTargets !== undefined ? assignedTargets[idx$1] : toPerCase;
-      }) : schemas$1[idx$1];
-    let tag = schema$1.type;
+        mut.to = assignedTargets !== undefined ? assignedTargets[idx] : toPerCase;
+      }) : schemas$1[idx];
+    let tag = schema.type;
     let tagFlag = flags[tag];
-    let key = unionToKey(schema$1);
-    if ((activeKey$1 === "" || activeKey$1 === key) && !(tagFlag & 16 && "fromDefault" in selfSchema)) {
+    let key = unionToKey(schema);
+    if ((activeKey === "" || activeKey === key) && !(tagFlag & 16 && "fromDefault" in selfSchema)) {
       let initialArr = byKey[key];
       if (initialArr !== undefined) {
-        if (tagFlag & 64 && nestedLoc in schema$1.properties) {
-          initialArr.splice(initialArr.length - 1 | 0, 0, schema$1);
+        if (tagFlag & 64 && nestedLoc in schema.properties) {
+          initialArr.splice(initialArr.length - 1 | 0, 0, schema);
         } else if (!(tagFlag & 2096)) {
-          initialArr.push(schema$1);
+          initialArr.push(schema);
         }
       } else {
         let typeValidationInput = scope(input);
@@ -2391,7 +2398,7 @@ function unionDecoder(input) {
             tagFlag & 16 ? unit() : (
                 tagFlag & 64 ? dictFactory(unknown) : (
                     tagFlag & 128 ? array(unknown) : (
-                        tagFlag & 8192 ? instance(schema$1.class) : (
+                        tagFlag & 8192 ? instance(schema.class) : (
                             tagFlag & 2048 ? nan() : (
                                 tagFlag & 2 ? string() : (
                                     tagFlag & 4 ? float() : (
@@ -2423,7 +2430,7 @@ function unionDecoder(input) {
         byKey[key] = [
           typeValidationInput,
           typeValidationOutput,
-          schema$1
+          schema
         ];
         let shouldDeopt = true;
         let valRef = typeValidationOutput;
@@ -2444,7 +2451,7 @@ function unionDecoder(input) {
               if (embeddedError) {
                 staticBlockFailure.contents = "";
                 if (blockCode) {
-                  let errorVar = `e` + (idx$1 + keyIdx | 0);
+                  let errorVar = `e` + (idx + keyIdx | 0);
                   start = start + (`try{` + blockCode + `throw ` + embeddedError + `}catch(` + errorVar + `){`);
                   end = "}" + end;
                   caught = caught + `,` + errorVar;
@@ -2452,7 +2459,7 @@ function unionDecoder(input) {
                   caught = caught + `,` + embeddedError;
                 }
               } else if (blockCode) {
-                let errorVar$1 = `e` + (idx$1 + keyIdx | 0);
+                let errorVar$1 = `e` + (idx + keyIdx | 0);
                 start = start + (`try{` + blockCode + `}catch(` + errorVar$1 + `){`);
                 end = "}" + end;
                 caught = caught + `,` + errorVar$1;
@@ -2472,8 +2479,8 @@ function unionDecoder(input) {
   if (!exit) {
     let nextElse = false;
     let noop = "";
-    for (let idx$2 = 0, idx_finish = keys$1.length; idx$2 < idx_finish; ++idx$2) {
-      let arr$1 = byKey$1[keys$1[idx$2]];
+    for (let idx$1 = 0, idx_finish = keys$1.length; idx$1 < idx_finish; ++idx$1) {
+      let arr$1 = byKey$1[keys$1[idx$1]];
       let typeValidationOutput$2 = arr$1[1];
       let firstSchema = arr$1[2];
       let itemsCode$1 = getArrItemsCode(arr$1, false);
@@ -3672,6 +3679,133 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = `~` + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = optionFactory(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
+        throw new Error(`[Sury] ` + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
+    throw new Error(`[Sury] ` + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
+    }
+  });
+}
+
 function traverseDefinition(definition, onNode) {
   if (typeof definition !== objectTag || definition === null) {
     return parse(definition);
@@ -3714,74 +3848,14 @@ function traverseDefinition(definition, onNode) {
   return mut$2;
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3881,127 +3955,60 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = `~` + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = optionFactory(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
-        throw new Error(`[Sury] ` + message);
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
       }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
-    throw new Error(`[Sury] ` + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
       }
     } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
+      accAtFrom = acc;
     }
-    v = completeObjectVal(output);
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
   }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
 }
 
 function definitionToShapedSchema(definition) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2088,6 +2088,34 @@ function unionAssignTargets(sources, target) {
   });
 }
 
+function unionTypeValidationSchema(tagFlag, schema) {
+  if (tagFlag & 32) {
+    return nullLiteral();
+  } else if (tagFlag & 16) {
+    return unit();
+  } else if (tagFlag & 64) {
+    return dictFactory(unknown);
+  } else if (tagFlag & 128) {
+    return array(unknown);
+  } else if (tagFlag & 8192) {
+    return instance(schema.class);
+  } else if (tagFlag & 2048) {
+    return nan();
+  } else if (tagFlag & 2) {
+    return string();
+  } else if (tagFlag & 4) {
+    return float();
+  } else if (tagFlag & 8) {
+    return bool();
+  } else if (tagFlag & 1024) {
+    return bigint();
+  } else if (tagFlag & 16384) {
+    return symbol();
+  } else {
+    return unknown;
+  }
+}
+
 function unionPrioritizeConst(inputSchema, schemas) {
   if (!(constField in inputSchema)) {
     return schemas;
@@ -2394,27 +2422,7 @@ function unionDecoder(input) {
         }
       } else {
         let typeValidationInput = scope(input);
-        typeValidationInput.e = tagFlag & 32 ? nullLiteral() : (
-            tagFlag & 16 ? unit() : (
-                tagFlag & 64 ? dictFactory(unknown) : (
-                    tagFlag & 128 ? array(unknown) : (
-                        tagFlag & 8192 ? instance(schema.class) : (
-                            tagFlag & 2048 ? nan() : (
-                                tagFlag & 2 ? string() : (
-                                    tagFlag & 4 ? float() : (
-                                        tagFlag & 8 ? bool() : (
-                                            tagFlag & 1024 ? bigint() : (
-                                                tagFlag & 16384 ? symbol() : unknown
-                                              )
-                                          )
-                                      )
-                                  )
-                              )
-                          )
-                      )
-                  )
-              )
-          );
+        typeValidationInput.e = unionTypeValidationSchema(tagFlag, schema);
         let typeValidationOutput;
         try {
           typeValidationOutput = parse$1(typeValidationInput);
@@ -3679,125 +3687,6 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
-}
-
-function getShapedParserOutput(input, targetSchema) {
-  let from = targetSchema.from;
-  let fromFlattened = targetSchema.fromFlattened;
-  let v;
-  if (fromFlattened !== undefined) {
-    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
-  } else if (from !== undefined) {
-    v = scope(getValByFrom(input, from, 0));
-  } else if (constField in targetSchema) {
-    v = nextConst(input, targetSchema, undefined);
-  } else {
-    let output = makeObjectVal(input, targetSchema);
-    output.io = true;
-    let items = targetSchema.items;
-    if (items !== undefined) {
-      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
-        let location = idx.toString();
-        add(output, location, getShapedParserOutput(input, items[idx]));
-      }
-    } else {
-      let properties = targetSchema.properties;
-      if (properties !== undefined) {
-        let keys = Object.keys(properties);
-        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-          let location$1 = keys[idx$1];
-          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
-        }
-      } else {
-        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
-        throw new Error(`[Sury] ` + message);
-      }
-    }
-    v = completeObjectVal(output);
-  }
-  v.prev = undefined;
-  v.e = targetSchema;
-  return v;
-}
-
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = `~` + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = optionFactory(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
-        throw new Error(`[Sury] ` + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
-    throw new Error(`[Sury] ` + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
 function definitionToSchema(definition) {
   return traverseDefinition(definition, node => {
     if (node["~standard"]) {
@@ -3806,56 +3695,60 @@ function definitionToSchema(definition) {
   });
 }
 
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
     }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
   }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
   }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
   }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
 }
 
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
@@ -3955,66 +3848,175 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
     }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
   }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
   }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
   }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
 }
 
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = `~` + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
+  };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = optionFactory(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
+        throw new Error(`[Sury] ` + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
+    throw new Error(`[Sury] ` + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function getShapedParserOutput(input, targetSchema) {
+  let from = targetSchema.from;
+  let fromFlattened = targetSchema.fromFlattened;
+  let v;
+  if (fromFlattened !== undefined) {
+    v = scope(getValByFrom(input.fv[fromFlattened], targetSchema.from, 0));
+  } else if (from !== undefined) {
+    v = scope(getValByFrom(input, from, 0));
+  } else if (constField in targetSchema) {
+    v = nextConst(input, targetSchema, undefined);
+  } else {
+    let output = makeObjectVal(input, targetSchema);
+    output.io = true;
+    let items = targetSchema.items;
+    if (items !== undefined) {
+      for (let idx = 0, idx_finish = items.length; idx < idx_finish; ++idx) {
+        let location = idx.toString();
+        add(output, location, getShapedParserOutput(input, items[idx]));
+      }
+    } else {
+      let properties = targetSchema.properties;
+      if (properties !== undefined) {
+        let keys = Object.keys(properties);
+        for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+          let location$1 = keys[idx$1];
+          add(output, location$1, getShapedParserOutput(input, properties[location$1]));
+        }
+      } else {
+        let message = `Don't know where the value is coming from: ` + toExpression(targetSchema);
+        throw new Error(`[Sury] ` + message);
+      }
+    }
+    v = completeObjectVal(output);
+  }
+  v.prev = undefined;
+  v.e = targetSchema;
+  return v;
+}
+
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input) {
@@ -4037,6 +4039,12 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return markOutput(output, input);
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -2196,11 +2196,6 @@ function unionDecoder(input) {
     }
     let activeKey = unionActiveKey(input.s, initialInputTagFlag, schemas);
     let initialInline = input.i;
-    let fail = caught => embed(input, function () {
-      let args = arguments;
-      let errorDetails = makeInvalidInputDetails(selfSchema, unknown, input.path, args[0], true, args.length > 1 ? Array.from(args).slice(1) : undefined, undefined);
-      throw new SuryError(errorDetails);
-    }) + `(` + input.v() + caught + `)`;
     let output = refine(input, undefined, undefined, undefined);
     let outputAnyOf = [];
     let staticBlockFailure = {
@@ -2220,11 +2215,11 @@ function unionDecoder(input) {
       let itemIdx = 2;
       let lastIdx = arr.length - 1 | 0;
       while (itemIdx <= lastIdx) {
-        let input = scope(typeValidationOutput);
-        input.u = true;
-        input.t = typeValidationOutput.t;
-        input.io = false;
-        input.e = arr[itemIdx];
+        let input$1 = scope(typeValidationOutput);
+        input$1.u = true;
+        input$1.t = typeValidationOutput.t;
+        input$1.io = false;
+        input$1.e = arr[itemIdx];
         let isLast = itemIdx === lastIdx;
         let isFirst = itemIdx === 2;
         let isOnlyCase = isFirst && isLast;
@@ -2235,7 +2230,7 @@ function unionDecoder(input) {
           contents: ""
         };
         try {
-          let itemOutput = parse$1(input);
+          let itemOutput = parse$1(input$1);
           outputAnyOf.push(itemOutput.s);
           itemCode = merge(itemOutput, itemCond);
           if (itemOutput.t) {
@@ -2249,14 +2244,14 @@ function unionDecoder(input) {
             }
           }
         } catch (exn) {
-          let errorVar = embed(input, getOrRethrow(exn));
+          let errorVar = embed(input$1, getOrRethrow(exn));
           caught = caught + `,` + errorVar;
           if (isDeopt && isOnlyCase) {
             staticBlockFailure.contents = errorVar;
             itemSkipped = true;
           } else if (isLast) {
             withExhaustiveCheck = false;
-            itemCode = isDeopt ? "throw " + errorVar : fail(caught);
+            itemCode = isDeopt ? "throw " + errorVar : unionFail(input, selfSchema, caught);
           } else {
             itemSkipped = true;
           }
@@ -2299,7 +2294,7 @@ function unionDecoder(input) {
                 itemStart = itemStart + (`try{` + code$1 + `}catch(` + errorVar$1 + `){`);
                 caught$1 = caught$1 + `,` + errorVar$1;
               }
-              itemStart = itemStart + fail(caught$1) + "}".repeat(code.length) + "}";
+              itemStart = itemStart + unionFail(input, selfSchema, caught$1) + "}".repeat(code.length) + "}";
             }
             itemNextElse = true;
           }
@@ -2342,7 +2337,7 @@ function unionDecoder(input) {
           if (itemNoop.contents) {
             if (itemStart || caught) {
               let if_$2 = itemNextElse ? "else if" : "if";
-              itemStart = itemStart + if_$2 + (`(!(` + itemNoop.contents + `)){` + fail(caught) + `}`);
+              itemStart = itemStart + if_$2 + (`(!(` + itemNoop.contents + `)){` + unionFail(input, selfSchema, caught) + `}`);
             } else {
               pushCheck(typeValidationOutput, {
                 c: param => `(` + itemNoop.contents + `)`,
@@ -2350,7 +2345,7 @@ function unionDecoder(input) {
               });
             }
           } else if (withExhaustiveCheck) {
-            let errorCode = fail(caught);
+            let errorCode = unionFail(input, selfSchema, caught);
             itemStart = itemStart + (
               itemNextElse ? `else{` + errorCode + `}` : errorCode
             );
@@ -2515,7 +2510,7 @@ function unionDecoder(input) {
           noop = noop ? noop + `||` + blockCond$1 : blockCond$1;
         }
       }
-      let errorCode = fail(caught);
+      let errorCode = unionFail(input, selfSchema, caught);
       let tmp;
       if (noop) {
         let if_$1 = nextElse ? "else if" : "if";
@@ -2538,6 +2533,14 @@ function unionDecoder(input) {
     o.e = toPerCase !== undefined ? (o.io = true, getOutputSchema(toPerCase)) : selfSchema;
     return o;
   }
+}
+
+function unionFail(input, selfSchema, caught) {
+  return embed(input, function () {
+    let args = arguments;
+    let errorDetails = makeInvalidInputDetails(selfSchema, unknown, input.path, args[0], true, args.length > 1 ? Array.from(args).slice(1) : undefined, undefined);
+    throw new SuryError(errorDetails);
+  }) + `(` + input.v() + caught + `)`;
 }
 
 function unionFactory(schemas) {
@@ -3698,18 +3701,78 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
+function definitionToSchema(definition) {
+  return traverseDefinition(definition, node => {
+    if (node["~standard"]) {
+      return node;
     }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
+  });
+}
+
+function nested(fieldName) {
+  let parentCtx = this;
+  let cacheId = `~` + fieldName;
+  let ctx = parentCtx[cacheId];
+  if (ctx !== undefined) {
+    return Primitive_option.valFromOption(ctx);
+  }
+  let properties = {};
+  let required = [];
+  let schema = base(objectTag, false);
+  schema.required = required;
+  schema.properties = properties;
+  schema.additionalItems = globalConfig.a;
+  schema.decoder = objectDecoder;
+  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
+  let field = (fieldName, schema) => {
+    let inlinedLocation = fromString(fieldName);
+    if (fieldName in properties) {
+      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
+    }
+    required.push(fieldName);
+    properties[fieldName] = schema;
+    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
   };
+  let tag = (tag$1, asValue) => {
+    field(tag$1, definitionToSchema(asValue));
+  };
+  let fieldOr = (fieldName, schema, or) => {
+    let schema$1 = optionFactory(schema, undefined);
+    return field(fieldName, getWithDefault(schema$1, {
+      TAG: "Value",
+      _0: or
+    }));
+  };
+  let flatten = schema => {
+    let match = schema.type;
+    if (match === "object") {
+      let to = schema.to;
+      let flattenedProperties = schema.properties;
+      if (to) {
+        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
+        throw new Error(`[Sury] ` + message);
+      }
+      let flattenedKeys = Object.keys(flattenedProperties);
+      let result = {};
+      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
+        let key = flattenedKeys[idx];
+        result[key] = field(key, flattenedProperties[key]);
+      }
+      return result;
+    }
+    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
+    throw new Error(`[Sury] ` + message$1);
+  };
+  let ctx$1 = {
+    field: field,
+    f: field,
+    fieldOr: fieldOr,
+    tag: tag,
+    nested: nested,
+    flatten: flatten
+  };
+  parentCtx[cacheId] = ctx$1;
+  return ctx$1;
 }
 
 function getShapedParserOutput(input, targetSchema) {
@@ -3751,14 +3814,18 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
 }
 
 function traverseDefinition(definition, onNode) {
@@ -3956,84 +4023,14 @@ function prepareShapedSerializerAcc(acc, input) {
   }
 }
 
-function nested(fieldName) {
-  let parentCtx = this;
-  let cacheId = `~` + fieldName;
-  let ctx = parentCtx[cacheId];
-  if (ctx !== undefined) {
-    return Primitive_option.valFromOption(ctx);
-  }
-  let properties = {};
-  let required = [];
-  let schema = base(objectTag, false);
-  schema.required = required;
-  schema.properties = properties;
-  schema.additionalItems = globalConfig.a;
-  schema.decoder = objectDecoder;
-  let parentSchema = parentCtx.f(fieldName, schema)[itemSymbol];
-  let field = (fieldName, schema) => {
-    let inlinedLocation = fromString(fieldName);
-    if (fieldName in properties) {
-      throw new Error(`[Sury] ` + (`The field ` + inlinedLocation + ` defined twice`));
-    }
-    required.push(fieldName);
-    properties[fieldName] = schema;
-    return proxifyShapedSchema(schema, parentSchema.from.concat(fieldName), parentSchema.fromFlattened);
-  };
-  let tag = (tag$1, asValue) => {
-    field(tag$1, definitionToSchema(asValue));
-  };
-  let fieldOr = (fieldName, schema, or) => {
-    let schema$1 = optionFactory(schema, undefined);
-    return field(fieldName, getWithDefault(schema$1, {
-      TAG: "Value",
-      _0: or
-    }));
-  };
-  let flatten = schema => {
-    let match = schema.type;
-    if (match === "object") {
-      let to = schema.to;
-      let flattenedProperties = schema.properties;
-      if (to) {
-        let message = `Unsupported nested flatten for transformed object schema ` + toExpression(schema);
-        throw new Error(`[Sury] ` + message);
-      }
-      let flattenedKeys = Object.keys(flattenedProperties);
-      let result = {};
-      for (let idx = 0, idx_finish = flattenedKeys.length; idx < idx_finish; ++idx) {
-        let key = flattenedKeys[idx];
-        result[key] = field(key, flattenedProperties[key]);
-      }
-      return result;
-    }
-    let message$1 = `Can't flatten ` + toExpression(schema) + ` schema`;
-    throw new Error(`[Sury] ` + message$1);
-  };
-  let ctx$1 = {
-    field: field,
-    f: field,
-    fieldOr: fieldOr,
-    tag: tag,
-    nested: nested,
-    flatten: flatten
-  };
-  parentCtx[cacheId] = ctx$1;
-  return ctx$1;
-}
-
-function definitionToSchema(definition) {
-  return traverseDefinition(definition, node => {
-    if (node["~standard"]) {
-      return node;
-    }
-  });
-}
-
-function definitionToShapedSchema(definition) {
-  let s = copySchema(traverseDefinition(definition, toEmbededItem));
-  s.serializer = shapedSerializer;
-  return s;
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function shapedParser(input) {
@@ -4056,6 +4053,12 @@ function shapedParser(input) {
   output.t = true;
   output.prev = input;
   return markOutput(output, input);
+}
+
+function definitionToShapedSchema(definition) {
+  let s = copySchema(traverseDefinition(definition, toEmbededItem));
+  s.serializer = shapedSerializer;
+  return s;
 }
 
 function shape(schema, definer) {

--- a/packages/sury/src/Sury.res.mjs
+++ b/packages/sury/src/Sury.res.mjs
@@ -1984,6 +1984,110 @@ function unionPerVariantVal(input, target) {
   }));
 }
 
+function unionReservable(schema) {
+  if (schema.to === undefined && schema.parser === undefined && schema.serializer === undefined) {
+    return !(flags[schema.type] & 9152);
+  } else {
+    return false;
+  }
+}
+
+function unionAssignTargets(sources, target) {
+  let anyOf = target.anyOf;
+  let targetCases = anyOf !== undefined ? (
+      target.type === unionTag ? anyOf : [target]
+    ) : [target];
+  let sourceLen = sources.length;
+  let targetLen = targetCases.length;
+  let reserved = [];
+  let assigned = [];
+  for (let _for = 0; _for < targetLen; ++_for) {
+    reserved.push(false);
+  }
+  for (let _for$1 = 0; _for$1 < sourceLen; ++_for$1) {
+    assigned.push(undefined);
+  }
+  let claim = (si, ti) => {
+    reserved[ti] = true;
+    assigned[si] = targetCases[ti];
+  };
+  for (let si = 0; si < sourceLen; ++si) {
+    let s = sources[si];
+    if (unionReservable(s)) {
+      let sKey = unionToKey(s);
+      let chosen = -1;
+      for (let ti = 0; ti < targetLen; ++ti) {
+        if (chosen === -1 && !reserved[ti]) {
+          let t = targetCases[ti];
+          if (unionToKey(t) === sKey && t.const === s.const) {
+            chosen = ti;
+          }
+        }
+      }
+      if (chosen === -1) {
+        for (let ti$1 = 0; ti$1 < targetLen; ++ti$1) {
+          if (chosen === -1 && !reserved[ti$1] && unionToKey(targetCases[ti$1]) === sKey) {
+            chosen = ti$1;
+          }
+        }
+      }
+      if (chosen !== -1) {
+        claim(si, chosen);
+      }
+    }
+  }
+  for (let si$1 = 0; si$1 < sourceLen; ++si$1) {
+    let match = assigned[si$1];
+    if (match === undefined) {
+      let sTag = sources[si$1].type;
+      let oppositeTag = sTag === nullTag ? undefinedTag : (
+          sTag === undefinedTag ? nullTag : sTag
+        );
+      if (oppositeTag !== sTag) {
+        let chosen$1 = -1;
+        for (let ti$2 = 0; ti$2 < targetLen; ++ti$2) {
+          if (chosen$1 === -1 && !reserved[ti$2] && targetCases[ti$2].type === oppositeTag) {
+            chosen$1 = ti$2;
+          }
+        }
+        if (chosen$1 !== -1) {
+          claim(si$1, chosen$1);
+        }
+      }
+    }
+  }
+  let free = [];
+  for (let ti$3 = 0; ti$3 < targetLen; ++ti$3) {
+    if (!reserved[ti$3]) {
+      free.push(targetCases[ti$3]);
+    }
+  }
+  let freeSchema;
+  if (free.length === targetLen) {
+    freeSchema = target;
+  } else {
+    let len = free.length;
+    freeSchema = len !== 1 ? (
+        len !== 0 ? unionFactory(free) : never_()
+      ) : free[0];
+  }
+  for (let si$2 = 0; si$2 < sourceLen; ++si$2) {
+    let match$1 = assigned[si$2];
+    if (match$1 !== undefined) {
+      
+    } else {
+      assigned[si$2] = unionReservable(sources[si$2]) ? freeSchema : target;
+    }
+  }
+  return assigned.map(opt => {
+    if (opt !== undefined) {
+      return opt;
+    } else {
+      return never_();
+    }
+  });
+}
+
 function unionEncoder(input, target) {
   let inputAnyOf = input.s.anyOf;
   if (target.type === unionTag && unionGetToPerCase(target) === undefined && unionIsWiderSchema(target.anyOf, inputAnyOf) || !unionCanDispatchPerVariant(inputAnyOf, target)) {
@@ -2264,10 +2368,11 @@ function unionDecoder(input) {
   } else {
     schemas$1 = schemas;
   }
+  let assignedTargets = toPerCase !== undefined && activeKey$1 === "" ? unionAssignTargets(schemas$1, toPerCase) : undefined;
   for (let idx$1 = 0; idx$1 <= lastIdx; ++idx$1) {
     let schema$1 = toPerCase !== undefined ? updateOutput(schemas$1[idx$1], mut => {
         appendUnionRefiners(mut);
-        mut.to = toPerCase;
+        mut.to = assignedTargets !== undefined ? assignedTargets[idx$1] : toPerCase;
       }) : schemas$1[idx$1];
     let tag = schema$1.type;
     let tagFlag = flags[tag];
@@ -3567,6 +3672,118 @@ function proxifyShapedSchema(schema, from, fromFlattened) {
   });
 }
 
+function traverseDefinition(definition, onNode) {
+  if (typeof definition !== objectTag || definition === null) {
+    return parse(definition);
+  }
+  let s = onNode(definition);
+  if (s !== undefined) {
+    return s;
+  }
+  if (Array.isArray(definition)) {
+    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
+      let schema = traverseDefinition(definition[idx], onNode);
+      definition[idx] = schema;
+    }
+    let mut = base(arrayTag, false);
+    mut.items = definition;
+    mut.additionalItems = "strict";
+    mut.decoder = arrayDecoder;
+    return mut;
+  }
+  let cnstr = definition.constructor;
+  if (cnstr && cnstr !== Object) {
+    let mut$1 = base(instanceTag, true);
+    mut$1.class = cnstr;
+    mut$1.const = definition;
+    mut$1.decoder = literalDecoder;
+    return mut$1;
+  }
+  let fieldNames = Object.keys(definition);
+  let length = fieldNames.length;
+  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
+    let location = fieldNames[idx$1];
+    let schema$1 = traverseDefinition(definition[location], onNode);
+    definition[location] = schema$1;
+  }
+  let mut$2 = base(objectTag, false);
+  mut$2.required = fieldNames;
+  mut$2.properties = definition;
+  mut$2.additionalItems = globalConfig.a;
+  mut$2.decoder = objectDecoder;
+  return mut$2;
+}
+
+function getValByFrom(_input, from, _idx) {
+  while (true) {
+    let idx = _idx;
+    let input = _input;
+    let key = from[idx];
+    if (key === undefined) {
+      return input;
+    }
+    _idx = idx + 1 | 0;
+    _input = input.d[key];
+    continue;
+  };
+}
+
+function prepareShapedSerializerAcc(acc, input) {
+  let match = input.e;
+  let from = match.from;
+  if (from !== undefined) {
+    let fromFlattened = match.fromFlattened;
+    let accAtFrom;
+    if (fromFlattened !== undefined) {
+      if (acc.flattened === undefined) {
+        acc.flattened = [];
+      }
+      let acc$1 = acc.flattened[fromFlattened];
+      if (acc$1 !== undefined) {
+        accAtFrom = acc$1;
+      } else {
+        let newAcc = {};
+        acc.flattened[fromFlattened] = newAcc;
+        accAtFrom = newAcc;
+      }
+    } else {
+      accAtFrom = acc;
+    }
+    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
+      let key = from[idx];
+      let p = accAtFrom.properties;
+      let p$1;
+      if (p !== undefined) {
+        p$1 = p;
+      } else {
+        let p$2 = {};
+        accAtFrom.properties = p$2;
+        p$1 = p$2;
+      }
+      let acc$2 = p$1[key];
+      let tmp;
+      if (acc$2 !== undefined) {
+        tmp = acc$2;
+      } else {
+        let newAcc$1 = {};
+        p$1[key] = newAcc$1;
+        tmp = newAcc$1;
+      }
+      accAtFrom = tmp;
+    }
+    accAtFrom.val = input;
+    return;
+  }
+  let vals = input.d;
+  if (vals === undefined) {
+    return;
+  }
+  let keys = Object.keys(vals);
+  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
+    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
+  }
+}
+
 function getShapedSerializerOutput(input, acc, targetSchema, path) {
   let exit = 0;
   if (acc !== undefined) {
@@ -3664,62 +3881,6 @@ function getShapedSerializerOutput(input, acc, targetSchema, path) {
   }
 }
 
-function prepareShapedSerializerAcc(acc, input) {
-  let match = input.e;
-  let from = match.from;
-  if (from !== undefined) {
-    let fromFlattened = match.fromFlattened;
-    let accAtFrom;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
-        acc.flattened = [];
-      }
-      let acc$1 = acc.flattened[fromFlattened];
-      if (acc$1 !== undefined) {
-        accAtFrom = acc$1;
-      } else {
-        let newAcc = {};
-        acc.flattened[fromFlattened] = newAcc;
-        accAtFrom = newAcc;
-      }
-    } else {
-      accAtFrom = acc;
-    }
-    for (let idx = 0, idx_finish = from.length; idx < idx_finish; ++idx) {
-      let key = from[idx];
-      let p = accAtFrom.properties;
-      let p$1;
-      if (p !== undefined) {
-        p$1 = p;
-      } else {
-        let p$2 = {};
-        accAtFrom.properties = p$2;
-        p$1 = p$2;
-      }
-      let acc$2 = p$1[key];
-      let tmp;
-      if (acc$2 !== undefined) {
-        tmp = acc$2;
-      } else {
-        let newAcc$1 = {};
-        p$1[key] = newAcc$1;
-        tmp = newAcc$1;
-      }
-      accAtFrom = tmp;
-    }
-    accAtFrom.val = input;
-    return;
-  }
-  let vals = input.d;
-  if (vals === undefined) {
-    return;
-  }
-  let keys = Object.keys(vals);
-  for (let idx$1 = 0, idx_finish$1 = keys.length; idx$1 < idx_finish$1; ++idx$1) {
-    prepareShapedSerializerAcc(acc, vals[keys[idx$1]]);
-  }
-}
-
 function nested(fieldName) {
   let parentCtx = this;
   let cacheId = `~` + fieldName;
@@ -3794,58 +3955,6 @@ function definitionToSchema(definition) {
   });
 }
 
-function shapedSerializer(input) {
-  let acc = {};
-  prepareShapedSerializerAcc(acc, input);
-  let targetSchema = input.e.to;
-  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
-  output.t = true;
-  output.prev = input;
-  return output;
-}
-
-function traverseDefinition(definition, onNode) {
-  if (typeof definition !== objectTag || definition === null) {
-    return parse(definition);
-  }
-  let s = onNode(definition);
-  if (s !== undefined) {
-    return s;
-  }
-  if (Array.isArray(definition)) {
-    for (let idx = 0, idx_finish = definition.length; idx < idx_finish; ++idx) {
-      let schema = traverseDefinition(definition[idx], onNode);
-      definition[idx] = schema;
-    }
-    let mut = base(arrayTag, false);
-    mut.items = definition;
-    mut.additionalItems = "strict";
-    mut.decoder = arrayDecoder;
-    return mut;
-  }
-  let cnstr = definition.constructor;
-  if (cnstr && cnstr !== Object) {
-    let mut$1 = base(instanceTag, true);
-    mut$1.class = cnstr;
-    mut$1.const = definition;
-    mut$1.decoder = literalDecoder;
-    return mut$1;
-  }
-  let fieldNames = Object.keys(definition);
-  let length = fieldNames.length;
-  for (let idx$1 = 0; idx$1 < length; ++idx$1) {
-    let location = fieldNames[idx$1];
-    let schema$1 = traverseDefinition(definition[location], onNode);
-    definition[location] = schema$1;
-  }
-  let mut$2 = base(objectTag, false);
-  mut$2.required = fieldNames;
-  mut$2.properties = definition;
-  mut$2.additionalItems = globalConfig.a;
-  mut$2.decoder = objectDecoder;
-  return mut$2;
-}
-
 function getShapedParserOutput(input, targetSchema) {
   let from = targetSchema.from;
   let fromFlattened = targetSchema.fromFlattened;
@@ -3885,18 +3994,14 @@ function getShapedParserOutput(input, targetSchema) {
   return v;
 }
 
-function getValByFrom(_input, from, _idx) {
-  while (true) {
-    let idx = _idx;
-    let input = _input;
-    let key = from[idx];
-    if (key === undefined) {
-      return input;
-    }
-    _idx = idx + 1 | 0;
-    _input = input.d[key];
-    continue;
-  };
+function shapedSerializer(input) {
+  let acc = {};
+  prepareShapedSerializerAcc(acc, input);
+  let targetSchema = input.e.to;
+  let output = getShapedSerializerOutput(input, acc, targetSchema, "");
+  output.t = true;
+  output.prev = input;
+  return output;
 }
 
 function definitionToShapedSchema(definition) {

--- a/packages/sury/tests/S_to_dictToObject_test.res
+++ b/packages/sury/tests/S_to_dictToObject_test.res
@@ -16,9 +16,9 @@ open Vitest
 // as optional (`option<V>`) when `V` is a concrete type that can't itself be
 // undefined. The existing union coercion then handles a missing key uniformly:
 //   - optional target field  -> absence decodes to None
-//   - required `string` field -> absence stringifies to "undefined" (the
-//     reversibility-locked None <-> "undefined" sentinel; tightening this is a
-//     deferred "tier fix")
+//   - required `string` field -> absence errors: the `string` source variant
+//     claims the `string` target (tier 1, exclusive), so the reserved `unit` arm
+//     has no target and can't stringify to "undefined" (the "tier fix")
 //   - required `bigint` field -> absence errors (no undefined coercion)
 //
 // The remaining gap (encoding back to dict<string>) is still pinned against its
@@ -66,27 +66,29 @@ test("[milestone 1] absent required bigint field errors", t => {
   )
 })
 
-test("[milestone 1] absent required string field stringifies to \"undefined\" (deferred tier fix)", t => {
+test("[milestone 1] absent required string field errors (tier fix)", t => {
   let schema = makeSchema()
 
-  // A missing `foo` (required string) flows through the option's undefined arm,
-  // which the string coercion turns into the literal "undefined" — the mirror of
-  // the `string -> option` `"undefined" <-> None` sentinel, locked in by
-  // reversibility. Tightening this to an error is a deferred "tier fix".
-  t->Assert.deepEqual(
-    %raw(`{"bar":"7","zoo":"1.5"}`)->S.parseOrThrow(~to=schema),
-    {"foo": "undefined", "bar": 7n, "zoo": Some(1.5)},
+  // A missing `foo` (required string) reads as `option<string>`. The `string`
+  // source variant claims the `string` target (tier 1, exclusive), so the absent
+  // `unit` arm has no target left and errors instead of stringifying to
+  // "undefined" — the tier fix that tightens the old None <-> "undefined" sentinel.
+  t->U.assertThrowsMessage(
+    () => %raw(`{"bar":"7","zoo":"1.5"}`)->S.parseOrThrow(~to=schema),
+    `Failed at ["foo"]: Expected never, received undefined`,
   )
 })
 
-test("the literal string \"undefined\" decodes to None (string sentinel)", t => {
+test("the literal string \"undefined\" no longer decodes to None (sentinel removed)", t => {
   let schema = makeSchema()
 
-  // Present-value coercion routes through the option's string arm, so the literal
-  // string "undefined" maps to None as well — the same sentinel as above.
-  t->Assert.deepEqual(
-    %raw(`{"foo":"a","bar":"123","zoo":"undefined"}`)->S.parseOrThrow(~to=schema),
-    {"foo": "a", "bar": 123n, "zoo": None},
+  // `zoo` is `option<float>`; its `unit`/None arm is reserved by the absent
+  // `undefined` read, so the present string "undefined" can't reach it via tier-3
+  // stringified-const coercion. It is parsed as a number (`+"undefined"` = NaN)
+  // and errors — the surprising string sentinel is gone.
+  t->U.assertThrowsMessage(
+    () => %raw(`{"foo":"a","bar":"123","zoo":"undefined"}`)->S.parseOrThrow(~to=schema),
+    `Failed at ["zoo"]: Expected number, received "undefined"`,
   )
 })
 
@@ -96,7 +98,7 @@ test("[milestone 1] compiled parse code models each dict read as optional", t =>
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[9](i);for(let v0 in i){try{let v1=i[v0];typeof v1==="string"||e[0](v1);}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}let v3=i["foo"],v5=i["bar"],v7=i["zoo"];if(v3===void 0){v3="undefined"}else if(!(typeof v3==="string")){e[1](v3)}if(typeof v5==="string"){let v4;try{v4=BigInt(v5)}catch(_){e[2](v5)}v5=v4}else if(v5===void 0){e[4](v5,e[3])}else{e[5](v5)}if(typeof v7==="string"){try{let v6=+v7;!Number.isNaN(v6)||e[6](v7);v7=v6}catch(e0){if(v7==="undefined"){v7=void 0}else{e[7](v7,e0)}}}else if(!(v7===void 0)){e[8](v7)}return {"foo":v3,"bar":v5,"zoo":v7,}}`,
+    `i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[9](i);for(let v0 in i){try{let v1=i[v0];typeof v1==="string"||e[0](v1);}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}let v3=i["foo"],v5=i["bar"],v7=i["zoo"];if(v3===void 0){e[1](v3);}else if(!(typeof v3==="string")){e[2](v3)}if(typeof v5==="string"){let v4;try{v4=BigInt(v5)}catch(_){e[3](v5)}v5=v4}else if(v5===void 0){e[5](v5,e[4])}else{e[6](v5)}if(typeof v7==="string"){let v6=+v7;!Number.isNaN(v6)||e[7](v7);v7=v6}else if(!(v7===void 0)){e[8](v7)}return {"foo":v3,"bar":v5,"zoo":v7,}}`,
   )
 })
 

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -518,33 +518,29 @@ test("Coerce from string to optional bool", t => {
   )
 })
 
-test("Coerce from string to optional string (FIXME: asymmetric None handling)", t => {
+test("Coerce from string to optional string — reserved None has no target and errors", t => {
   let schema = S.string->S.to(S.option(S.string))
 
   // Parse: the source `string` matches the target union's `string` member via
   // tier 1, so the `unit`/None member is unreachable — even the literal
-  // "undefined" round-trips to Some, never None.
+  // "undefined" stays Some, never None.
   t->Assert.deepEqual("abc"->S.parseOrThrow(~to=schema), Some("abc"))
-  // FIXME: surprising — "undefined" parses to Some("undefined"), never None.
   t->Assert.deepEqual("undefined"->S.parseOrThrow(~to=schema), Some("undefined"))
 
-  // Encode reverses to source union [string, unit] -> target string. Each source
-  // variant resolves its tier ladder independently (targets are not consumed):
-  // `string` -> `string` is tier 1 identity; `unit`/None falls through to tier 3.
+  // Encode reverses to source union [string, unit] -> target string. The `string`
+  // variant claims the `string` target (tier 1, exclusive), so the `unit`/None
+  // variant has no target left: it errors instead of stringifying to "undefined".
   t->Assert.deepEqual(Some("abc")->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"abc"`))
-  // FIXME: invalid — None should fail with invalid type, because the `string`
-  // target is already taken by the tier-1 `string` match. Instead tier 3 coerces
-  // the `undefined` literal to the string "undefined". This also breaks
-  // round-tripping: encode(None) -> "undefined" -> parse -> Some("undefined").
-  t->Assert.deepEqual(None->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"undefined"`))
+  t->U.assertThrowsMessage(
+    () => None->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    `Expected never, received undefined`,
+  )
 
   t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{typeof i==="string"||e[0](i);return i}`)
-  // FIXME: invalid — the `i===void 0` branch should fail with invalid type
-  // (`e[..](i)`), not coerce to the string "undefined".
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Encode,
-    `i=>{if(i===void 0){i="undefined"}else if(!(typeof i==="string")){e[0](i)}return i}`,
+    `i=>{if(i===void 0){e[0](i);}else if(!(typeof i==="string")){e[1](i)}return i}`,
   )
 })
 
@@ -568,15 +564,17 @@ test("Coerce from optional string to null (tier 2: nullish bridge, None <-> null
   t->Assert.deepEqual(%raw(`"x"`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"x"`))
   t->Assert.deepEqual(%raw(`null`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`undefined`))
 
+  // Reservation gives each nullish variant its single bridged target, so the
+  // codegen is a direct assignment — no try/catch dispatch wrapper.
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Parse,
-    `i=>{if(i===void 0){try{i=null}catch(e1){e[0](i,e1)}}else if(!(typeof i==="string")){e[1](i)}return i}`,
+    `i=>{if(i===void 0){i=null}else if(!(typeof i==="string")){e[0](i)}return i}`,
   )
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Encode,
-    `i=>{if(i===null){try{i=void 0}catch(e1){e[0](i,e1)}}else if(!(typeof i==="string")){e[1](i)}return i}`,
+    `i=>{if(i===null){i=void 0}else if(!(typeof i==="string")){e[0](i)}return i}`,
   )
 })
 
@@ -960,10 +958,17 @@ test("Tier 1: source tag matches a target variant — identity wins, no cross-ty
 
   t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{typeof i==="string"||e[0](i);return i}`)
   t->U.assertCompiledCodeIsNoop(~schema, ~op=#Convert)
+  // Encode reverses to source union [bool, string] -> target string. The `string`
+  // variant claims the `string` target (tier 1, exclusive), so the `bool` variant
+  // can no longer coerce into it — it has no target left and errors.
+  t->U.assertThrowsMessage(
+    () => %raw(`true`)->S.decodeOrThrow(~from=schema, ~to=S.unknown),
+    `Expected never, received true`,
+  )
   t->U.assertCompiledCode(
     ~schema,
     ~op=#Encode,
-    `i=>{if(typeof i==="boolean"){i=""+i}else if(!(typeof i==="string")){e[0](i)}return i}`,
+    `i=>{if(typeof i==="boolean"){e[0](i);}else if(!(typeof i==="string")){e[1](i)}return i}`,
   )
 })
 
@@ -1243,8 +1248,13 @@ test("Converts union nested in object into a single schema (each source variant 
       }
     )->S.to(S.schema(s => {"f": s.matches(S.string)}))
 
-  t->Assert.deepEqual({"f": %raw(`123`)}->S.parseOrThrow(~to=schema), {"f": %raw(`"123"`)})
+  // The `string` variant claims the `string` target (tier 1, exclusive), so the
+  // `float` variant has no target left and errors — it is not coerced to a string.
   t->Assert.deepEqual({"f": %raw(`"abc"`)}->S.parseOrThrow(~to=schema), {"f": %raw(`"abc"`)})
+  t->U.assertThrowsMessage(
+    () => {"f": %raw(`123`)}->S.parseOrThrow(~to=schema),
+    `Failed at ["f"]: Expected never, received 123`,
+  )
 })
 
 test("Union variant failing to decode to the target reports an aggregated error", t => {
@@ -1334,8 +1344,13 @@ test("Converts union nested in tuple into a single schema (each source variant s
       s.matches(S.bool),
     ))->S.to(S.schema(s => (s.matches(S.string), s.matches(S.bool))))
 
-  t->Assert.deepEqual(%raw(`[123, true]`)->S.parseOrThrow(~to=schema), %raw(`["123", true]`))
+  // `string` claims the `string` target (tier 1, exclusive); the `float` variant
+  // has no target left and errors rather than coercing to a string.
   t->Assert.deepEqual(%raw(`["abc", false]`)->S.parseOrThrow(~to=schema), %raw(`["abc", false]`))
+  t->U.assertThrowsMessage(
+    () => %raw(`[123, true]`)->S.parseOrThrow(~to=schema),
+    `Failed at ["0"]: Expected never, received 123`,
+  )
 })
 
 asyncTest("Converts union nested in object into an async target (each source variant separately)", async t => {
@@ -1352,13 +1367,16 @@ asyncTest("Converts union nested in object into an async target (each source var
       ),
     )
 
-  t->Assert.deepEqual(
-    await %raw(`{f: 123}`)->S.parseAsyncOrThrow(~to=schema),
-    {"f": "123"},
-  )
+  // `string` claims the `string` target (tier 1, exclusive); the `float` variant
+  // has no target left and errors rather than coercing to a string. The error is
+  // synchronous (it fires while narrowing, before the async string arm runs).
   t->Assert.deepEqual(
     await %raw(`{f: "abc"}`)->S.parseAsyncOrThrow(~to=schema),
     {"f": "abc"},
+  )
+  t->U.assertThrowsMessage(
+    () => %raw(`{f: 123}`)->S.parseOrThrow(~to=schema),
+    `Failed at ["f"]: Expected never, received 123`,
   )
 })
 

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -518,6 +518,36 @@ test("Coerce from string to optional bool", t => {
   )
 })
 
+test("Coerce from string to optional string (FIXME: asymmetric None handling)", t => {
+  let schema = S.string->S.to(S.option(S.string))
+
+  // Parse: the source `string` matches the target union's `string` member via
+  // tier 1, so the `unit`/None member is unreachable — even the literal
+  // "undefined" round-trips to Some, never None.
+  t->Assert.deepEqual("abc"->S.parseOrThrow(~to=schema), Some("abc"))
+  // FIXME: surprising — "undefined" parses to Some("undefined"), never None.
+  t->Assert.deepEqual("undefined"->S.parseOrThrow(~to=schema), Some("undefined"))
+
+  // Encode reverses to source union [string, unit] -> target string. Each source
+  // variant resolves its tier ladder independently (targets are not consumed):
+  // `string` -> `string` is tier 1 identity; `unit`/None falls through to tier 3.
+  t->Assert.deepEqual(Some("abc")->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"abc"`))
+  // FIXME: invalid — None should fail with invalid type, because the `string`
+  // target is already taken by the tier-1 `string` match. Instead tier 3 coerces
+  // the `undefined` literal to the string "undefined". This also breaks
+  // round-tripping: encode(None) -> "undefined" -> parse -> Some("undefined").
+  t->Assert.deepEqual(None->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"undefined"`))
+
+  t->U.assertCompiledCode(~schema, ~op=#Parse, `i=>{typeof i==="string"||e[0](i);return i}`)
+  // FIXME: invalid — the `i===void 0` branch should fail with invalid type
+  // (`e[..](i)`), not coerce to the string "undefined".
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Encode,
+    `i=>{if(i===void 0){i="undefined"}else if(!(typeof i==="string")){e[0](i)}return i}`,
+  )
+})
+
 test("Coerce from object to string", t => {
   let schema = S.schema(s =>
     {

--- a/packages/sury/tests/S_to_test.res
+++ b/packages/sury/tests/S_to_test.res
@@ -548,6 +548,38 @@ test("Coerce from string to optional string (FIXME: asymmetric None handling)", 
   )
 })
 
+test("Coerce from optional string to null (tier 2: nullish bridge, None <-> null)", t => {
+  let schema = S.option(S.string)->S.to(S.null(S.string))
+
+  // Parse: source union [string, unit] -> target [string, null]. The `string`
+  // variant matches via tier 1; the `unit`/None variant has no `undefined`
+  // target, so tier 2 bridges it to the opposite nullish target `null` — it does
+  // not fall through to a tier-3 "undefined" stringification.
+  t->Assert.deepEqual("x"->S.parseOrThrow(~to=schema), %raw(`"x"`))
+  t->Assert.deepEqual(%raw(`undefined`)->S.parseOrThrow(~to=schema), %raw(`null`))
+  // `null` is not a valid input here (the input type is string | undefined).
+  t->U.assertThrowsMessage(
+    () => %raw(`null`)->S.parseOrThrow(~to=schema),
+    `Expected string | undefined, received null`,
+  )
+
+  // Encode reverses symmetrically: source [string, null] -> target [string, unit].
+  // The `null` variant bridges to the opposite nullish target `undefined`/None.
+  t->Assert.deepEqual(%raw(`"x"`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`"x"`))
+  t->Assert.deepEqual(%raw(`null`)->S.decodeOrThrow(~from=schema, ~to=S.unknown), %raw(`undefined`))
+
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Parse,
+    `i=>{if(i===void 0){try{i=null}catch(e1){e[0](i,e1)}}else if(!(typeof i==="string")){e[1](i)}return i}`,
+  )
+  t->U.assertCompiledCode(
+    ~schema,
+    ~op=#Encode,
+    `i=>{if(i===null){try{i=void 0}catch(e1){e[0](i,e1)}}else if(!(typeof i==="string")){e[1](i)}return i}`,
+  )
+})
+
 test("Coerce from object to string", t => {
   let schema = S.schema(s =>
     {


### PR DESCRIPTION
## Summary

Refactors the union decoder to use a three-tier reservation algorithm for assigning source variants to target variants when compiling `source → targetUnion`. This improves correctness by preventing unreachable variants and enables better code generation through per-case `.to` application.

## Key Changes

- **New `unionReservable` function**: Identifies variants that can participate in reservation (primitives, literals, null/undefined/NaN with no transformations).

- **New `unionAssignTargets` function**: Implements three-tier target assignment:
  - **Tier 1**: Same-type match with exact const preferred (reserved, exclusive)
  - **Tier 2**: Nullish bridge to opposite null/undefined (reserved, exclusive)
  - **Tier 3**: Remaining reservable variants coerce over free targets; non-reservable variants keep full target
  - Variants with no target assigned map to `never` and fail at runtime

- **New helper functions**: `unionTypeValidationSchema`, `unionPrioritizeConst`, `unionActiveKey`, `unionIsPassthrough`, `unionRefinerAttacher`, `unionFail` — extracted from inline union decoder logic for clarity and reusability.

- **Refactored `unionDecoder`**: Now delegates to `unionEmit` for the dispatch generation, using `unionIsPassthrough` to detect when input can be returned unchanged.

- **Per-case `.to` application**: When a union has a `.to` transformation and active key narrowing isn't possible, each variant's schema is updated with its assigned target and union refiners are attached per-case via `unionRefinerAttacher`.

- **Code formatting**: Fixed indentation and formatting throughout the union decoder section and related functions to match project conventions.

## Implementation Details

The reservation algorithm ensures that when coercing `source → targetUnion`:
- A `string` source variant claims the `string` target variant (tier 1), leaving `unit`/None unreachable
- A `null` source can bridge to `undefined` target if no same-type match exists (tier 2)
- Structural variants (objects, arrays, instances, refs, nested unions) and transforming variants keep the full target and dispatch at runtime (tier 3)

This prevents silent data loss and makes union coercion semantics explicit and predictable. The refactored code is more maintainable with extracted helper functions that can be tested and reasoned about independently.

https://claude.ai/code/session_01CuMuwLb7tufLms3U3Gs3Kv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified union conversion rules, including direct-match priority, nullish bridging, target reservation, and coercion behavior.
  * Added examples explaining exclusive matching and how to opt into cross-type transformations.

* **Behavior Changes**
  * Union conversions now prevent unmatched source variants from reusing targets claimed by direct matches.
  * Missing required fields and invalid `"undefined"` values now produce clear validation errors.
  * Improved synchronous error reporting for invalid union branches.

* **Refactor**
  * Improved internal union dispatch and shaped-schema processing without changing the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->