### PR TITLE
Add ts.aliases to verify alternate schema spellings

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -5,31 +5,31 @@ description: Develop Sury with the spec CLI. Use whenever changing Sury core log
 
 # Sury specs
 
-One `specs/<id>.yaml` = one schema's full contract: type, JSON Schema, and per-operation codegen + examples. You author only the schema and example *inputs*; `pnpm spec` (from repo root) derives every golden — **never hand-write one**.
+One `specs/<id>.yaml` = one schema's contract: type, JSON Schema, per-operation codegen + examples. You author only the schema and example *inputs*; `pnpm spec` derives every golden — **never hand-write one**.
 
 ## Workflow
 
 ```bash
 pnpm spec new --id <id> --ts "S.string.with(S.min, 3)"  # scaffold
 # edit specs/<id>.yaml: add example inputs under each op's `examples`
-pnpm spec check --write [id]   # (re)derive goldens from the live schema
+pnpm spec check --write [id]   # (re)derive goldens
 pnpm spec check [id]           # gate; omit [id] for all specs
 ```
 
-To add a case: add a named entry with just `input` under an op's `examples`, then `check --write`.
-The CLI strictly enforces the format — follow its error messages. Ops you can't assert take `_skip: <reason>`; ops that compile to a pass-through must be the bare literal `identity`.
+Add a case: named entry with just `input` under an op's `examples`, then `check --write`.
+Follow the CLI's error messages. Unassertable ops take `_skip: <reason>`; pass-through ops must be the bare literal `identity`.
 
-Examples must include every edge case you discover while working on or investigating the schema — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corner cases, values that exercise each branch of the generated check. If an edge case surfaced in a bug report, review, or investigation, it goes into `examples` before the work is done — the spec is where such findings are pinned, not test files or commit messages.
+Examples must cover every edge case found while investigating the schema — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corners, each generated-check branch. Findings from a bug report/review go into `examples`, not test files or commit messages.
 
 ## Aliases
 
-`ts.aliases` is an optional list of alternate `.with`-chain sources that should behave identically to `ts.schema` — e.g. a shorthand spelling (plain nested object literal instead of an explicit `S.schema(...)`) of the same schema. `spec check` evaluates each alias live and confirms it produces the same `ts.input`/`ts.output`, `jsonSchema`, and operation codegen as `ts.schema` — no separate goldens to maintain, and no examples of its own.
+`ts.aliases`: optional alternate `.with`-chain sources that must behave identically to `ts.schema` (e.g. a shorthand spelling of the same schema). `spec check` verifies matching `ts.input`/`ts.output`, `jsonSchema`, and operation codegen live — no separate goldens or examples.
 
 ## Specs are a metrics ratchet
 
-Goldens snapshot the library's key metrics per schema: generated code (`expression`), `ts.bundleBytes`, `ts.instantiations`, inferred types. When changing core logic, run `pnpm spec check --write` and **review the golden diff as the deliverable**: every metric should improve or stay flat. A regression is a design smell — rework the change; if genuinely impossible, call it out explicitly in the commit/PR.
+Goldens snapshot key metrics: generated code, `ts.bundleBytes`, `ts.instantiations`, inferred types. After core-logic changes, run `pnpm spec check --write` and **review the golden diff as the deliverable** — every metric should improve or stay flat. A regression is a design smell; if unavoidable, call it out in the commit/PR.
 
 ## Layout
 
-- `packages/sury/specs/*.yaml` — specs; published with the package as machine-checked documentation.
-- `packages/spec/` — the spec CLI. Don't touch it when working on Sury itself; if it should have caught or guided something better, add a bullet under **Spec Harness Suggestions** in `CONTRIBUTING.md`.
+- `packages/sury/specs/*.yaml` — specs; published as machine-checked documentation.
+- `packages/spec/` — the spec CLI. Don't touch it for Sury-itself work; gaps go under **Spec Harness Suggestions** in `CONTRIBUTING.md`.

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -5,7 +5,7 @@ description: Develop Sury with the spec CLI. Use whenever changing Sury core log
 
 # Sury specs
 
-One `specs/<id>.yaml` = one schema's contract: type, JSON Schema, per-operation codegen + examples. You author only the schema and example *inputs*; `pnpm spec` derives every golden — **never hand-write one**.
+One `specs/<id>.yaml` = one schema's contract: type, JSON Schema, per-operation codegen + examples. You author the schema, any aliases, and example *inputs*; `pnpm spec` derives every golden — **never hand-write one**.
 
 ## Workflow
 

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -21,6 +21,10 @@ The CLI strictly enforces the format — follow its error messages. Ops you can'
 
 Examples must include every edge case you discover while working on or investigating the schema — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corner cases, values that exercise each branch of the generated check. If an edge case surfaced in a bug report, review, or investigation, it goes into `examples` before the work is done — the spec is where such findings are pinned, not test files or commit messages.
 
+## Aliases
+
+`ts.aliases` is an optional list of alternate `.with`-chain sources that should behave identically to `ts.schema` — e.g. a shorthand spelling (plain nested object literal instead of an explicit `S.schema(...)`) of the same schema. `spec check` evaluates each alias live and confirms it produces the same `ts.input`/`ts.output`, `jsonSchema`, and operation codegen as `ts.schema` — no separate goldens to maintain, and no examples of its own.
+
 ## Specs are a metrics ratchet
 
 Goldens snapshot the library's key metrics per schema: generated code (`expression`), `ts.bundleBytes`, `ts.instantiations`, inferred types. When changing core logic, run `pnpm spec check --write` and **review the golden diff as the deliverable**: every metric should improve or stay flat. A regression is a design smell — rework the change; if genuinely impossible, call it out explicitly in the commit/PR.

--- a/packages/spec/format.ts
+++ b/packages/spec/format.ts
@@ -112,6 +112,12 @@ const ts = S.schema({
       "The schema under test, as JS `.with`-chain source (e.g. `S.string.with(S.min, 3)`). " +
       "You write this by hand; `spec check --write` never touches it.",
   }),
+  aliases: S.optional(S.array(S.string)).with(S.meta, {
+    description:
+      "Alternate `.with`-chain sources that must produce a schema equivalent to `schema` — " +
+      "same ts.input/ts.output, jsonSchema, and operations. Checked live (not separately " +
+      "snapshotted) by `spec check`. You write these by hand.",
+  }),
   input: orSkip(S.string).with(S.meta, {
     description: "`S.Input<typeof schema>` as a TS type string. Filled by `spec check --write`.",
   }),
@@ -157,6 +163,7 @@ const keyOrder = <T,>(order: Record<keyof T, true>) => Object.keys(order) as (ke
 export const KEY_ORDER = keyOrder<Spec>({ ts: true, jsonSchema: true, operations: true });
 export const TS_KEY_ORDER = keyOrder<Spec["ts"]>({
   schema: true,
+  aliases: true,
   input: true,
   output: true,
   instantiations: true,

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -374,6 +374,60 @@ const diffText = (a: string, b: string): string =>
     contextLines: 3,
   });
 
+// Confirms each `ts.aliases` entry evaluates to a schema equivalent to
+// `ts.schema` — same ts.input/ts.output, jsonSchema, and operations —
+// without giving an alias its own goldens to maintain. Compared directly
+// against the (already-validated) `spec`'s recorded values rather than
+// against each other, so a drifting alias is reported against the one
+// spelling the author actually reads top-to-bottom.
+export const checkAliases = async (spec: Spec): Promise<string[]> => {
+  const aliases = spec.ts.aliases;
+  if (!aliases || !aliases.length) return [];
+  const errs: string[] = [];
+  for (const aliasSrc of aliases) {
+    const label = `ts.aliases[${JSON.stringify(aliasSrc)}]`;
+    let aliasSchema: any;
+    try {
+      aliasSchema = evalSchema(aliasSrc);
+    } catch (e) {
+      errs.push(`${label}: did not evaluate: ${(e as Error).message}`);
+      continue;
+    }
+    if (!isUsableSchema(aliasSchema)) {
+      errs.push(`${label}: evaluated but isn't a Sury schema`);
+      continue;
+    }
+
+    if (!isSkip(spec.ts.input) || !isSkip(spec.ts.output)) {
+      const info = await deriveTypeInfo(aliasSrc);
+      if (!isSkip(spec.ts.input) && info.input !== spec.ts.input)
+        errs.push(`${label}: ts.input ${JSON.stringify(info.input)} !== ${JSON.stringify(spec.ts.input)}`);
+      if (!isSkip(spec.ts.output) && info.output !== spec.ts.output)
+        errs.push(`${label}: ts.output ${JSON.stringify(info.output)} !== ${JSON.stringify(spec.ts.output)}`);
+    }
+
+    const js = deriveJsonSchema(aliasSchema);
+    if (js.input !== spec.jsonSchema.input)
+      errs.push(`${label}: jsonSchema.input differs:\n${diffText(spec.jsonSchema.input, js.input)}`);
+    if (js.output !== spec.jsonSchema.output)
+      errs.push(`${label}: jsonSchema.output differs:\n${diffText(spec.jsonSchema.output, js.output)}`);
+
+    for (const opName of OP_ORDER) {
+      const op = spec.operations[opName];
+      const fn = OP_BUILDER[opName](aliasSchema);
+      const noop = isNoop(fn);
+      if (op === "identity") {
+        if (!noop) errs.push(`${label}: operations.${opName} is \`identity\` on schema but not on this alias`);
+      } else if (noop) {
+        errs.push(`${label}: operations.${opName} compiles to identity on this alias but not on schema`);
+      } else if (!isSkip(op.expression) && fn.toString() !== op.expression) {
+        errs.push(`${label}: operations.${opName}.expression differs:\n${diffText(op.expression, fn.toString())}`);
+      }
+    }
+  }
+  return errs;
+};
+
 // Never mutates a file or exits the process, so it's directly testable —
 // cli.ts's cmdCheck and tests/spec_errors_test.ts both call this same
 // function, so there's exactly one implementation of "what's wrong with this
@@ -425,6 +479,7 @@ export const checkSpec = async (
             : `goldens stale — run \`pnpm spec check ${id} --write\` (also formats canonically; use \`pnpm spec format\` for a formatting-only fix)`) +
             `:\n${diffText(canon, fresh)}`,
         );
+      errs.push(...(await checkAliases(spec)));
     } catch (e) {
       errs.push(`goldens could not be computed: ${(e as Error).message}`);
     }

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -398,31 +398,39 @@ export const checkAliases = async (spec: Spec): Promise<string[]> => {
       continue;
     }
 
-    if (!isSkip(spec.ts.input) || !isSkip(spec.ts.output)) {
-      const info = await deriveTypeInfo(aliasSrc);
-      if (!isSkip(spec.ts.input) && info.input !== spec.ts.input)
-        errs.push(`${label}: ts.input ${JSON.stringify(info.input)} !== ${JSON.stringify(spec.ts.input)}`);
-      if (!isSkip(spec.ts.output) && info.output !== spec.ts.output)
-        errs.push(`${label}: ts.output ${JSON.stringify(info.output)} !== ${JSON.stringify(spec.ts.output)}`);
-    }
-
-    const js = deriveJsonSchema(aliasSchema);
-    if (js.input !== spec.jsonSchema.input)
-      errs.push(`${label}: jsonSchema.input differs:\n${diffText(spec.jsonSchema.input, js.input)}`);
-    if (js.output !== spec.jsonSchema.output)
-      errs.push(`${label}: jsonSchema.output differs:\n${diffText(spec.jsonSchema.output, js.output)}`);
-
-    for (const opName of OP_ORDER) {
-      const op = spec.operations[opName];
-      const fn = OP_BUILDER[opName](aliasSchema);
-      const noop = isNoop(fn);
-      if (op === "identity") {
-        if (!noop) errs.push(`${label}: operations.${opName} is \`identity\` on schema but not on this alias`);
-      } else if (noop) {
-        errs.push(`${label}: operations.${opName} compiles to identity on this alias but not on schema`);
-      } else if (!isSkip(op.expression) && fn.toString() !== op.expression) {
-        errs.push(`${label}: operations.${opName}.expression differs:\n${diffText(op.expression, fn.toString())}`);
+    // Isolated per alias — a throw here (e.g. deriveTypeInfo failing to
+    // resolve the alias's type) must not abort the remaining aliases or
+    // surface as the outer, label-less "goldens could not be computed".
+    try {
+      if (!isSkip(spec.ts.input) || !isSkip(spec.ts.output)) {
+        const info = await deriveTypeInfo(aliasSrc);
+        if (!isSkip(spec.ts.input) && info.input !== spec.ts.input)
+          errs.push(`${label}: ts.input ${JSON.stringify(info.input)} !== ${JSON.stringify(spec.ts.input)}`);
+        if (!isSkip(spec.ts.output) && info.output !== spec.ts.output)
+          errs.push(`${label}: ts.output ${JSON.stringify(info.output)} !== ${JSON.stringify(spec.ts.output)}`);
       }
+
+      const js = deriveJsonSchema(aliasSchema);
+      if (js.input !== spec.jsonSchema.input)
+        errs.push(`${label}: jsonSchema.input differs:\n${diffText(spec.jsonSchema.input, js.input)}`);
+      if (js.output !== spec.jsonSchema.output)
+        errs.push(`${label}: jsonSchema.output differs:\n${diffText(spec.jsonSchema.output, js.output)}`);
+
+      for (const opName of OP_ORDER) {
+        const op = spec.operations[opName];
+        const fn = OP_BUILDER[opName](aliasSchema);
+        const noop = isNoop(fn);
+        if (op === "identity") {
+          if (!noop) errs.push(`${label}: operations.${opName} is \`identity\` on schema but not on this alias`);
+        } else if (noop) {
+          errs.push(`${label}: operations.${opName} compiles to identity on this alias but not on schema`);
+        } else if (!isSkip(op.expression) && fn.toString() !== op.expression) {
+          errs.push(`${label}: operations.${opName}.expression differs:\n${diffText(op.expression, fn.toString())}`);
+        }
+      }
+    } catch (e) {
+      errs.push(`${label}: could not be checked: ${(e as Error).message}`);
+      continue;
     }
   }
   return errs;

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -1,11 +1,11 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  schema: "S.schema({a: S.string, nested: S.schema({b: S.number, inner: S.schema({c: S.boolean, d: S.optional(S.string)})})})"
+  schema: "S.schema({a: S.string, nested: {b: S.number, inner: {c: S.boolean, d: S.optional(S.string)}}})"
   aliases:
-    - "S.schema({a: S.string, nested: S.schema({b: S.number, inner: {c: S.boolean, d: S.optional(S.string)}})})"
+    - "S.schema({a: S.string, nested: S.schema({b: S.number, inner: S.schema({c: S.boolean, d: S.optional(S.string)})})})"
   input: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
   output: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
-  instantiations: 5096
+  instantiations: 2789
   bundleBytes: 10437
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "string" }, nested: { type: "object", properties: { b: { type: "number" }, inner: { type: "object", properties: { c: { type: "boolean" }, d: { type: "string" } }, required: ["c"] } }, required: ["b", "inner"] } }, required: ["a", "nested"] }'

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: "S.schema({a: S.string, nested: S.schema({b: S.number, inner: S.schema({c: S.boolean, d: S.optional(S.string)})})})"
+  aliases:
+    - "S.schema({a: S.string, nested: S.schema({b: S.number, inner: {c: S.boolean, d: S.optional(S.string)}})})"
   input: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
   output: "{ a: string; nested: { b: number; inner: { d?: string | undefined; c: boolean; }; }; }"
   instantiations: 5096

--- a/packages/sury/specs/spec.schema.json
+++ b/packages/sury/specs/spec.schema.json
@@ -8,6 +8,13 @@
           "type": "string",
           "description": "The schema under test, as JS `.with`-chain source (e.g. `S.string.with(S.min, 3)`). You write this by hand; `spec check --write` never touches it."
         },
+        "aliases": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Alternate `.with`-chain sources that must produce a schema equivalent to `schema` — same ts.input/ts.output, jsonSchema, and operations. Checked live (not separately snapshotted) by `spec check`. You write these by hand."
+        },
         "input": {
           "anyOf": [
             {

--- a/packages/sury/specs/union5-discriminated.yaml
+++ b/packages/sury/specs/union5-discriminated.yaml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  schema: 'S.union([S.schema({kind: "a", a: S.string}), S.schema({kind: "b", b: S.number}), S.schema({kind: "c", c: S.boolean}), S.schema({kind: "d", d: S.bigint}), S.schema({kind: "e", e: S.symbol})])'
+  schema: 'S.union([{kind: "a", a: S.string}, {kind: "b", b: S.number}, {kind: "c", c: S.boolean}, {kind: "d", d: S.bigint}, {kind: "e", e: S.symbol}])'
+  aliases:
+    - 'S.union([S.schema({kind: "a", a: S.string}), S.schema({kind: "b", b: S.number}), S.schema({kind: "c", c: S.boolean}), S.schema({kind: "d", d: S.bigint}), S.schema({kind: "e", e: S.symbol})])'
   input: "{ kind: string; a: string; } | { kind: string; b: number; } | { kind: string; c: boolean; } | { kind: string; d: bigint; } | { kind: string; e: symbol; }"
   output: "{ kind: string; a: string; } | { kind: string; b: number; } | { kind: string; c: boolean; } | { kind: string; d: bigint; } | { kind: string; e: symbol; }"
-  instantiations: 10100
+  instantiations: 4789
   bundleBytes: 9906
 jsonSchema:
   input: 'Failed at ["d"]: Expected JSON, received bigint'

--- a/packages/sury/tests/spec_test.ts
+++ b/packages/sury/tests/spec_test.ts
@@ -14,6 +14,7 @@ import {
   recomputeGoldens,
   evalSchema,
   identityViolations,
+  checkAliases,
   lintSkips,
   lintSpecsDir,
 } from "../../spec/harness";
@@ -82,6 +83,14 @@ describe.each(specs)("spec: $id", ({ file }) => {
 
   test("goldens match live behavior (run `pnpm spec check --write`)", async () => {
     expect(serialize(await recomputeGoldens(spec))).toBe(serialize(spec));
+  });
+
+  // Only checkSpec runs this too — same reasoning as the identity-invariant
+  // test above: a drifting `ts.aliases` entry should fail `pnpm test`, not
+  // just the occasional manual `pnpm spec check`.
+  test("aliases (if any) are equivalent to the schema (run `pnpm spec check`)", async () => {
+    const errs = await checkAliases(spec);
+    expect(errs, errs.join("\n")).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Introduces `ts.aliases` — an optional list of alternate `.with`-chain sources that must behave identically to the primary `ts.schema`. This allows specs to document and verify shorthand or equivalent spellings without maintaining separate goldens.

## Changes

- **harness.ts**: Added `checkAliases()` function that validates each alias evaluates to a schema with matching `ts.input`/`ts.output`, `jsonSchema`, and operation codegen. Integrated into `checkSpec()` so alias drift is caught by both `pnpm spec check` and `pnpm test`.

- **format.ts**: Added `aliases` field to the `ts` schema definition with description and proper key ordering (after `schema`, before `input`).

- **spec_test.ts**: Added test case that runs `checkAliases()` on every spec, ensuring aliases stay in sync with the primary schema during development.

- **spec.schema.json**: Updated JSON Schema to include the new `aliases` field.

- **SKILL.md**: Documented the aliases feature and clarified spec workflow language.

- **Example specs**: Updated `object-in-object3.yaml` and `union5-discriminated.yaml` to demonstrate aliases by moving verbose `S.schema()` wrappers into aliases while simplifying the primary schema. This also reduced `instantiations` metrics (2789 and 4789 vs. prior 5096 and 10100), showing the benefit of the cleaner primary spelling.

## Implementation details

- Aliases are checked live against the spec's recorded golden values (not against each other), so drift is reported against the canonical schema the author reads top-to-bottom.
- No separate goldens or examples are maintained for aliases — they inherit validation from the primary schema.
- The check runs in both `checkSpec()` (manual `pnpm spec check`) and the test suite, catching regressions early.

https://claude.ai/code/session_01Km4BZmSuG6SXLvcQz1jVaA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Schema specifications can now include optional alternate equivalent representations via `aliases`.
  - Added validation to confirm each alias produces matching derived TypeScript I/O, JSON Schema I/O, and operation behavior.

- **Bug Fixes**
  - Improved detection/reporting when an alias’s derived artifacts don’t match the canonical schema.

- **Documentation**
  - Updated the specification-auth workflow guide with clearer rules for aliases and golden/guidance for checks.

- **Tests**
  - Added per-spec test coverage to ensure alias equivalence checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->