### PR TITLE
Refactor B_joinCode to return strings instead of mutating

### DIFF
--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -190,33 +190,28 @@ export const B_addCode = (val: Val, code: Code): void => {
       : [val.cp, code];
 }
 
-// The single stringification point: flattens the rope into `joinAcc`,
+// The single stringification point: flattens the rope into a string,
 // resolving each val marker to its codeFromPrev + checks + hoisted decls.
 // Resolving a val seals it — after its slots have been read into a string,
 // a late materialization can no longer emit there and must fall back to an
 // inline re-read. Mid-compile joins (closure bodies, discarded empty
 // trees) therefore need no extra bookkeeping: joining IS freezing.
-let joinAcc = "";
-const joinWalk = (code: Code): void => {
-  if (typeof code === "string") {
-    joinAcc = joinAcc + code;
-  } else if (Array.isArray(code)) {
-    for (let i = 0; i < code.length; i++) {
-      joinWalk(code[i]!);
-    }
-  } else {
-    code.fz = true;
-    joinWalk(code.cp);
-    joinAcc = joinAcc + code.ck!;
-    if (code.hd !== "") {
-      joinAcc = joinAcc + `let ${code.hd};`;
-    }
-  }
-}
+// Returns its result rather than accumulating into a shared field, so a
+// join nested inside another (a closure body resolved mid-walk) can't
+// corrupt the outer one.
 export const B_joinCode = (code: Code): string => {
-  joinAcc = "";
-  joinWalk(code);
-  return joinAcc;
+  if (typeof code === "string") {
+    return code;
+  }
+  if (Array.isArray(code)) {
+    let acc = "";
+    for (let i = 0; i < code.length; i++) {
+      acc = acc + B_joinCode(code[i]!);
+    }
+    return acc;
+  }
+  code.fz = true;
+  return B_joinCode(code.cp) + code.ck + (code.hd !== "" ? `let ${code.hd};` : "");
 }
 
 
@@ -506,6 +501,8 @@ export const B_merge = (val: Val, hoistCond?: { contents: string; pl?: boolean }
         // the cond routes between union cases, it doesn't reject, so
         // suppressing would break dispatch.
         const inputVar = liftInput;
+        // `liftInput` is only set when `hoistCond` is defined.
+        const cond = hoistCond!;
         const allChecks = val.vc!;
         let localHoist = "";
         for (let i = 0; i < allChecks.length; i++) {
@@ -529,9 +526,8 @@ export const B_merge = (val: Val, hoistCond?: { contents: string; pl?: boolean }
             // The cond now carries a rejecting validation, not just a
             // routing discriminant — an only-case must emit the exhaustive
             // else instead of falling through (see unionDecoder).
-            hoistCond!.pl = true;
+            cond.pl = true;
           }
-          const cond = hoistCond!;
           if (cond.contents) {
             cond.contents = `${localHoist}&&${cond.contents}`;
           } else {

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -1494,7 +1494,7 @@ export const valGet = (parent: Val, location: string): Val => {
       s: schema,
       e: schema,
       cp: "",
-    ck: "",
+      ck: "",
       hd: "",
       path: pathConcat(parent.path, pathAppend),
       g: parent.g,

--- a/packages/sury/src/types.ts
+++ b/packages/sury/src/types.ts
@@ -234,8 +234,9 @@ export type Val = {
   // @as("cp") — codeFromPrev
   cp: Code;
   // Emitted checks code, set by `merge` when this val's segment is consed
-  // into the rope (the val doubles as its own hole). @as("ck") — checksCode
-  ck?: string;
+  // into the rope (the val doubles as its own hole). Initialized "" at every
+  // construction so the join can read it unconditionally. @as("ck") — checksCode
+  ck: string;
   // No-throw producer expression (e.g. `+i`): set by coercions whose
   // producing expression can never throw, so `merge(~hoistCond)` may fold
   // it into a union dispatch condition instead of deopting the case to

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -120,7 +120,7 @@ test("identity claimed but the operation doesn't actually compile to identity", 
     -   instantiations: 254
     -   bundleBytes: 4012
     +   instantiations: 5181
-    +   bundleBytes: 4499
+    +   bundleBytes: 4500
       jsonSchema:
     -   input: '{ type: "string" }'
     -   output: '{ type: "string" }'


### PR DESCRIPTION
## Summary

Refactored the code stringification logic to eliminate a shared mutable accumulator field, improving correctness for nested joins (e.g., closure bodies resolved mid-walk) and simplifying the implementation.

## Key Changes

- **Eliminated shared mutable state**: Removed the module-level `joinAcc` field that accumulated stringification results. This field could be corrupted when a nested join (like a closure body) was resolved during an outer join's walk.

- **Changed B_joinCode to return strings**: Converted `B_joinCode` from a void function that mutated `joinAcc` to one that returns accumulated strings directly. Each recursive call now builds its own local accumulator, preventing interference between nested joins.

- **Simplified implementation**: Inlined the former `joinWalk` helper into `B_joinCode`, reducing indirection and making the control flow clearer. The function now directly returns results rather than side-effecting into a shared field.

- **Updated Val.ck type**: Changed the `ck` field in the `Val` type from optional (`ck?: string`) to required (`ck: string`), initialized to `""` at construction. This allows `B_joinCode` to read it unconditionally without null checks, and the code now uses `code.ck` directly instead of `code.ck!`.

- **Improved code clarity**: Added a comment explaining why the function returns results rather than accumulating into a shared field, documenting the nested-join safety invariant.

- **Minor formatting fix**: Corrected indentation in `composites.ts` for consistency.

## Implementation Details

The refactoring maintains the same stringification semantics while improving safety. The key insight is that by returning strings instead of mutating a shared field, nested joins (which can occur when resolving closure bodies during code generation) cannot corrupt the outer join's accumulated result. This is a correctness fix that also simplifies the code by eliminating a class of subtle bugs.

https://claude.ai/code/session_01Tg7md9k6Qu9KxwnDquMEGZ