### PR TITLE
Support array literal syntax for tuple schemas

### DIFF
--- a/packages/sury/specs/literal-array.yaml
+++ b/packages/sury/specs/literal-array.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema(["bar", true])
+  aliases:
+    - S.literal(["bar", true])
   input: '["bar", true]'
   output: '["bar", true]'
   instantiations: 532

--- a/packages/sury/specs/literal-bigint.yaml
+++ b/packages/sury/specs/literal-bigint.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema(123n)
+  aliases:
+    - S.literal(123n)
   input: 123n
   output: 123n
   instantiations: 379

--- a/packages/sury/specs/literal-boolean.yaml
+++ b/packages/sury/specs/literal-boolean.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema(true)
+  aliases:
+    - S.literal(true)
   input: "true"
   output: "true"
   instantiations: 378

--- a/packages/sury/specs/literal-number.yaml
+++ b/packages/sury/specs/literal-number.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema(123)
+  aliases:
+    - S.literal(123)
   input: "123"
   output: "123"
   instantiations: 382

--- a/packages/sury/specs/literal-object.yaml
+++ b/packages/sury/specs/literal-object.yaml
@@ -4,6 +4,7 @@ ts:
   aliases:
     - 'S.schema({ foo: "bar" as const })'
     - 'S.schema({ foo: S.schema("bar") })'
+    - 'S.literal({ foo: "bar" })'
   input: '{ foo: "bar"; }'
   output: '{ foo: "bar"; }'
   instantiations: 1043

--- a/packages/sury/specs/literal-string.yaml
+++ b/packages/sury/specs/literal-string.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema("tuna")
+  aliases:
+    - S.literal("tuna")
   input: '"tuna"'
   output: '"tuna"'
   instantiations: 429

--- a/packages/sury/specs/literal-symbol.yaml
+++ b/packages/sury/specs/literal-symbol.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema(Symbol.for("tuna"))
+  aliases:
+    - S.literal(Symbol.for("tuna"))
   input: symbol
   output: symbol
   instantiations: 389

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -1,27 +1,30 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  schema: S.schema([S.string, S.number])
+  schema: S.schema(["bar", S.number])
   aliases:
-    - S.tuple([S.string, S.number])
-  input: "[string, number]"
-  output: "[string, number]"
-  instantiations: 1132
+    - S.tuple(["bar", S.number])
+  input: '["bar", number]'
+  output: '["bar", number]'
+  instantiations: 967
   bundleBytes: 9689
 jsonSchema:
-  input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string" }, { type: "number" }] }'
-  output: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string" }, { type: "number" }] }'
+  input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "bar" }, { type: "number" }] }'
+  output: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "bar" }, { type: "number" }] }'
 operations:
   parse:
-    expression: i=>{Array.isArray(i)&&i.length===2||e[2](i);let v0=i["0"],v1=i["1"];typeof v0==="string"||e[0](v0);typeof v1==="number"&&!Number.isNaN(v1)||e[1](v1);return i}
+    expression: i=>{Array.isArray(i)&&i.length===2||e[2](i);let v0=i["0"],v1=i["1"];v0==="bar"||e[0](v0);typeof v1==="number"&&!Number.isNaN(v1)||e[1](v1);return i}
     examples:
       valid:
-        input: '["hello", 42]'
-        output: '["hello", 42]'
+        input: '["bar", 42]'
+        output: '["bar", 42]'
       wrong-length:
-        input: '["hello"]'
-        error: Expected [string, number], received ["hello"]
+        input: '["bar"]'
+        error: Expected ["bar", number], received ["bar"]
+      invalid-literal:
+        input: '["baz", 42]'
+        error: 'Failed at ["0"]: Expected "bar", received "baz"'
       invalid-item:
-        input: '["hello", "not a number"]'
+        input: '["bar", "not a number"]'
         error: 'Failed at ["1"]: Expected number, received "not a number"'
   decode: identity
   encode: identity

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.schema([S.string, S.number])
+  aliases:
+    - S.tuple([S.string, S.number])
   input: "[string, number]"
   output: "[string, number]"
   instantiations: 1132

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -485,9 +485,6 @@ export function schema<const T>(
   value: T
 ): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
 
-export function literal<const T extends unknown[]>(
-  schemas: [...T]
-): Schema<[...UnknownArrayToOutput<T>], [...UnknownArrayToInput<T>]>;
 export function literal<const T>(
   value: T
 ): Schema<UnknownToOutput<T>, UnknownToInput<T>>;

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -485,6 +485,13 @@ export function schema<const T>(
   value: T
 ): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
 
+export function literal<const T extends unknown[]>(
+  schemas: [...T]
+): Schema<[...UnknownArrayToOutput<T>], [...UnknownArrayToInput<T>]>;
+export function literal<const T>(
+  value: T
+): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
+
 export function union<const A, const B extends unknown[]>(
   schemas: [A, ...B]
 ): Schema<

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -638,6 +638,9 @@ export function tuple<Output, Input extends unknown[]>(
     tag: (inputIndex: number, value: unknown) => void;
   }) => Output
 ): Schema<Output, Input>;
+export function tuple<const T extends unknown[]>(
+  schemas: [...T]
+): Schema<[...UnknownArrayToOutput<T>], [...UnknownArrayToInput<T>]>;
 
 export function optional<
   Output,

--- a/packages/sury/src/S.res
+++ b/packages/sury/src/S.res
@@ -519,10 +519,9 @@ module Tuple = {
 
 @module("sury") external tuple: (Tuple.s => 'value) => t<'value> = "tuple"
 let tuple1 = v0 => tuple(s => s.item(0, v0))
-// The public JS `tuple` also accepts an array definition directly.
-@module("sury") external tuple2: array<t<unknown>> => t<'value> = "tuple"
+@module("sury") external tuple2: array<t<unknown>> => t<'value> = "schema"
 let tuple2 = (v1, v2) => tuple2([castToUnknown(v1), castToUnknown(v2)])
-@module("sury") external tuple3: array<t<unknown>> => t<'value> = "tuple"
+@module("sury") external tuple3: array<t<unknown>> => t<'value> = "schema"
 let tuple3 = (v1, v2, v3) => tuple3([castToUnknown(v1), castToUnknown(v2), castToUnknown(v3)])
 
 module Option = {

--- a/packages/sury/src/S.res
+++ b/packages/sury/src/S.res
@@ -519,10 +519,10 @@ module Tuple = {
 
 @module("sury") external tuple: (Tuple.s => 'value) => t<'value> = "tuple"
 let tuple1 = v0 => tuple(s => s.item(0, v0))
-// An array definition passed to the public JS `schema` is a tuple schema.
-@module("sury") external tuple2: array<t<unknown>> => t<'value> = "schema"
+// The public JS `tuple` also accepts an array definition directly.
+@module("sury") external tuple2: array<t<unknown>> => t<'value> = "tuple"
 let tuple2 = (v1, v2) => tuple2([castToUnknown(v1), castToUnknown(v2)])
-@module("sury") external tuple3: array<t<unknown>> => t<'value> = "schema"
+@module("sury") external tuple3: array<t<unknown>> => t<'value> = "tuple"
 let tuple3 = (v1, v2, v3) => tuple3([castToUnknown(v1), castToUnknown(v2), castToUnknown(v3)])
 
 module Option = {

--- a/packages/sury/src/S.res.mjs
+++ b/packages/sury/src/S.res.mjs
@@ -77,14 +77,14 @@ function tuple1(v0) {
 }
 
 function tuple2(v1, v2) {
-  return Sury.schema([
+  return Sury.tuple([
     v1,
     v2
   ]);
 }
 
 function tuple3(v1, v2, v3) {
-  return Sury.schema([
+  return Sury.tuple([
     v1,
     v2,
     v3

--- a/packages/sury/src/S.res.mjs
+++ b/packages/sury/src/S.res.mjs
@@ -77,14 +77,14 @@ function tuple1(v0) {
 }
 
 function tuple2(v1, v2) {
-  return Sury.tuple([
+  return Sury.schema([
     v1,
     v2
   ]);
 }
 
 function tuple3(v1, v2, v3) {
-  return Sury.tuple([
+  return Sury.schema([
     v1,
     v2,
     v3

--- a/packages/sury/src/entry.ts
+++ b/packages/sury/src/entry.ts
@@ -92,7 +92,7 @@ export {
   global,
 } from "./jsapi";
 export { getDecoder as decoder, reverse, instance } from "./parse";
-export { js_schema as schema, js_schema as literal, enum } from "./factory";
+export { schemaFactory as schema, schemaFactory as literal, enum } from "./factory";
 export {
   recursive,
   strict,
@@ -161,4 +161,4 @@ export {
 } from "./refinements";
 // The ReScript-flavored schema factory (definer-callback ctx); the public JS
 // `schema` takes a raw definition instead.
-export { schemaFactory as $res_schema } from "./factory";
+export { schemaDefiner as $res_schema } from "./factory";

--- a/packages/sury/src/entry.ts
+++ b/packages/sury/src/entry.ts
@@ -92,7 +92,7 @@ export {
   global,
 } from "./jsapi";
 export { getDecoder as decoder, reverse, instance } from "./parse";
-export { js_schema as schema, literal, enum } from "./factory";
+export { js_schema as schema, js_schema as literal, enum } from "./factory";
 export {
   recursive,
   strict,

--- a/packages/sury/src/factory.ts
+++ b/packages/sury/src/factory.ts
@@ -644,11 +644,10 @@ export const schemaFactory = (definer: (ctx: unknown) => unknown): Internal => {
 export const js_schema = (definition: unknown): Internal => {
   return definitionToSchema(definition);
 }
-export const literal = js_schema;
 
 // PORT-NOTE: `enum` is a reserved word in TS — defined as `enum_` and
 // re-exported under the name `enum` (legal as an export alias).
 const enum_ = (values: unknown[]): Internal => {
-  return unionFactory(values.map(literal));
+  return unionFactory(values.map(js_schema));
 }
 export { enum_ as enum };

--- a/packages/sury/src/factory.ts
+++ b/packages/sury/src/factory.ts
@@ -9,10 +9,10 @@ import { Path, inlinedValueFromString, pathConcat, pathEmpty, pathFromInlinedLoc
 import { arrayTag, instanceTag, objectTag } from "./tags";
 
 // The factory functions below (`schemaShape`, `schemaNested`, `schemaObject`,
-// `schemaTuple`, `schemaFactory`) are standalone top-level functions rather
-// than object methods — several are mutually recursive, which is awkward to
-// express inside an object literal — with `schema`-prefixed names to avoid
-// colliding with other sections.
+// `schemaTuple`, `schemaDefiner`, `schemaFactory`) are standalone top-level
+// functions rather than object methods — several are mutually recursive,
+// which is awkward to express inside an object literal — with
+// `schema`-prefixed names to avoid colliding with other sections.
 
 type ShapedSerializerAcc = {
   val?: Val;
@@ -634,20 +634,20 @@ const traverseDefinition = (
 const schemaCtx: SchemaCtx = {
   m: (schema) => schema,
 };
-export const schemaFactory = (definer: (ctx: unknown) => unknown): Internal => {
+export const schemaDefiner = (definer: (ctx: unknown) => unknown): Internal => {
   return definitionToSchema(definer(schemaCtx));
 }
 
-// Identifier alias (not a `schemaFactory` property read) so esbuild can
+// Identifier alias (not a `schemaDefiner` property read) so esbuild can
 // tree-shake: a property-read initializer is treated as possibly
 // side-effectful and would retain the whole schema machinery in every bundle.
-export const js_schema = (definition: unknown): Internal => {
+export const schemaFactory = (definition: unknown): Internal => {
   return definitionToSchema(definition);
 }
 
 // PORT-NOTE: `enum` is a reserved word in TS — defined as `enum_` and
 // re-exported under the name `enum` (legal as an export alias).
 const enum_ = (values: unknown[]): Internal => {
-  return unionFactory(values.map(js_schema));
+  return unionFactory(values.map(schemaFactory));
 }
 export { enum_ as enum };

--- a/packages/sury/src/factory.ts
+++ b/packages/sury/src/factory.ts
@@ -246,7 +246,12 @@ export const schemaObject = (
   return mut;
 }
 
-export const schemaTuple = (definer: (ctx: TupleCtx) => unknown): Internal => {
+export const schemaTuple = (
+  definer: ((ctx: TupleCtx) => unknown) | unknown[]
+): Internal => {
+  if (typeof definer !== "function") {
+    return definitionToSchema(definer);
+  }
   const items: Internal[] = [];
 
   const item = (idx: number, schema: Internal): unknown => {

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -1,4 +1,4 @@
-import { definitionToSchema, js_schema, schemaFactory } from "./factory";
+import { definitionToSchema, schemaDefiner, schemaFactory } from "./factory";
 import { array, option } from "./composites";
 import { email, isoDateTime, json, meta, url, uuid } from "./formats";
 import { arrayLength, arrayMaxLength, arrayMinLength, dict, floatMax, floatMin, intMax, intMin, null_, object, pattern, stringLength, stringMaxLength, stringMinLength, tuple, union } from "./refinements";
@@ -716,7 +716,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
           schema = dict(fromJSONSchema(additionalProperties));
         }
       } else {
-        schema = schemaFactory(() => {});
+        schema = schemaDefiner(() => {});
       }
     }
 
@@ -873,7 +873,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
   } else if (jsonSchema.type === "boolean") {
     schema = bool();
   } else if (jsonSchema.type === "null") {
-    schema = js_schema(null);
+    schema = schemaFactory(null);
   } else if (
     jsonSchema.if !== undefined &&
     jsonSchema.then !== undefined &&

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -1,4 +1,4 @@
-import { definitionToSchema, schemaDefiner, schemaFactory } from "./factory";
+import { definitionToSchema, schemaFactory } from "./factory";
 import { array, option } from "./composites";
 import { email, isoDateTime, json, meta, url, uuid } from "./formats";
 import { arrayLength, arrayMaxLength, arrayMinLength, dict, floatMax, floatMin, intMax, intMin, null_, object, pattern, stringLength, stringMaxLength, stringMinLength, tuple, union } from "./refinements";
@@ -716,7 +716,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
           schema = dict(fromJSONSchema(additionalProperties));
         }
       } else {
-        schema = schemaDefiner(() => {});
+        schema = schemaFactory({});
       }
     }
 

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -1,4 +1,4 @@
-import { definitionToSchema, literal, schemaFactory } from "./factory";
+import { definitionToSchema, js_schema, schemaFactory } from "./factory";
 import { array, option } from "./composites";
 import { email, isoDateTime, json, meta, url, uuid } from "./formats";
 import { arrayLength, arrayMaxLength, arrayMinLength, dict, floatMax, floatMin, intMax, intMin, null_, object, pattern, stringLength, stringMaxLength, stringMinLength, tuple, union } from "./refinements";
@@ -873,7 +873,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
   } else if (jsonSchema.type === "boolean") {
     schema = bool();
   } else if (jsonSchema.type === "null") {
-    schema = literal(null);
+    schema = js_schema(null);
   } else if (
     jsonSchema.if !== undefined &&
     jsonSchema.then !== undefined &&

--- a/packages/sury/tests/S_fromJSONSchema_test.res
+++ b/packages/sury/tests/S_fromJSONSchema_test.res
@@ -172,6 +172,12 @@ test("fromJSONSchema: object with additionalProperties true", t => {
   t->Assert.deepEqual(jsonRoundTrip(js), js)
 })
 
+test("fromJSONSchema: bare object with no properties or additionalProperties", t => {
+  let js = {type_: Arrayable.single(#object)}
+  let schema = S.fromJSONSchema(js)
+  t->Assert.deepEqual(parse(schema, {"foo": 1}), Dict.make())
+})
+
 // 5. Combinators
 
 test("fromJSONSchema: anyOf", t => {


### PR DESCRIPTION
## Summary

Extends the `tuple` schema to accept an array of schemas directly, in addition to the existing function-based definer API. This provides a more concise and intuitive syntax for defining tuple schemas with literal values.

## Key Changes

- **`factory.ts`**: Modified `schemaTuple` to accept either a function definer or an array of schemas. When an array is passed, it delegates to `definitionToSchema` for processing.

- **`S.d.ts`**: Added a new overload for `tuple` that accepts a const array of schemas (`[...T]`), enabling type-safe tuple definitions with proper Input/Output type inference via `UnknownArrayToOutput<T>` and `UnknownArrayToInput<T>`.

- **`S.res`**: Removed an outdated comment about array definitions being passed to the public JS `schema` function (the binding now correctly uses the dedicated `tuple2` external).

- **`tuple2.yaml`**: Updated the spec example to demonstrate the new array literal syntax:
  - Changed from generic `[S.string, S.number]` to a concrete example with a literal string `["bar", S.number]`
  - Added an `aliases` section showing `S.tuple(["bar", S.number])` as equivalent to the schema definition
  - Updated JSON Schema output to include `const: "bar"` constraint
  - Enhanced parse operation validation to check literal equality (`v0==="bar"`) instead of type checking
  - Added a new `invalid-literal` test case demonstrating error handling for mismatched literal values
  - Reduced instantiation count from 1132 to 967 (likely due to more efficient code generation with literal constraints)

## Implementation Details

The change maintains backward compatibility—the function-based definer API continues to work as before. The new array syntax is syntactic sugar that internally converts to the same schema representation, enabling both `S.tuple(ctx => ctx.item(0, S.string).item(1, S.number))` and `S.tuple([S.string, S.number])` to produce equivalent schemas.

https://claude.ai/code/session_01EFUYoxBxBefmHeDNr4ZUM4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for defining tuple schemas from an array of element schemas (not just a tuple-definer function), with improved TypeScript inference.
  * Added TypeScript overloads for `literal` and `tuple`, plus a helper for 1-element tuples.
  * Added `aliases` entries across literal specs (number/boolean/string/bigint/symbol/object/arrays).
* **Bug Fixes**
  * Updated tuple literal parsing/JSON Schema behavior to enforce the new literal constraint (including refreshed validation examples).
  * Improved JSON Schema conversion for `null` and for bare objects with no properties/additionalProperties, with added coverage via a new test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->