### PR TITLE
Fix error handling in try/catch example

### DIFF
--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1717,7 +1717,7 @@ If you want to handle the error, the best way to use `try/catch` block:
 
 ```rescript
 try true->S.parseOrThrow(~to=schema) catch {
-| S.Error(error) => Console.log(error.message)
+| S.Exn(error) => Console.log(error.message)
 }
 ```
 


### PR DESCRIPTION
I may have got it wrong, but `Sury.res` doesn't expose an `Error` exn. It does expose an `Exn` exn though.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the error-handling example to use the appropriate exception pattern while preserving error message logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->