### PR TITLE
Fix tuple2 spec: use literal type for first element

### DIFF
--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -8,7 +8,7 @@ ts:
   instantiations: 967
   bundleBytes: 9689
 vs:
-  zod: z.tuple([z.string(), z.number()])
+  zod: z.tuple([z.literal("bar"), z.number()])
 jsonSchema:
   input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "bar" }, { type: "number" }] }'
   output: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "bar" }, { type: "number" }] }'


### PR DESCRIPTION
## Summary
Updates the `tuple2` specification to accurately reflect the schema's actual behavior, where the first element is constrained to a literal value rather than accepting any string.

## Changes
- Updated the Zod validator in `packages/sury/specs/tuple2.yaml` from `z.tuple([z.string(), z.number()])` to `z.tuple([z.literal("bar"), z.number()])` to match the JSON Schema definition which already correctly specifies `const: "bar"` for the first element.

## Details
The JSON Schema input/output already correctly defined the first tuple element as a string with `const: "bar"`, but the Zod validator was incorrectly using `z.string()` without the literal constraint. This fix ensures the test specification is internally consistent and accurately validates against the intended schema behavior.

https://claude.ai/code/session_012ZsPcR2hXfxmZaZMRHQZyR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened tuple validation to require the exact literal value `"bar"` as the first element, ensuring runtime checks match the documented schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->