### PR TITLE
Fix nested optional field JSON encoding (#311)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -354,6 +354,7 @@ error message, a strictness gap that let a bad spec through — add a bullet her
 instead of silently working around it.
 
 - <placeholder>
+- No operation dimension for JSON-target conversions (`.to(S.json)` / `.to(S.jsonString)`), so bugs like #311 (nested optional fields failing to encode) can't be captured as spec examples — their repros live in `tests/` instead.
 
 ## License
 

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -540,7 +540,10 @@ export const unionIsWiderSchema = (schemaAnyOf: Internal[], inputAnyOf: Internal
         ) &&
         inputSchema.type === schema.type &&
         inputSchema.const === schema.const &&
-        inputSchema.to === undefined
+        inputSchema.to === undefined &&
+        // A paired variant with its own `.to` still transforms the value,
+        // so passing the input through would skip the conversion
+        schema.to === undefined
       );
     } else {
       return false;

--- a/packages/sury/src/formats.ts
+++ b/packages/sury/src/formats.ts
@@ -1,9 +1,9 @@
 import { defsPath, recursiveDecoder, transform } from "./operations";
 import { array, arrayDecoder, completeObjectVal, dictFactory, makeObjectVal, unionDecoder, unionFactory, unionPerVariantVal, valGet } from "./composites";
-import { bool, float, inputToString, jsonName, literalDecoder, nullLiteral, numberDecoder, string, stringDecoderFn, unit } from "./primitives";
-import { baseSchema, cached, copySchema, unknown } from "./schema";
+import { bool, float, inputToString, jsonName, literalDecoder, nullLiteral, numberDecoder, string, stringDecoderFn } from "./primitives";
+import { baseSchema, cached, copySchema, unknown, updateOutput } from "./schema";
 import { B_addObjectField, B_embed, B_embedInvalidInput, B_failWithErrorMessage, B_next, B_nextConst, B_refine, B_unsupportedDecode, B_varWithoutAllocation, _var, failInvalidType } from "./builder";
-import { getDecoder, instanceDecoder, parse, reverse } from "./parse";
+import { getDecoder, getOutputSchema, instanceDecoder, parse, reverse } from "./parse";
 import { Internal, SchemaErrorMessage, Val, isLiteral } from "./types";
 import { Builder, Encoder } from "./builder";
 import { flagUnsafeHas } from "./flags";
@@ -107,7 +107,20 @@ export const jsonDecoderFn = (input: Val): Val => {
         itemVal.io = false;
 
         if (itemVal.s.type === unionTag && itemVal.s.has![undefinedTag]) {
-          itemVal.e = unionFactory([unit(), json()]);
+          // Per-variant conversion instead of a generic `undefined | JSON`
+          // check: an undefined variant stays undefined so the object
+          // rebuild omits the field, while non-jsonable variants get
+          // `.to(json)` appended and keep converting recursively (#311)
+          itemVal.e = unionFactory(
+            itemVal.s.anyOf!.map((variant) => {
+              const variantOutput = getOutputSchema(variant);
+              return variantOutput.type === undefinedTag || isJsonable(variantOutput)
+                ? variant
+                : updateOutput<Internal>(variant, (mut) => {
+                    mut.to = json();
+                  });
+            })
+          );
           const itemOutput = parse(itemVal);
           itemOutput.o = true;
           B_addObjectField(jsonVal, key, itemOutput);

--- a/packages/sury/tests/Example_test.res
+++ b/packages/sury/tests/Example_test.res
@@ -63,11 +63,10 @@ test("Example", t => {
         "Tags": ["Loved"],
       }`),
   )
-  // FIXME: This can be improved, currently we run unknown->json decoder for optional deprecatedAgeRestriction
   t->U.assertCompiledCode(
     ~schema=filmSchema,
     ~op=#EncodeToJson,
-    `i=>{let v0=i["tags"],v3=i["deprecatedAgeRestriction"];try{v3===void 0||e[0](v3);}catch(e1){try{try{e[1](v3);}catch(v4){v4.path="[\\"deprecatedAgeRestriction\\"]"+v4.path;throw v4}}catch(e2){e[2](v3,e1,e2)}}let v5={"Id":i["id"],"Title":i["title"],"Tags":v0,"Rating":i["rating"],};if(v3!==void 0){v5["Age"]=v3}return v5}`,
+    `i=>{let v0=i["tags"],v4=i["deprecatedAgeRestriction"];let v3={"Id":i["id"],"Title":i["title"],"Tags":v0,"Rating":i["rating"],};if(v4!==void 0){v3["Age"]=v4}return v3}`,
   )
 })
 

--- a/packages/sury/tests/S_issue311_repro_test.res
+++ b/packages/sury/tests/S_issue311_repro_test.res
@@ -5,6 +5,11 @@ open Vitest
 // JSON, received ..." because an object field typed as a union with an
 // undefined variant was checked against generic JSON instead of having
 // each variant converted recursively.
+//
+// How None serializes depends on whether the schema can represent it by
+// absence: `option` and `nullableAsOption` accept undefined/missing, so None
+// serializes as an omitted field (round-trips back to None); `nullAsOption`
+// has only a `null` representation, so None serializes as JSON `null`.
 
 type inner = {s: option<string>}
 type outer = {a: option<inner>}
@@ -34,6 +39,39 @@ test("Nested nullable option round-trips through S.json", t => {
   let encoded = value->S.decodeOrThrow(~from=outerSchema, ~to=S.json)
   t->Assert.deepEqual(encoded, %raw(`{a: {}}`))
   t->Assert.deepEqual(encoded->S.parseOrThrow(~to=outerSchema), value)
+})
+
+test("Field-level JSON encoding: option/nullableAsOption omit None, nullAsOption emits null", t => {
+  // The crux of #311: a schema that can represent None by absence omits it;
+  // nullAsOption can't (no undefined arm), so its None becomes JSON null.
+  let optionSchema = S.schema(m => {"v": m.matches(S.option(S.string))})
+  let nullableAsOptionSchema = S.schema(m => {"v": m.matches(S.nullableAsOption(S.string))})
+  let nullAsOptionSchema = S.schema(m => {"v": m.matches(S.nullAsOption(S.string))})
+
+  t->Assert.deepEqual({"v": None}->S.decodeOrThrow(~from=optionSchema, ~to=S.json), %raw(`{}`))
+  t->Assert.deepEqual(
+    {"v": None}->S.decodeOrThrow(~from=nullableAsOptionSchema, ~to=S.json),
+    %raw(`{}`),
+  )
+  t->Assert.deepEqual(
+    {"v": None}->S.decodeOrThrow(~from=nullAsOptionSchema, ~to=S.json),
+    %raw(`{v: null}`),
+  )
+
+  // Present values serialize the same for all three.
+  t->Assert.deepEqual(
+    {"v": Some("x")}->S.decodeOrThrow(~from=nullableAsOptionSchema, ~to=S.json),
+    %raw(`{v: "x"}`),
+  )
+})
+
+test("nullAsOption nested inside an option object field emits null, not omit", t => {
+  let innerSchema = S.schema(m => {"s": m.matches(S.nullAsOption(S.string))})
+  let outerSchema = S.schema(m => {"a": m.matches(S.option(innerSchema))})
+  t->Assert.deepEqual(
+    {"a": Some({"s": None})}->S.decodeOrThrow(~from=outerSchema, ~to=S.json),
+    %raw(`{a: {s: null}}`),
+  )
 })
 
 test("Plain optional object field with an optional field encodes to JSON", t => {

--- a/packages/sury/tests/S_issue311_repro_test.res
+++ b/packages/sury/tests/S_issue311_repro_test.res
@@ -1,0 +1,93 @@
+open Vitest
+
+// https://github.com/DZakh/sury/issues/311 — encoding a nested optional
+// (or nullable-as-option) field to JSON failed with "Expected undefined |
+// JSON, received ..." because an object field typed as a union with an
+// undefined variant was checked against generic JSON instead of having
+// each variant converted recursively.
+
+type inner = {s: option<string>}
+type outer = {a: option<inner>}
+
+let makeNullableSchemas = () => {
+  let innerSchema = S.schema(m => {s: m.matches(S.nullableAsOption(S.string))})
+  let outerSchema = S.schema(m => {a: m.matches(S.nullableAsOption(innerSchema))})
+  outerSchema
+}
+
+test("Nested nullable option encodes to JSON string (issue shape)", t => {
+  let outerSchema = makeNullableSchemas()
+  t->Assert.deepEqual(
+    {a: Some({s: None})}->S.decodeOrThrow(~from=outerSchema, ~to=S.jsonString),
+    `{"a":{}}`,
+  )
+  t->Assert.deepEqual(
+    {a: Some({s: Some("x")})}->S.decodeOrThrow(~from=outerSchema, ~to=S.jsonString),
+    `{"a":{"s":"x"}}`,
+  )
+  t->Assert.deepEqual({a: None}->S.decodeOrThrow(~from=outerSchema, ~to=S.jsonString), `{}`)
+})
+
+test("Nested nullable option round-trips through S.json", t => {
+  let outerSchema = makeNullableSchemas()
+  let value = {a: Some({s: None})}
+  let encoded = value->S.decodeOrThrow(~from=outerSchema, ~to=S.json)
+  t->Assert.deepEqual(encoded, %raw(`{a: {}}`))
+  t->Assert.deepEqual(encoded->S.parseOrThrow(~to=outerSchema), value)
+})
+
+test("Plain optional object field with an optional field encodes to JSON", t => {
+  let innerSchema = S.schema(m => {s: m.matches(S.option(S.string))})
+  let outerSchema = S.schema(m => {a: m.matches(S.option(innerSchema))})
+  t->Assert.deepEqual(
+    {a: Some({s: None})}->S.decodeOrThrow(~from=outerSchema, ~to=S.json),
+    %raw(`{a: {}}`),
+  )
+  t->Assert.deepEqual({a: None}->S.decodeOrThrow(~from=outerSchema, ~to=S.json), %raw(`{}`))
+})
+
+type dictInner = {name: string, counter: option<string>}
+type dictOuter = {items: option<dict<dictInner>>}
+
+test("Optional dict of objects with optional fields encodes to JSON (issue comment repro)", t => {
+  let innerSchema = S.schema(m =>
+    {
+      name: m.matches(S.string),
+      counter: m.matches(S.option(S.string)),
+    }
+  )
+  let outerSchema = S.schema(m => {items: m.matches(S.option(S.dict(innerSchema)))})
+  let value = {items: Some(Dict.fromArray([("a", {name: "x", counter: None})]))}
+  t->Assert.deepEqual(
+    value->S.decodeOrThrow(~from=outerSchema, ~to=S.json),
+    %raw(`{items: {a: {name: "x"}}}`),
+  )
+})
+
+test("Optional array field of objects with optional fields encodes to JSON", t => {
+  let innerSchema = S.schema(m => {s: m.matches(S.option(S.string))})
+  let schema = S.schema(m => {"list": m.matches(S.option(S.array(innerSchema)))})
+  t->Assert.deepEqual(
+    {"list": Some([{s: None}, {s: Some("x")}])}->S.decodeOrThrow(~from=schema, ~to=S.json),
+    %raw(`{list: [{}, {s: "x"}]}`),
+  )
+})
+
+test("Optional non-jsonable field converts per variant instead of leaking through", t => {
+  let schema = S.schema(m => {"d": m.matches(S.option(S.bigint))})
+  t->Assert.deepEqual(
+    {"d": Some(5n)}->S.decodeOrThrow(~from=schema, ~to=S.json),
+    %raw(`{d: "5"}`),
+  )
+  t->Assert.deepEqual({"d": None}->S.decodeOrThrow(~from=schema, ~to=S.json), %raw(`{}`))
+})
+
+test("Jsonable optional field no longer runs a redundant deep JSON validation", t => {
+  let innerSchema = S.schema(m => {s: m.matches(S.option(S.string))})
+  let outerSchema = S.schema(m => {a: m.matches(S.option(innerSchema))})
+  t->U.assertCompiledCode(
+    ~schema=outerSchema,
+    ~op=#EncodeToJson,
+    `i=>{let v0=i["a"];if(typeof v0==="object"&&v0&&!Array.isArray(v0)){let v1=v0["s"];if(!(typeof v1==="string"||v1===void 0)){e[0](v1)}let v3={"s":v1,};try{let v2={};if(v1!==void 0){v2["s"]=v1}v3=v2}catch(e0){e[1](v3,e0)}v0=v3}else if(!(v0===void 0)){e[2](v0)}let v4={};if(v0!==void 0){v4["a"]=v0}return v4}`,
+  )
+})

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -188,7 +188,7 @@ test("identity claimed but the operation doesn't actually compile to identity", 
     -   instantiations: 254
     -   bundleBytes: 3744
     +   instantiations: 5181
-    +   bundleBytes: 4218
+    +   bundleBytes: 4217
       vs:
         zod: z.string()
       jsonSchema:
@@ -262,7 +262,7 @@ test("eq-to-parse claimed but the operation doesn't actually compile to the same
     +   input: string
     +   output: string
     +   instantiations: 5181
-    +   bundleBytes: 4218
+    +   bundleBytes: 4217
       vs:
         zod: z.never()
       jsonSchema:


### PR DESCRIPTION
## Summary

Fixes a bug where encoding nested optional fields to JSON failed with "Expected undefined | JSON, received ..." errors. The issue occurred when an object field was typed as a union with an undefined variant — the encoder was checking the entire union against generic JSON instead of converting each variant recursively.

## Changes

- **formats.ts**: Replace generic `undefined | JSON` union check with per-variant conversion logic. When a union variant contains an undefined arm, keep undefined as-is (so the object rebuild omits the field), while non-jsonable variants get `.to(json)` appended to continue recursive conversion. This ensures nested optional fields with non-jsonable inner types (like `option<bigint>`) encode correctly.

- **composites.ts**: Update `unionIsWiderSchema` to account for paired variants with their own `.to` transformation. A variant with a `.to` still transforms the value, so passing the input through would skip the conversion.

- **tests**: Add comprehensive test coverage for the fix:
  - Nested nullable options encoding to JSON
  - Round-tripping through `S.json`
  - Field-level JSON encoding behavior differences (`option` vs `nullableAsOption` vs `nullAsOption`)
  - Optional dicts and arrays with optional fields
  - Optional non-jsonable fields (e.g., `option<bigint>`)
  - Verification that the generated code no longer runs redundant deep JSON validation

- **Example_test.res**: Remove outdated FIXME comment and verify the improved generated code no longer performs unnecessary validation on optional deprecated fields.

## Implementation Details

The fix leverages the existing `getOutputSchema` helper to inspect each union variant and determine whether it needs conversion. Variants that are already jsonable or represent undefined pass through unchanged, while non-jsonable variants get wrapped with `.to(json)` to ensure proper recursive conversion. This maintains the correct semantics where `option` and `nullableAsOption` omit None fields, while `nullAsOption` emits JSON `null`.

https://claude.ai/code/session_011WDr8A79vgSCVwKp2iEnpn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON encoding for nested optional and nullable fields.
  * Correctly omits undefined fields while preserving explicit `null` values.
  * Prevented invalid conversions for non-JSON-compatible union variants.
  * Tightened schema compatibility checks during decoding.

* **Tests**
  * Added coverage for nested optional fields, arrays, dictionaries, and compiled JSON output.
  * Updated expected compiler diagnostics and snapshots.

* **Documentation**
  * Documented current limitations of the JSON conversion spec harness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->