### PR TITLE
Bump version to 11.0.0-alpha.11

### DIFF
--- a/packages/sury-ppx/jsr.json
+++ b/packages/sury-ppx/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/ppx",
-  "version": "11.0.0-alpha.9",
+  "version": "11.0.0-alpha.11",
   "license": "MIT",
   "exports": "./index.ts"
 }

--- a/packages/sury-ppx/package.json
+++ b/packages/sury-ppx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury-ppx",
-  "version": "11.0.0-alpha.9",
+  "version": "11.0.0-alpha.11",
   "description": "⚙️ ReScript PPX to generate Sury schema from types",
   "keywords": [
     "Sury",
@@ -33,6 +33,6 @@
     "postinstall": "node ./install.cjs"
   },
   "peerDependencies": {
-    "sury": "^11.0.0-alpha.9"
+    "sury": "^11.0.0-alpha.11"
   }
 }

--- a/packages/sury/jsr.json
+++ b/packages/sury/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/sury",
-  "version": "11.0.0-alpha.9",
+  "version": "11.0.0-alpha.11",
   "license": "MIT",
   "exclude": ["!src", "!rescript.json", "!README.md", "!package.json", "!docs"],
   "exports": "./src/S.mjs"

--- a/packages/sury/package.json
+++ b/packages/sury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury",
-  "version": "11.0.0-alpha.9",
+  "version": "11.0.0-alpha.11",
   "private": true,
   "description": "🧬 The fastest schema with next-gen DX",
   "keywords": [


### PR DESCRIPTION
Bumps the version of the Sury packages from `11.0.0-alpha.9` to `11.0.0-alpha.11`.

## Changes

- Updated `sury-ppx` package version in `package.json` and `jsr.json`
- Updated `sury` package version in `package.json` and `jsr.json`
- Updated peer dependency constraint for `sury` in `sury-ppx` to match the new version

This is a routine version bump for the alpha release cycle.

https://claude.ai/code/session_01VcNt3UcYcAmKosUhcvdxX2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Sury packages to version `11.0.0-alpha.11`.
  * Updated the package compatibility requirement to match the new Sury release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->