### PR TITLE
Speed up schema construction & operation compilation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,7 +353,13 @@ case the harness *should* have caught or guided better — a missing check, a we
 error message, a strictness gap that let a bad spec through — add a bullet here
 instead of silently working around it.
 
-- <placeholder>
+- `bundleBytes`'s ±1% tolerance band (harness.ts `recomputeGoldens`) lets small
+  regressions accumulate silently: several commits each drifting <1% keep
+  passing against a stale golden, and the change that finally crosses the line
+  gets blamed for the whole accumulated delta (observed: a +9 B change surfaced
+  as +97 B because ~88 B of prior drift was hiding inside the band). Consider
+  tracking the live measurement alongside the golden, or re-recording when the
+  drift direction is consistent across runs.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,13 +353,7 @@ case the harness *should* have caught or guided better — a missing check, a we
 error message, a strictness gap that let a bad spec through — add a bullet here
 instead of silently working around it.
 
-- `bundleBytes`'s ±1% tolerance band (harness.ts `recomputeGoldens`) lets small
-  regressions accumulate silently: several commits each drifting <1% keep
-  passing against a stale golden, and the change that finally crosses the line
-  gets blamed for the whole accumulated delta (observed: a +9 B change surfaced
-  as +97 B because ~88 B of prior drift was hiding inside the band). Consider
-  tracking the live measurement alongside the golden, or re-recording when the
-  drift direction is consistent across runs.
+- <placeholder>
 
 ## License
 

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -383,15 +383,12 @@ export const recomputeGoldens = async (obj: Spec): Promise<Spec> => {
   }
 
   if (bundleBytesPromise) {
-    const measured = await bundleBytesPromise;
-    // ±1% tolerance: gzip byte counts wobble with toolchain bumps (esbuild,
-    // zlib) even when nothing about the schema changed. Within the band the
-    // recorded golden is kept, so an unrelated dependency bump doesn't go
-    // stale across every spec at once; a real size change (>1%) re-records
-    // exactly.
-    const prior = next.ts.bundleBytes;
-    next.ts.bundleBytes =
-      typeof prior === "number" && Math.abs(measured - prior) <= prior * 0.01 ? prior : measured;
+    // Recorded exactly — no tolerance band. A band (formerly ±1%, meant to
+    // absorb toolchain wobble) let consistent sub-1% drift accumulate against
+    // stale goldens and misattributed the whole delta to whichever change
+    // finally crossed the line. A toolchain bump now re-records every spec at
+    // once, which is the honest diff.
+    next.ts.bundleBytes = await bundleBytesPromise;
   }
   return next;
 };

--- a/packages/sury/specs/any.yaml
+++ b/packages/sury/specs/any.yaml
@@ -4,7 +4,7 @@ ts:
   input: any
   output: any
   instantiations: 254
-  bundleBytes: 3462
+  bundleBytes: 3504
 vs:
   zod: z.any()
 jsonSchema:

--- a/packages/sury/specs/any.yaml
+++ b/packages/sury/specs/any.yaml
@@ -4,7 +4,7 @@ ts:
   input: any
   output: any
   instantiations: 254
-  bundleBytes: 3504
+  bundleBytes: 3479
 vs:
   zod: z.any()
 jsonSchema:

--- a/packages/sury/specs/bigint.yaml
+++ b/packages/sury/specs/bigint.yaml
@@ -4,7 +4,7 @@ ts:
   input: bigint
   output: bigint
   instantiations: 254
-  bundleBytes: 3744
+  bundleBytes: 3799
 vs:
   zod: z.bigint()
 jsonSchema:

--- a/packages/sury/specs/bigint.yaml
+++ b/packages/sury/specs/bigint.yaml
@@ -4,7 +4,7 @@ ts:
   input: bigint
   output: bigint
   instantiations: 254
-  bundleBytes: 3799
+  bundleBytes: 3788
 vs:
   zod: z.bigint()
 jsonSchema:

--- a/packages/sury/specs/boolean.yaml
+++ b/packages/sury/specs/boolean.yaml
@@ -4,7 +4,7 @@ ts:
   input: boolean
   output: boolean
   instantiations: 254
-  bundleBytes: 3733
+  bundleBytes: 3791
 vs:
   zod: z.boolean()
 jsonSchema:

--- a/packages/sury/specs/boolean.yaml
+++ b/packages/sury/specs/boolean.yaml
@@ -4,7 +4,7 @@ ts:
   input: boolean
   output: boolean
   instantiations: 254
-  bundleBytes: 3791
+  bundleBytes: 3784
 vs:
   zod: z.boolean()
 jsonSchema:

--- a/packages/sury/specs/int32.yaml
+++ b/packages/sury/specs/int32.yaml
@@ -4,7 +4,7 @@ ts:
   input: number
   output: number
   instantiations: 254
-  bundleBytes: 3833
+  bundleBytes: 3901
 vs:
   zod: z.int32()
 jsonSchema:

--- a/packages/sury/specs/int32.yaml
+++ b/packages/sury/specs/int32.yaml
@@ -4,7 +4,7 @@ ts:
   input: number
   output: number
   instantiations: 254
-  bundleBytes: 3901
+  bundleBytes: 3892
 vs:
   zod: z.int32()
 jsonSchema:

--- a/packages/sury/specs/literal-array.yaml
+++ b/packages/sury/specs/literal-array.yaml
@@ -6,7 +6,7 @@ ts:
   input: '["bar", true]'
   output: '["bar", true]'
   instantiations: 532
-  bundleBytes: 9382
+  bundleBytes: 9444
 vs:
   zod: z.tuple([z.literal("bar"), z.literal(true)])
 jsonSchema:

--- a/packages/sury/specs/literal-array.yaml
+++ b/packages/sury/specs/literal-array.yaml
@@ -6,7 +6,7 @@ ts:
   input: '["bar", true]'
   output: '["bar", true]'
   instantiations: 532
-  bundleBytes: 9447
+  bundleBytes: 9435
 vs:
   zod: z.tuple([z.literal("bar"), z.literal(true)])
 jsonSchema:

--- a/packages/sury/specs/literal-bigint.yaml
+++ b/packages/sury/specs/literal-bigint.yaml
@@ -6,7 +6,7 @@ ts:
   input: 123n
   output: 123n
   instantiations: 379
-  bundleBytes: 9378
+  bundleBytes: 9440
 vs:
   zod: z.literal(123n)
 jsonSchema:

--- a/packages/sury/specs/literal-bigint.yaml
+++ b/packages/sury/specs/literal-bigint.yaml
@@ -6,7 +6,7 @@ ts:
   input: 123n
   output: 123n
   instantiations: 379
-  bundleBytes: 9444
+  bundleBytes: 9432
 vs:
   zod: z.literal(123n)
 jsonSchema:

--- a/packages/sury/specs/literal-boolean.yaml
+++ b/packages/sury/specs/literal-boolean.yaml
@@ -6,7 +6,7 @@ ts:
   input: "true"
   output: "true"
   instantiations: 378
-  bundleBytes: 9374
+  bundleBytes: 9437
 vs:
   zod: z.literal(true)
 jsonSchema:

--- a/packages/sury/specs/literal-boolean.yaml
+++ b/packages/sury/specs/literal-boolean.yaml
@@ -6,7 +6,7 @@ ts:
   input: "true"
   output: "true"
   instantiations: 378
-  bundleBytes: 9440
+  bundleBytes: 9428
 vs:
   zod: z.literal(true)
 jsonSchema:

--- a/packages/sury/specs/literal-number.yaml
+++ b/packages/sury/specs/literal-number.yaml
@@ -6,7 +6,7 @@ ts:
   input: "123"
   output: "123"
   instantiations: 382
-  bundleBytes: 9443
+  bundleBytes: 9431
 vs:
   zod: z.literal(123)
 jsonSchema:

--- a/packages/sury/specs/literal-number.yaml
+++ b/packages/sury/specs/literal-number.yaml
@@ -6,7 +6,7 @@ ts:
   input: "123"
   output: "123"
   instantiations: 382
-  bundleBytes: 9377
+  bundleBytes: 9440
 vs:
   zod: z.literal(123)
 jsonSchema:

--- a/packages/sury/specs/literal-object.yaml
+++ b/packages/sury/specs/literal-object.yaml
@@ -8,7 +8,7 @@ ts:
   input: '{ foo: "bar"; }'
   output: '{ foo: "bar"; }'
   instantiations: 1043
-  bundleBytes: 9382
+  bundleBytes: 9444
 vs:
   zod: 'z.object({ foo: z.literal("bar") })'
 jsonSchema:

--- a/packages/sury/specs/literal-object.yaml
+++ b/packages/sury/specs/literal-object.yaml
@@ -8,7 +8,7 @@ ts:
   input: '{ foo: "bar"; }'
   output: '{ foo: "bar"; }'
   instantiations: 1043
-  bundleBytes: 9447
+  bundleBytes: 9435
 vs:
   zod: 'z.object({ foo: z.literal("bar") })'
 jsonSchema:

--- a/packages/sury/specs/literal-string.yaml
+++ b/packages/sury/specs/literal-string.yaml
@@ -6,7 +6,7 @@ ts:
   input: '"tuna"'
   output: '"tuna"'
   instantiations: 429
-  bundleBytes: 9444
+  bundleBytes: 9432
 vs:
   zod: z.literal("tuna")
 jsonSchema:

--- a/packages/sury/specs/literal-string.yaml
+++ b/packages/sury/specs/literal-string.yaml
@@ -6,7 +6,7 @@ ts:
   input: '"tuna"'
   output: '"tuna"'
   instantiations: 429
-  bundleBytes: 9378
+  bundleBytes: 9441
 vs:
   zod: z.literal("tuna")
 jsonSchema:

--- a/packages/sury/specs/literal-symbol.yaml
+++ b/packages/sury/specs/literal-symbol.yaml
@@ -6,7 +6,7 @@ ts:
   input: symbol
   output: symbol
   instantiations: 389
-  bundleBytes: 9382
+  bundleBytes: 9447
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/literal-symbol.yaml
+++ b/packages/sury/specs/literal-symbol.yaml
@@ -6,7 +6,7 @@ ts:
   input: symbol
   output: symbol
   instantiations: 389
-  bundleBytes: 9450
+  bundleBytes: 9438
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/merge-optional.yaml
+++ b/packages/sury/specs/merge-optional.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ name: string; _id?: string | undefined; _rev?: string | undefined; code: string; _deleted?: boolean | undefined; }"
   output: "{ name: string; _id?: string | undefined; _rev?: string | undefined; code: string; _deleted?: boolean | undefined; }"
   instantiations: 7626
-  bundleBytes: 10433
+  bundleBytes: 10423
 vs:
   zod:
     schema: "z.object({ _id: z.string().optional(), _rev: z.string().optional(), name: z.string(), code: z.string(), _deleted: z.boolean().optional() })"

--- a/packages/sury/specs/merge-optional.yaml
+++ b/packages/sury/specs/merge-optional.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ name: string; _id?: string | undefined; _rev?: string | undefined; code: string; _deleted?: boolean | undefined; }"
   output: "{ name: string; _id?: string | undefined; _rev?: string | undefined; code: string; _deleted?: boolean | undefined; }"
   instantiations: 7626
-  bundleBytes: 10387
+  bundleBytes: 10431
 vs:
   zod:
     schema: "z.object({ _id: z.string().optional(), _rev: z.string().optional(), name: z.string(), code: z.string(), _deleted: z.boolean().optional() })"

--- a/packages/sury/specs/merge.yaml
+++ b/packages/sury/specs/merge.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   instantiations: 4700
-  bundleBytes: 10069
+  bundleBytes: 10051
 vs:
   zod: "z.object({ a: z.string(), b: z.number(), c: z.boolean() }).extend({ d: z.bigint(), e: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/merge.yaml
+++ b/packages/sury/specs/merge.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; }"
   instantiations: 4700
-  bundleBytes: 10020
+  bundleBytes: 10067
 vs:
   zod: "z.object({ a: z.string(), b: z.number(), c: z.boolean() }).extend({ d: z.bigint(), e: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/nan.yaml
+++ b/packages/sury/specs/nan.yaml
@@ -4,7 +4,7 @@ ts:
   input: number
   output: number
   instantiations: 382
-  bundleBytes: 9377
+  bundleBytes: 9439
 vs:
   zod: z.nan()
 jsonSchema:

--- a/packages/sury/specs/nan.yaml
+++ b/packages/sury/specs/nan.yaml
@@ -4,7 +4,7 @@ ts:
   input: number
   output: number
   instantiations: 382
-  bundleBytes: 9442
+  bundleBytes: 9430
 vs:
   zod: z.nan()
 jsonSchema:

--- a/packages/sury/specs/never.yaml
+++ b/packages/sury/specs/never.yaml
@@ -4,7 +4,7 @@ ts:
   input: never
   output: never
   instantiations: 254
-  bundleBytes: 3570
+  bundleBytes: 3569
 vs:
   zod: z.never()
 jsonSchema:

--- a/packages/sury/specs/never.yaml
+++ b/packages/sury/specs/never.yaml
@@ -4,7 +4,7 @@ ts:
   input: never
   output: never
   instantiations: 254
-  bundleBytes: 3589
+  bundleBytes: 3570
 vs:
   zod: z.never()
 jsonSchema:

--- a/packages/sury/specs/never.yaml
+++ b/packages/sury/specs/never.yaml
@@ -4,7 +4,7 @@ ts:
   input: never
   output: never
   instantiations: 254
-  bundleBytes: 3591
+  bundleBytes: 3589
 vs:
   zod: z.never()
 jsonSchema:

--- a/packages/sury/specs/never.yaml
+++ b/packages/sury/specs/never.yaml
@@ -4,7 +4,7 @@ ts:
   input: never
   output: never
   instantiations: 254
-  bundleBytes: 3551
+  bundleBytes: 3591
 vs:
   zod: z.never()
 jsonSchema:

--- a/packages/sury/specs/null.yaml
+++ b/packages/sury/specs/null.yaml
@@ -4,7 +4,7 @@ ts:
   input: "null"
   output: "null"
   instantiations: 369
-  bundleBytes: 9439
+  bundleBytes: 9427
 vs:
   zod: z.null()
 jsonSchema:

--- a/packages/sury/specs/null.yaml
+++ b/packages/sury/specs/null.yaml
@@ -4,7 +4,7 @@ ts:
   input: "null"
   output: "null"
   instantiations: 369
-  bundleBytes: 9375
+  bundleBytes: 9436
 vs:
   zod: z.null()
 jsonSchema:

--- a/packages/sury/specs/number.yaml
+++ b/packages/sury/specs/number.yaml
@@ -4,7 +4,7 @@ ts:
   input: number
   output: number
   instantiations: 254
-  bundleBytes: 3891
+  bundleBytes: 3887
 vs:
   zod: z.number()
 jsonSchema:

--- a/packages/sury/specs/number.yaml
+++ b/packages/sury/specs/number.yaml
@@ -4,7 +4,7 @@ ts:
   input: number
   output: number
   instantiations: 254
-  bundleBytes: 3827
+  bundleBytes: 3891
 vs:
   zod: z.number()
 jsonSchema:

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -7,7 +7,7 @@ ts:
   input: "{ a: string; nested: { b: number; inner: { c: boolean; d?: string | undefined; }; }; }"
   output: "{ a: string; nested: { b: number; inner: { c: boolean; d?: string | undefined; }; }; }"
   instantiations: 2769
-  bundleBytes: 10481
+  bundleBytes: 10470
 vs:
   zod: "z.object({ a: z.string(), nested: z.object({ b: z.number(), inner: z.object({ c: z.boolean(), d: z.string().optional() }) }) })"
 jsonSchema:

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -7,7 +7,7 @@ ts:
   input: "{ a: string; nested: { b: number; inner: { c: boolean; d?: string | undefined; }; }; }"
   output: "{ a: string; nested: { b: number; inner: { c: boolean; d?: string | undefined; }; }; }"
   instantiations: 2769
-  bundleBytes: 10437
+  bundleBytes: 10479
 vs:
   zod: "z.object({ a: z.string(), nested: z.object({ b: z.number(), inner: z.object({ c: z.boolean(), d: z.string().optional() }) }) })"
 jsonSchema:

--- a/packages/sury/specs/object-reserved-names.yaml
+++ b/packages/sury/specs/object-reserved-names.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ constructor: string; hasOwnProperty: number; }"
   output: "{ constructor: string; hasOwnProperty: number; }"
   instantiations: 1468
-  bundleBytes: 11863
+  bundleBytes: 11840
 vs:
   zod: "z.object({ constructor: z.string(), hasOwnProperty: z.number() })"
 jsonSchema:

--- a/packages/sury/specs/object-reserved-names.yaml
+++ b/packages/sury/specs/object-reserved-names.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ constructor: string; hasOwnProperty: number; }"
   output: "{ constructor: string; hasOwnProperty: number; }"
   instantiations: 1468
-  bundleBytes: 11809
+  bundleBytes: 11861
 vs:
   zod: "z.object({ constructor: z.string(), hasOwnProperty: z.number() })"
 jsonSchema:

--- a/packages/sury/specs/object1.yaml
+++ b/packages/sury/specs/object1.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ a: string; }"
   output: "{ a: string; }"
   instantiations: 1205
-  bundleBytes: 9597
+  bundleBytes: 9576
 vs:
   zod: "z.object({ a: z.string() })"
 jsonSchema:

--- a/packages/sury/specs/object1.yaml
+++ b/packages/sury/specs/object1.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ a: string; }"
   output: "{ a: string; }"
   instantiations: 1205
-  bundleBytes: 9497
+  bundleBytes: 9597
 vs:
   zod: "z.object({ a: z.string() })"
 jsonSchema:

--- a/packages/sury/specs/object1.yaml
+++ b/packages/sury/specs/object1.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ a: string; }"
   output: "{ a: string; }"
   instantiations: 1205
-  bundleBytes: 9578
+  bundleBytes: 9561
 vs:
   zod: "z.object({ a: z.string() })"
 jsonSchema:

--- a/packages/sury/specs/object10.yaml
+++ b/packages/sury/specs/object10.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   instantiations: 2331
-  bundleBytes: 9962
+  bundleBytes: 9950
 vs:
   zod: "z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.bigint(), e: z.symbol(), f: z.string(), g: z.number(), h: z.boolean(), i: z.bigint(), j: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/object10.yaml
+++ b/packages/sury/specs/object10.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   instantiations: 2331
-  bundleBytes: 9993
+  bundleBytes: 9960
 vs:
   zod: "z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.bigint(), e: z.symbol(), f: z.string(), g: z.number(), h: z.boolean(), i: z.bigint(), j: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/object10.yaml
+++ b/packages/sury/specs/object10.yaml
@@ -4,7 +4,7 @@ ts:
   input: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   output: "{ a: string; b: number; c: boolean; d: bigint; e: symbol; f: string; g: number; h: boolean; i: bigint; j: symbol; }"
   instantiations: 2331
-  bundleBytes: 9889
+  bundleBytes: 9993
 vs:
   zod: "z.object({ a: z.string(), b: z.number(), c: z.boolean(), d: z.bigint(), e: z.symbol(), f: z.string(), g: z.number(), h: z.boolean(), i: z.bigint(), j: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/object5-optional.yaml
+++ b/packages/sury/specs/object5-optional.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ a: string; c: boolean; e: symbol; b?: number | undefined; d?: bigint | undefined; }"
   output: "{ a: string; c: boolean; e: symbol; b?: number | undefined; d?: bigint | undefined; }"
   instantiations: 3610
-  bundleBytes: 10573
+  bundleBytes: 10562
 vs:
   zod: "z.object({ a: z.string(), b: z.number().optional(), c: z.boolean(), d: z.bigint().optional(), e: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/object5-optional.yaml
+++ b/packages/sury/specs/object5-optional.yaml
@@ -6,7 +6,7 @@ ts:
   input: "{ a: string; c: boolean; e: symbol; b?: number | undefined; d?: bigint | undefined; }"
   output: "{ a: string; c: boolean; e: symbol; b?: number | undefined; d?: bigint | undefined; }"
   instantiations: 3610
-  bundleBytes: 10539
+  bundleBytes: 10572
 vs:
   zod: "z.object({ a: z.string(), b: z.number().optional(), c: z.boolean(), d: z.bigint().optional(), e: z.symbol() })"
 jsonSchema:

--- a/packages/sury/specs/string.yaml
+++ b/packages/sury/specs/string.yaml
@@ -4,7 +4,7 @@ ts:
   input: string
   output: string
   instantiations: 254
-  bundleBytes: 3744
+  bundleBytes: 3795
 vs:
   zod: z.string()
 jsonSchema:

--- a/packages/sury/specs/string.yaml
+++ b/packages/sury/specs/string.yaml
@@ -4,7 +4,7 @@ ts:
   input: string
   output: string
   instantiations: 254
-  bundleBytes: 3795
+  bundleBytes: 3790
 vs:
   zod: z.string()
 jsonSchema:

--- a/packages/sury/specs/symbol.yaml
+++ b/packages/sury/specs/symbol.yaml
@@ -4,7 +4,7 @@ ts:
   input: symbol
   output: symbol
   instantiations: 254
-  bundleBytes: 3713
+  bundleBytes: 3706
 vs:
   zod: z.symbol()
 jsonSchema:

--- a/packages/sury/specs/symbol.yaml
+++ b/packages/sury/specs/symbol.yaml
@@ -4,7 +4,7 @@ ts:
   input: symbol
   output: symbol
   instantiations: 254
-  bundleBytes: 3660
+  bundleBytes: 3713
 vs:
   zod: z.symbol()
 jsonSchema:

--- a/packages/sury/specs/tuple10.yaml
+++ b/packages/sury/specs/tuple10.yaml
@@ -4,7 +4,7 @@ ts:
   input: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   instantiations: 2282
-  bundleBytes: 9869
+  bundleBytes: 9973
 vs:
   zod: z.tuple([z.string(), z.number(), z.boolean(), z.bigint(), z.symbol(), z.string(), z.number(), z.boolean(), z.bigint(), z.symbol()])
 jsonSchema:

--- a/packages/sury/specs/tuple10.yaml
+++ b/packages/sury/specs/tuple10.yaml
@@ -4,7 +4,7 @@ ts:
   input: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   instantiations: 2282
-  bundleBytes: 9942
+  bundleBytes: 9931
 vs:
   zod: z.tuple([z.string(), z.number(), z.boolean(), z.bigint(), z.symbol(), z.string(), z.number(), z.boolean(), z.bigint(), z.symbol()])
 jsonSchema:

--- a/packages/sury/specs/tuple10.yaml
+++ b/packages/sury/specs/tuple10.yaml
@@ -4,7 +4,7 @@ ts:
   input: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   output: "[string, number, boolean, bigint, symbol, string, number, boolean, bigint, symbol]"
   instantiations: 2282
-  bundleBytes: 9973
+  bundleBytes: 9940
 vs:
   zod: z.tuple([z.string(), z.number(), z.boolean(), z.bigint(), z.symbol(), z.string(), z.number(), z.boolean(), z.bigint(), z.symbol()])
 jsonSchema:

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -6,7 +6,7 @@ ts:
   input: '["bar", number]'
   output: '["bar", number]'
   instantiations: 967
-  bundleBytes: 9674
+  bundleBytes: 9660
 vs:
   zod: z.tuple([z.literal("bar"), z.number()])
 jsonSchema:

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -6,7 +6,7 @@ ts:
   input: '["bar", number]'
   output: '["bar", number]'
   instantiations: 967
-  bundleBytes: 9689
+  bundleBytes: 9672
 vs:
   zod: z.tuple([z.literal("bar"), z.number()])
 jsonSchema:

--- a/packages/sury/specs/tuple2.yaml
+++ b/packages/sury/specs/tuple2.yaml
@@ -8,7 +8,7 @@ ts:
   instantiations: 967
   bundleBytes: 9689
 vs:
-  zod: z.tuple([z.string(), z.number()])
+  zod: z.tuple([z.literal("bar"), z.number()])
 jsonSchema:
   input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "bar" }, { type: "number" }] }'
   output: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "bar" }, { type: "number" }] }'

--- a/packages/sury/specs/undefined.yaml
+++ b/packages/sury/specs/undefined.yaml
@@ -4,7 +4,7 @@ ts:
   input: undefined
   output: undefined
   instantiations: 369
-  bundleBytes: 9441
+  bundleBytes: 9429
 vs:
   zod: z.undefined()
 jsonSchema:

--- a/packages/sury/specs/undefined.yaml
+++ b/packages/sury/specs/undefined.yaml
@@ -4,7 +4,7 @@ ts:
   input: undefined
   output: undefined
   instantiations: 369
-  bundleBytes: 9375
+  bundleBytes: 9438
 vs:
   zod: z.undefined()
 jsonSchema:

--- a/packages/sury/specs/union2.yaml
+++ b/packages/sury/specs/union2.yaml
@@ -4,7 +4,7 @@ ts:
   input: string | number
   output: string | number
   instantiations: 972
-  bundleBytes: 9797
+  bundleBytes: 9767
 vs:
   zod: z.union([z.string(), z.number()])
 jsonSchema:

--- a/packages/sury/specs/union2.yaml
+++ b/packages/sury/specs/union2.yaml
@@ -4,7 +4,7 @@ ts:
   input: string | number
   output: string | number
   instantiations: 972
-  bundleBytes: 9693
+  bundleBytes: 9797
 vs:
   zod: z.union([z.string(), z.number()])
 jsonSchema:

--- a/packages/sury/specs/union2.yaml
+++ b/packages/sury/specs/union2.yaml
@@ -4,7 +4,7 @@ ts:
   input: string | number
   output: string | number
   instantiations: 972
-  bundleBytes: 9770
+  bundleBytes: 9755
 vs:
   zod: z.union([z.string(), z.number()])
 jsonSchema:

--- a/packages/sury/specs/union5-discriminated.yaml
+++ b/packages/sury/specs/union5-discriminated.yaml
@@ -6,7 +6,7 @@ ts:
   input: '{ kind: "a"; a: string; } | { kind: "b"; b: number; } | { kind: "c"; c: boolean; } | { kind: "d"; d: bigint; } | { kind: "e"; e: symbol; }'
   output: '{ kind: "a"; a: string; } | { kind: "b"; b: number; } | { kind: "c"; c: boolean; } | { kind: "d"; d: bigint; } | { kind: "e"; e: symbol; }'
   instantiations: 4876
-  bundleBytes: 9973
+  bundleBytes: 9962
 vs:
   zod: 'z.discriminatedUnion("kind", [z.object({ kind: z.literal("a"), a: z.string() }), z.object({ kind: z.literal("b"), b: z.number() }), z.object({ kind: z.literal("c"), c: z.boolean() }), z.object({ kind: z.literal("d"), d: z.bigint() }), z.object({ kind: z.literal("e"), e: z.symbol() })])'
 jsonSchema:

--- a/packages/sury/specs/union5-discriminated.yaml
+++ b/packages/sury/specs/union5-discriminated.yaml
@@ -6,7 +6,7 @@ ts:
   input: '{ kind: "a"; a: string; } | { kind: "b"; b: number; } | { kind: "c"; c: boolean; } | { kind: "d"; d: bigint; } | { kind: "e"; e: symbol; }'
   output: '{ kind: "a"; a: string; } | { kind: "b"; b: number; } | { kind: "c"; c: boolean; } | { kind: "d"; d: bigint; } | { kind: "e"; e: symbol; }'
   instantiations: 4876
-  bundleBytes: 9906
+  bundleBytes: 9972
 vs:
   zod: 'z.discriminatedUnion("kind", [z.object({ kind: z.literal("a"), a: z.string() }), z.object({ kind: z.literal("b"), b: z.number() }), z.object({ kind: z.literal("c"), c: z.boolean() }), z.object({ kind: z.literal("d"), d: z.bigint() }), z.object({ kind: z.literal("e"), e: z.symbol() })])'
 jsonSchema:

--- a/packages/sury/specs/union5.yaml
+++ b/packages/sury/specs/union5.yaml
@@ -4,7 +4,7 @@ ts:
   input: string | number | bigint | boolean | symbol
   output: string | number | bigint | boolean | symbol
   instantiations: 1877
-  bundleBytes: 9875
+  bundleBytes: 9943
 vs:
   zod: z.union([z.string(), z.number(), z.bigint(), z.boolean(), z.symbol()])
 jsonSchema:

--- a/packages/sury/specs/union5.yaml
+++ b/packages/sury/specs/union5.yaml
@@ -4,7 +4,7 @@ ts:
   input: string | number | bigint | boolean | symbol
   output: string | number | bigint | boolean | symbol
   instantiations: 1877
-  bundleBytes: 9945
+  bundleBytes: 9934
 vs:
   zod: z.union([z.string(), z.number(), z.bigint(), z.boolean(), z.symbol()])
 jsonSchema:

--- a/packages/sury/specs/unknown.yaml
+++ b/packages/sury/specs/unknown.yaml
@@ -4,7 +4,7 @@ ts:
   input: unknown
   output: unknown
   instantiations: 254
-  bundleBytes: 3462
+  bundleBytes: 3504
 vs:
   zod: z.unknown()
 jsonSchema:

--- a/packages/sury/specs/unknown.yaml
+++ b/packages/sury/specs/unknown.yaml
@@ -4,7 +4,7 @@ ts:
   input: unknown
   output: unknown
   instantiations: 254
-  bundleBytes: 3504
+  bundleBytes: 3478
 vs:
   zod: z.unknown()
 jsonSchema:

--- a/packages/sury/specs/void.yaml
+++ b/packages/sury/specs/void.yaml
@@ -4,7 +4,7 @@ ts:
   input: void
   output: void
   instantiations: 254
-  bundleBytes: 3859
+  bundleBytes: 3858
 vs:
   zod: z.void()
 jsonSchema:

--- a/packages/sury/specs/void.yaml
+++ b/packages/sury/specs/void.yaml
@@ -4,7 +4,7 @@ ts:
   input: void
   output: void
   instantiations: 254
-  bundleBytes: 3864
+  bundleBytes: 3859
 vs:
   zod: z.void()
 jsonSchema:

--- a/packages/sury/specs/void.yaml
+++ b/packages/sury/specs/void.yaml
@@ -4,7 +4,7 @@ ts:
   input: void
   output: void
   instantiations: 254
-  bundleBytes: 3825
+  bundleBytes: 3864
 vs:
   zod: z.void()
 jsonSchema:

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -181,67 +181,43 @@ export const B_hoistDecl = (owner: Val, decl: string): void => {
 }
 
 
-// 1-char-minified placeholder for "field unset" in B_val calls.
-export const U = undefined;
-
-// THE single Val creator: every codegen Val is born here, so they all share
-// one object literal → ONE V8 hidden class → monomorphic property reads in
-// the hot merge/parse loops and cheap allocation. Positional args cover only
-// the fields that ever vary at creation; `cp`/`hd` always start "" and
-// `fv`/`fz`/`o` always start unset, so they're hardcoded. Callers pass `U`
-// for unset slots. Add a new Val field HERE (and in the `Val` type), nowhere
-// else.
-export const B_val = (
-  b: Val | undefined,
-  p: Val | undefined,
-  v: () => string,
-  i: string,
-  s: Internal,
-  io: boolean | undefined,
-  e: Internal,
-  prev: Val | undefined,
-  f: Flag,
-  d: Record<string, Val> | undefined,
-  vc: Check[] | undefined,
-  u: boolean | undefined,
-  t: boolean | undefined,
-  path: Path,
-  g: BGlobal
-): Val => ({
-  b,
-  p,
-  v,
-  i,
-  s,
-  io,
-  e,
-  prev,
-  f,
-  d,
-  fv: U,
-  cp: "",
-  hd: "",
-  fz: U,
-  vc,
-  u,
-  t,
-  path,
-  g,
-  o: U,
-});
-
 export const B_operationArg = (
   schema: Internal,
   expected: Internal,
   flag: Flag,
   defs: Record<string, Internal> | undefined
 ): Val => {
-  return B_val(U, U, _var, operationArgVar, schema, U, expected, U, valFlagNone, U, U, U, U, pathEmpty, {
-    d: defs,
-    o: flag,
-    e: [],
-    v: -1,
-  });
+  // Every Val literal in the codegen path lists the same fields in the same
+  // order (undefined where unset) so V8 gives them all ONE hidden class —
+  // monomorphic property reads in the hot merge/parse loops and faster
+  // allocation. Keep this canonical order in sync across all Val creators.
+  return {
+    b: undefined,
+    p: undefined,
+    v: _var,
+    i: operationArgVar,
+    s: schema,
+    io: undefined,
+    e: expected,
+    prev: undefined,
+    f: valFlagNone,
+    d: undefined,
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: undefined,
+    path: pathEmpty,
+    g: {
+      d: defs,
+      o: flag,
+      e: [],
+      v: -1,
+    },
+    o: undefined,
+  };
 }
 
 export const B_throw = (errorDetails: ErrorDetails): never => {
@@ -532,14 +508,58 @@ export const B_next = (prev: Val, initial: string, schema: Internal, expected: I
   // child vals are shared by reference with `prev`/`val`, not copied — see
   // the matching note on B_scope's `d: val.d` below. Whether that aliasing
   // is actually safe is an open question, not a settled design.
-  return B_val(U, U, _notVar, initial, schema, U, expected, prev, valFlagNone, prev.d, U, U, true, prev.path, prev.g);
+  // Canonical Val field order (see B_operationArg).
+  return {
+    b: undefined,
+    p: undefined,
+    v: _notVar,
+    i: initial,
+    s: schema,
+    io: undefined,
+    e: expected,
+    prev,
+    f: valFlagNone,
+    d: prev.d,
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: true,
+    path: prev.path,
+    g: prev.g,
+    o: undefined,
+  };
 }
 
 // Pass a non-empty `~checks` or omit it. Never pass `~checks=[]` —
 // that would break the val.checks "absent iff no checks" invariant.
 export const B_refine = (val: Val, schema: Internal = val.s, checks?: Check[], expected: Internal = val.e): Val => {
   const shouldLink = val.v !== _var;
-  const nextVal = B_val(U, U, shouldLink ? _prevVar : _var, val.i, schema, U, expected, val, val.f, val.d, checks, U, val.t, val.path, val.g);
+  // Canonical Val field order (see B_operationArg).
+  const nextVal: Val = {
+    b: undefined,
+    p: undefined,
+    v: shouldLink ? _prevVar : _var,
+    i: val.i,
+    s: schema,
+    io: undefined,
+    e: expected,
+    prev: val,
+    f: val.f,
+    d: val.d,
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: checks,
+    u: undefined,
+    t: val.t,
+    path: val.path,
+    g: val.g,
+    o: undefined,
+  };
   if (shouldLink) {
     B_linkVar(val, nextVal);
   }
@@ -629,27 +649,35 @@ export const B_dynamicScope = (from: Val, locationVar: string): Val => {
   // dict sources; the `unknown` fallback keeps a misuse safe instead of crashing.
   const schemaAdditionalItems = from.s.additionalItems;
   const expectedAdditionalItems = from.e.additionalItems;
-  return B_val(
-    U,
-    from,
-    _notVarBeforeValidation,
-    `${from.v()}[${locationVar}]`,
-    schemaAdditionalItems !== undefined && typeof schemaAdditionalItems !== "string"
-      ? schemaAdditionalItems
-      : unknown,
-    U,
-    expectedAdditionalItems !== undefined && typeof expectedAdditionalItems !== "string"
-      ? expectedAdditionalItems
-      : unknown,
-    U,
-    from.f,
-    U,
-    U,
-    U,
-    U,
-    pathEmpty,
-    from.g
-  );
+  // Canonical Val field order (see B_operationArg).
+  return {
+    b: undefined,
+    p: from,
+    v: _notVarBeforeValidation,
+    i: `${from.v()}[${locationVar}]`,
+    s:
+      schemaAdditionalItems !== undefined && typeof schemaAdditionalItems !== "string"
+        ? schemaAdditionalItems
+        : unknown,
+    io: undefined,
+    e:
+      expectedAdditionalItems !== undefined && typeof expectedAdditionalItems !== "string"
+        ? expectedAdditionalItems
+        : unknown,
+    prev: undefined,
+    f: from.f,
+    d: undefined,
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: undefined,
+    path: pathEmpty,
+    g: from.g,
+    o: undefined,
+  };
 }
 
 export const B_nextConst = (from: Val, schema: Internal, expected?: Internal): Val => {
@@ -699,8 +727,29 @@ export const B_scope = (val: Val): Val => {
   const shouldLink = val.v !== _var;
 
   // TODO: Simplify bond
-  // `d: val.d` — see the aliasing note on B_next's `d: prev.d` above.
-  const nextVal = B_val(val, U, shouldLink ? _bondVar : _var, val.i, val.s, val.io, val.e, U, flagNone, val.d, U, false, false, val.path, val.g);
+  // Canonical Val field order (see B_operationArg).
+  const nextVal: Val = {
+    b: val,
+    p: undefined,
+    v: shouldLink ? _bondVar : _var,
+    i: val.i,
+    s: val.s,
+    io: val.io,
+    e: val.e,
+    prev: undefined,
+    f: flagNone,
+    d: val.d, // See the aliasing note on B_next's `d: prev.d` above.
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: false,
+    t: false,
+    path: val.path,
+    g: val.g,
+    o: undefined,
+  };
   if (shouldLink) {
     B_linkVar(val, nextVal);
   }

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -1,5 +1,5 @@
 import { SuryError, unknown } from "./schema";
-import { BGlobal, Check, ErrorDetails, Internal, InvalidInputDetails, SuryErrorRecord, Val, immutableEmptyArray, s, shouldPrependPathKey, stringify, toExpression } from "./types";
+import { BGlobal, Check, ErrorDetails, Internal, InvalidInputDetails, SuryErrorRecord, U, Val, immutableEmptyArray, s, shouldPrependPathKey, stringify, toExpression } from "./types";
 import { Flag, flagAsync, flagNone, flagUnsafeHas, valFlagAsync, valFlagNone } from "./flags";
 import { Path, inlinedValueFromString, pathConcat, pathEmpty, pathFromInlinedLocation } from "./path";
 import { arrayTag, tagFlagBigint, tagFlagFunction, tagFlagInstance, tagFlagString, tagFlagSymbol, tagFlagUndefined, tagFlags } from "./tags";
@@ -87,7 +87,7 @@ export function _notVar(this: Val): string {
     return val.i;
   } else {
     const v = B_varWithoutAllocation(val.g);
-    if (val.prev !== undefined) {
+    if (val.prev !== U) {
       // Own the decl in codeFromPrev: a non-empty codeFromPrev is
       // non-hoistable in `merge`, so a union discriminant reading this var
       // can't be lifted above its `let` (the str->to(option(int)) bug class).
@@ -120,8 +120,8 @@ export const operationArgVar = "i";
 // error semantics. Stable reference → adjacent checks fuse.
 export const failInvalidType = (input: Val): (value: unknown) => ErrorDetails => {
   const em = input.e.errorMessage;
-  const override = em !== undefined ? (em.type !== undefined ? em.type : em._) : undefined;
-  return B_invalidInputBuilder(undefined, undefined, override)(input);
+  const override = em !== U ? (em.type !== U ? em.type : em._) : U;
+  return B_invalidInputBuilder(U, U, override)(input);
 }
 
 export const B_embed = (b: Val, value: unknown): string => {
@@ -192,23 +192,23 @@ export const B_operationArg = (
   // monomorphic property reads in the hot merge/parse loops and faster
   // allocation. Keep this canonical order in sync across all Val creators.
   return {
-    b: undefined,
-    p: undefined,
+    b: U,
+    p: U,
     v: _var,
     i: operationArgVar,
     s: schema,
-    io: undefined,
+    io: U,
     e: expected,
-    prev: undefined,
+    prev: U,
     f: valFlagNone,
-    d: undefined,
-    fv: undefined,
+    d: U,
+    fv: U,
     cp: "",
     hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
-    t: undefined,
+    fz: U,
+    vc: U,
+    u: U,
+    t: U,
     path: pathEmpty,
     g: {
       d: defs,
@@ -216,7 +216,7 @@ export const B_operationArg = (
       e: [],
       v: -1,
     },
-    o: undefined,
+    o: U,
   };
 }
 
@@ -277,7 +277,7 @@ export const B_makeInvalidConversionDetails = (input: Val, to: Internal, cause: 
 // Checks run against `prev.var()`, so the runtime type at check time
 // is `prev.schema`, not the post-narrowing schema on the current val.
 const B_receivedSchema = (val: Val): Internal => {
-  return val.prev !== undefined ? val.prev.s : val.s;
+  return val.prev !== U ? val.prev.s : val.s;
 }
 
 export const B_makeInvalidInputDetails = (
@@ -290,12 +290,12 @@ export const B_makeInvalidInputDetails = (
   reasonOverride?: string
 ): ErrorDetails => {
   let reasonRef =
-    reasonOverride !== undefined
+    reasonOverride !== U
       ? reasonOverride
       : `Expected ${toExpression(expected)}, received ${
           includeInput ? stringify(input) : toExpression(received)
         }`;
-  if (unionErrors !== undefined) {
+  if (unionErrors !== U) {
     const caseErrors = unionErrors;
     const seenReasons = new Set<string>();
     for (let idx = 0; idx < caseErrors.length; idx++) {
@@ -335,7 +335,7 @@ export const B_invalidInputBuilder = (
   includeInput: boolean = true
 ): (input: Val) => (value: unknown) => ErrorDetails => {
   return (input: Val) => {
-    const expected_ = expected !== undefined ? expected : input.e;
+    const expected_ = expected !== U ? expected : input.e;
     const received = B_receivedSchema(input);
     const path = extraPath === pathEmpty ? input.path : pathConcat(input.path, extraPath);
     return (value: unknown) =>
@@ -345,7 +345,7 @@ export const B_invalidInputBuilder = (
         path,
         value,
         includeInput,
-        undefined,
+        U,
         reasonOverride
       );
   };
@@ -358,10 +358,10 @@ export const B_failWithErrorMessage = (
 ): (input: Val) => (value: unknown) => ErrorDetails => {
   return (input: Val) => {
     const em = input.e.errorMessage as Record<string, string | undefined> | undefined;
-    const override = em !== undefined ? (em[key] !== undefined ? em[key] : em["_"]) : undefined;
-    const m = override !== undefined ? override : defaultMessage;
-    if (m !== undefined) {
-      return B_invalidInputBuilder(undefined, undefined, m)(input);
+    const override = em !== U ? (em[key] !== U ? em[key] : em["_"]) : U;
+    const m = override !== U ? override : defaultMessage;
+    if (m !== U) {
+      return B_invalidInputBuilder(U, U, m)(input);
     } else {
       return failInvalidType(input);
     }
@@ -428,14 +428,14 @@ export const B_merge = (val: Val, hoistCond?: { contents: string }): string => {
   let current: Val | undefined = val;
   let code = "";
 
-  while (current !== undefined) {
+  while (current !== U) {
     const val: Val = current;
     current = val.prev;
 
     let currentCode = "";
 
     if (val.vc) {
-      if (hoistCond !== undefined && B_isHoistable(val)) {
+      if (hoistCond !== U && B_isHoistable(val)) {
         // Partition: route type-narrows to hoistCond, emit refines inline.
         // `noValidation` is intentionally bypassed for the hoisted part —
         // the cond routes between union cases, it doesn't reject, so
@@ -510,26 +510,26 @@ export const B_next = (prev: Val, initial: string, schema: Internal, expected: I
   // is actually safe is an open question, not a settled design.
   // Canonical Val field order (see B_operationArg).
   return {
-    b: undefined,
-    p: undefined,
+    b: U,
+    p: U,
     v: _notVar,
     i: initial,
     s: schema,
-    io: undefined,
+    io: U,
     e: expected,
     prev,
     f: valFlagNone,
     d: prev.d,
-    fv: undefined,
+    fv: U,
     cp: "",
     hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
+    fz: U,
+    vc: U,
+    u: U,
     t: true,
     path: prev.path,
     g: prev.g,
-    o: undefined,
+    o: U,
   };
 }
 
@@ -539,26 +539,26 @@ export const B_refine = (val: Val, schema: Internal = val.s, checks?: Check[], e
   const shouldLink = val.v !== _var;
   // Canonical Val field order (see B_operationArg).
   const nextVal: Val = {
-    b: undefined,
-    p: undefined,
+    b: U,
+    p: U,
     v: shouldLink ? _prevVar : _var,
     i: val.i,
     s: schema,
-    io: undefined,
+    io: U,
     e: expected,
     prev: val,
     f: val.f,
     d: val.d,
-    fv: undefined,
+    fv: U,
     cp: "",
     hd: "",
-    fz: undefined,
+    fz: U,
     vc: checks,
-    u: undefined,
+    u: U,
     t: val.t,
     path: val.path,
     g: val.g,
-    o: undefined,
+    o: U,
   };
   if (shouldLink) {
     B_linkVar(val, nextVal);
@@ -569,7 +569,7 @@ export const B_refine = (val: Val, schema: Internal = val.s, checks?: Check[], e
 // Lazy-allocate helper for mutating an existing val (as opposed to
 // building a local array and passing it through `refine`).
 export const B_pushCheck = (val: Val, check: Check): void => {
-  if (val.vc !== undefined) {
+  if (val.vc !== U) {
     val.vc.push(check);
   } else {
     val.vc = [check];
@@ -583,40 +583,40 @@ export const B_pushCheck = (val: Val, check: Check): void => {
 export const B_markOutput = (val: Val, valInput: Val): Val => {
   let deferredInputChecks: Check[] | undefined;
   const inputRefiner = valInput.e.inputRefiner;
-  if (inputRefiner !== undefined) {
+  if (inputRefiner !== U) {
     const checks = inputRefiner(valInput);
     if (checks.length > 0) {
-      if (valInput.prev !== undefined) {
+      if (valInput.prev !== U) {
         for (let i = 0; i < checks.length; i++) {
           B_pushCheck(valInput, checks[i]!);
         }
-        deferredInputChecks = undefined;
+        deferredInputChecks = U;
       } else {
         deferredInputChecks = checks;
       }
     } else {
-      deferredInputChecks = undefined;
+      deferredInputChecks = U;
     }
   } else {
-    deferredInputChecks = undefined;
+    deferredInputChecks = U;
   }
 
   let outputChecks: Check[] | undefined;
   const refiner = val.e.refiner;
-  if (refiner !== undefined) {
+  if (refiner !== U) {
     const checks = refiner(val);
-    outputChecks = checks.length > 0 ? checks : undefined;
+    outputChecks = checks.length > 0 ? checks : U;
   } else {
-    outputChecks = undefined;
+    outputChecks = U;
   }
 
   let result: Val;
-  if (deferredInputChecks !== undefined && outputChecks !== undefined) {
-    result = B_refine(val, undefined, deferredInputChecks.concat(outputChecks));
-  } else if (deferredInputChecks !== undefined) {
-    result = B_refine(val, undefined, deferredInputChecks);
-  } else if (outputChecks !== undefined) {
-    result = B_refine(val, undefined, outputChecks);
+  if (deferredInputChecks !== U && outputChecks !== U) {
+    result = B_refine(val, U, deferredInputChecks.concat(outputChecks));
+  } else if (deferredInputChecks !== U) {
+    result = B_refine(val, U, deferredInputChecks);
+  } else if (outputChecks !== U) {
+    result = B_refine(val, U, outputChecks);
   } else {
     result = val;
   }
@@ -637,7 +637,7 @@ export const B_hoistChildChecks = (parent: Val, child: Val, key: string): void =
         f: check.f,
       });
     });
-    child.vc = undefined;
+    child.vc = U;
   }
 }
 
@@ -651,32 +651,32 @@ export const B_dynamicScope = (from: Val, locationVar: string): Val => {
   const expectedAdditionalItems = from.e.additionalItems;
   // Canonical Val field order (see B_operationArg).
   return {
-    b: undefined,
+    b: U,
     p: from,
     v: _notVarBeforeValidation,
     i: `${from.v()}[${locationVar}]`,
     s:
-      schemaAdditionalItems !== undefined && typeof schemaAdditionalItems !== "string"
+      schemaAdditionalItems !== U && typeof schemaAdditionalItems !== "string"
         ? schemaAdditionalItems
         : unknown,
-    io: undefined,
+    io: U,
     e:
-      expectedAdditionalItems !== undefined && typeof expectedAdditionalItems !== "string"
+      expectedAdditionalItems !== U && typeof expectedAdditionalItems !== "string"
         ? expectedAdditionalItems
         : unknown,
-    prev: undefined,
+    prev: U,
     f: from.f,
-    d: undefined,
-    fv: undefined,
+    d: U,
+    fv: U,
     cp: "",
     hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
-    t: undefined,
+    fz: U,
+    vc: U,
+    u: U,
+    t: U,
     path: pathEmpty,
     g: from.g,
-    o: undefined,
+    o: U,
   };
 }
 
@@ -730,25 +730,25 @@ export const B_scope = (val: Val): Val => {
   // Canonical Val field order (see B_operationArg).
   const nextVal: Val = {
     b: val,
-    p: undefined,
+    p: U,
     v: shouldLink ? _bondVar : _var,
     i: val.i,
     s: val.s,
     io: val.io,
     e: val.e,
-    prev: undefined,
+    prev: U,
     f: flagNone,
     d: val.d, // See the aliasing note on B_next's `d: prev.d` above.
-    fv: undefined,
+    fv: U,
     cp: "",
     hd: "",
-    fz: undefined,
-    vc: undefined,
+    fz: U,
+    vc: U,
     u: false,
     t: false,
     path: val.path,
     g: val.g,
-    o: undefined,
+    o: U,
   };
   if (shouldLink) {
     B_linkVar(val, nextVal);
@@ -790,7 +790,7 @@ export const B_effectCtx = (input: Val): EffectCtx => {
   return {
     fail: (message: string, path: Path = pathEmpty): never => {
       const error = new SuryError(
-        B_invalidInputBuilder(undefined, path, message, false)(input)(void 0)
+        B_invalidInputBuilder(U, path, message, false)(input)(U)
       );
       // Read about this in shouldPrependPathKey comment.
       (error as unknown as Record<string, unknown>)[shouldPrependPathKey] = 1;
@@ -814,7 +814,7 @@ const B_mergeWithCatch = (
     // FIXME: Instead of this wrap all S.transform in a try/catch
     !flagUnsafeHas(val.f, valFlagAsync)
   ) {
-    return valCode + (appendSafe !== undefined ? appendSafe() : "");
+    return valCode + (appendSafe !== U ? appendSafe() : "");
   } else {
     const errorVar = B_varWithoutAllocation(val.g);
 
@@ -824,7 +824,7 @@ const B_mergeWithCatch = (
       val.i = `${val.i}.catch(${errorVar}=>{${catchCode}})`;
     }
     return `try{${valCode}${
-      appendSafe !== undefined ? appendSafe() : ""
+      appendSafe !== U ? appendSafe() : ""
     }}catch(${errorVar}){${catchCode}}`;
   }
 }
@@ -835,7 +835,7 @@ export const B_mergeWithPathPrepend = (
   locationVar?: string,
   appendSafe?: () => string
 ): string => {
-  if (val.path === pathEmpty && locationVar === undefined) {
+  if (val.path === pathEmpty && locationVar === U) {
     return B_merge(val);
   } else {
     return B_mergeWithCatch(
@@ -843,7 +843,7 @@ export const B_mergeWithPathPrepend = (
       (errorVar) =>
         `${errorVar}.path=${
           parent.path === "" ? "" : `${inlinedValueFromString(parent.path)}+`
-        }${locationVar !== undefined ? `'["'+${locationVar}+'"]'+` : ""}${errorVar}.path`,
+        }${locationVar !== U ? `'["'+${locationVar}+'"]'+` : ""}${errorVar}.path`,
       appendSafe
     );
   }

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -152,17 +152,6 @@ export const B_inlineConst = (b: Val, schema: Internal): string => {
   }
 }
 
-// Escape a location into an inlined JS string literal. Previously this cached
-// the result on bGlobal, but that cost more than it saved: the cache key
-// `"${location}"` is itself a fresh string (and for a plain identifier is
-// byte-identical to the value it caches), and stashing arbitrary field-name
-// keys on the per-compile bGlobal transitioned it to dictionary mode. A direct
-// escape allocates strictly fewer strings and keeps bGlobal monomorphic.
-export const B_inlineLocation = (global: BGlobal, location: string): string => {
-  return inlinedValueFromString(location);
-}
-
-
 export const B_varWithoutAllocation = (global: BGlobal): string => {
   const newCounter = global.v + 1;
   global.v = newCounter;
@@ -630,7 +619,7 @@ export const B_markOutput = (val: Val, valInput: Val): Val => {
 // parent's own type guard. No-op if the child has no checks.
 export const B_hoistChildChecks = (parent: Val, child: Val, key: string): void => {
   if (child.vc) {
-    const pathAppend = pathFromInlinedLocation(B_inlineLocation(parent.g, key));
+    const pathAppend = pathFromInlinedLocation(inlinedValueFromString(key));
     child.vc!.forEach((check) => {
       B_pushCheck(parent, {
         c: (inputVar) => check.c(inputVar + pathAppend),

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -181,43 +181,67 @@ export const B_hoistDecl = (owner: Val, decl: string): void => {
 }
 
 
+// 1-char-minified placeholder for "field unset" in B_val calls.
+export const U = undefined;
+
+// THE single Val creator: every codegen Val is born here, so they all share
+// one object literal → ONE V8 hidden class → monomorphic property reads in
+// the hot merge/parse loops and cheap allocation. Positional args cover only
+// the fields that ever vary at creation; `cp`/`hd` always start "" and
+// `fv`/`fz`/`o` always start unset, so they're hardcoded. Callers pass `U`
+// for unset slots. Add a new Val field HERE (and in the `Val` type), nowhere
+// else.
+export const B_val = (
+  b: Val | undefined,
+  p: Val | undefined,
+  v: () => string,
+  i: string,
+  s: Internal,
+  io: boolean | undefined,
+  e: Internal,
+  prev: Val | undefined,
+  f: Flag,
+  d: Record<string, Val> | undefined,
+  vc: Check[] | undefined,
+  u: boolean | undefined,
+  t: boolean | undefined,
+  path: Path,
+  g: BGlobal
+): Val => ({
+  b,
+  p,
+  v,
+  i,
+  s,
+  io,
+  e,
+  prev,
+  f,
+  d,
+  fv: U,
+  cp: "",
+  hd: "",
+  fz: U,
+  vc,
+  u,
+  t,
+  path,
+  g,
+  o: U,
+});
+
 export const B_operationArg = (
   schema: Internal,
   expected: Internal,
   flag: Flag,
   defs: Record<string, Internal> | undefined
 ): Val => {
-  // Every Val literal in the codegen path lists the same fields in the same
-  // order (undefined where unset) so V8 gives them all ONE hidden class —
-  // monomorphic property reads in the hot merge/parse loops and faster
-  // allocation. Keep this canonical order in sync across all Val creators.
-  return {
-    b: undefined,
-    p: undefined,
-    v: _var,
-    i: operationArgVar,
-    s: schema,
-    io: undefined,
-    e: expected,
-    prev: undefined,
-    f: valFlagNone,
-    d: undefined,
-    fv: undefined,
-    cp: "",
-    hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
-    t: undefined,
-    path: pathEmpty,
-    g: {
-      d: defs,
-      o: flag,
-      e: [],
-      v: -1,
-    },
-    o: undefined,
-  };
+  return B_val(U, U, _var, operationArgVar, schema, U, expected, U, valFlagNone, U, U, U, U, pathEmpty, {
+    d: defs,
+    o: flag,
+    e: [],
+    v: -1,
+  });
 }
 
 export const B_throw = (errorDetails: ErrorDetails): never => {
@@ -508,58 +532,14 @@ export const B_next = (prev: Val, initial: string, schema: Internal, expected: I
   // child vals are shared by reference with `prev`/`val`, not copied — see
   // the matching note on B_scope's `d: val.d` below. Whether that aliasing
   // is actually safe is an open question, not a settled design.
-  // Canonical Val field order (see B_operationArg).
-  return {
-    b: undefined,
-    p: undefined,
-    v: _notVar,
-    i: initial,
-    s: schema,
-    io: undefined,
-    e: expected,
-    prev,
-    f: valFlagNone,
-    d: prev.d,
-    fv: undefined,
-    cp: "",
-    hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
-    t: true,
-    path: prev.path,
-    g: prev.g,
-    o: undefined,
-  };
+  return B_val(U, U, _notVar, initial, schema, U, expected, prev, valFlagNone, prev.d, U, U, true, prev.path, prev.g);
 }
 
 // Pass a non-empty `~checks` or omit it. Never pass `~checks=[]` —
 // that would break the val.checks "absent iff no checks" invariant.
 export const B_refine = (val: Val, schema: Internal = val.s, checks?: Check[], expected: Internal = val.e): Val => {
   const shouldLink = val.v !== _var;
-  // Canonical Val field order (see B_operationArg).
-  const nextVal: Val = {
-    b: undefined,
-    p: undefined,
-    v: shouldLink ? _prevVar : _var,
-    i: val.i,
-    s: schema,
-    io: undefined,
-    e: expected,
-    prev: val,
-    f: val.f,
-    d: val.d,
-    fv: undefined,
-    cp: "",
-    hd: "",
-    fz: undefined,
-    vc: checks,
-    u: undefined,
-    t: val.t,
-    path: val.path,
-    g: val.g,
-    o: undefined,
-  };
+  const nextVal = B_val(U, U, shouldLink ? _prevVar : _var, val.i, schema, U, expected, val, val.f, val.d, checks, U, val.t, val.path, val.g);
   if (shouldLink) {
     B_linkVar(val, nextVal);
   }
@@ -649,35 +629,27 @@ export const B_dynamicScope = (from: Val, locationVar: string): Val => {
   // dict sources; the `unknown` fallback keeps a misuse safe instead of crashing.
   const schemaAdditionalItems = from.s.additionalItems;
   const expectedAdditionalItems = from.e.additionalItems;
-  // Canonical Val field order (see B_operationArg).
-  return {
-    b: undefined,
-    p: from,
-    v: _notVarBeforeValidation,
-    i: `${from.v()}[${locationVar}]`,
-    s:
-      schemaAdditionalItems !== undefined && typeof schemaAdditionalItems !== "string"
-        ? schemaAdditionalItems
-        : unknown,
-    io: undefined,
-    e:
-      expectedAdditionalItems !== undefined && typeof expectedAdditionalItems !== "string"
-        ? expectedAdditionalItems
-        : unknown,
-    prev: undefined,
-    f: from.f,
-    d: undefined,
-    fv: undefined,
-    cp: "",
-    hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
-    t: undefined,
-    path: pathEmpty,
-    g: from.g,
-    o: undefined,
-  };
+  return B_val(
+    U,
+    from,
+    _notVarBeforeValidation,
+    `${from.v()}[${locationVar}]`,
+    schemaAdditionalItems !== undefined && typeof schemaAdditionalItems !== "string"
+      ? schemaAdditionalItems
+      : unknown,
+    U,
+    expectedAdditionalItems !== undefined && typeof expectedAdditionalItems !== "string"
+      ? expectedAdditionalItems
+      : unknown,
+    U,
+    from.f,
+    U,
+    U,
+    U,
+    U,
+    pathEmpty,
+    from.g
+  );
 }
 
 export const B_nextConst = (from: Val, schema: Internal, expected?: Internal): Val => {
@@ -727,29 +699,8 @@ export const B_scope = (val: Val): Val => {
   const shouldLink = val.v !== _var;
 
   // TODO: Simplify bond
-  // Canonical Val field order (see B_operationArg).
-  const nextVal: Val = {
-    b: val,
-    p: undefined,
-    v: shouldLink ? _bondVar : _var,
-    i: val.i,
-    s: val.s,
-    io: val.io,
-    e: val.e,
-    prev: undefined,
-    f: flagNone,
-    d: val.d, // See the aliasing note on B_next's `d: prev.d` above.
-    fv: undefined,
-    cp: "",
-    hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: false,
-    t: false,
-    path: val.path,
-    g: val.g,
-    o: undefined,
-  };
+  // `d: val.d` — see the aliasing note on B_next's `d: prev.d` above.
+  const nextVal = B_val(val, U, shouldLink ? _bondVar : _var, val.i, val.s, val.io, val.e, U, flagNone, val.d, U, false, false, val.path, val.g);
   if (shouldLink) {
     B_linkVar(val, nextVal);
   }

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -152,18 +152,14 @@ export const B_inlineConst = (b: Val, schema: Internal): string => {
   }
 }
 
-// Escape it once per compiled operation.
-// Use bGlobal as cache, so we don't allocate another object + it's garbage collected.
+// Escape a location into an inlined JS string literal. Previously this cached
+// the result on bGlobal, but that cost more than it saved: the cache key
+// `"${location}"` is itself a fresh string (and for a plain identifier is
+// byte-identical to the value it caches), and stashing arbitrary field-name
+// keys on the per-compile bGlobal transitioned it to dictionary mode. A direct
+// escape allocates strictly fewer strings and keeps bGlobal monomorphic.
 export const B_inlineLocation = (global: BGlobal, location: string): string => {
-  const key = `"${location}"`;
-  const cached = (global as unknown as Record<string, string | undefined>)[key];
-  if (cached !== undefined) {
-    return cached;
-  } else {
-    const inlinedLocation = inlinedValueFromString(location);
-    (global as unknown as Record<string, string>)[key] = inlinedLocation;
-    return inlinedLocation;
-  }
+  return inlinedValueFromString(location);
 }
 
 

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -187,14 +187,28 @@ export const B_operationArg = (
   flag: Flag,
   defs: Record<string, Internal> | undefined
 ): Val => {
+  // Every Val literal in the codegen path lists the same fields in the same
+  // order (undefined where unset) so V8 gives them all ONE hidden class —
+  // monomorphic property reads in the hot merge/parse loops and faster
+  // allocation. Keep this canonical order in sync across all Val creators.
   return {
-    cp: "",
-    hd: "",
+    b: undefined,
+    p: undefined,
     v: _var,
     i: operationArgVar,
-    f: valFlagNone,
     s: schema,
+    io: undefined,
     e: expected,
+    prev: undefined,
+    f: valFlagNone,
+    d: undefined,
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: undefined,
     path: pathEmpty,
     g: {
       d: defs,
@@ -202,6 +216,7 @@ export const B_operationArg = (
       e: [],
       v: -1,
     },
+    o: undefined,
   };
 }
 
@@ -489,23 +504,32 @@ const B_linkVar = (val: Val, nextVal: Val): void => {
 }
 
 export const B_next = (prev: Val, initial: string, schema: Internal, expected: Internal = prev.e): Val => {
+  // FIXME: `d` (the object-field-vals dict) and other val fields that hold
+  // child vals are shared by reference with `prev`/`val`, not copied — see
+  // the matching note on B_scope's `d: val.d` below. Whether that aliasing
+  // is actually safe is an open question, not a settled design.
+  // Canonical Val field order (see B_operationArg).
   return {
-    // FIXME: `d` (the object-field-vals dict) and other val fields that hold
-    // child vals are shared by reference with `prev`/`val`, not copied — see
-    // the matching note on B_scope's `d: val.d` below. Whether that aliasing
-    // is actually safe is an open question, not a settled design.
-    prev,
+    b: undefined,
+    p: undefined,
     v: _notVar,
     i: initial,
-    f: valFlagNone,
     s: schema,
+    io: undefined,
     e: expected,
+    prev,
+    f: valFlagNone,
+    d: prev.d,
+    fv: undefined,
     cp: "",
     hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: true,
     path: prev.path,
     g: prev.g,
-    t: true,
-    d: prev.d,
+    o: undefined,
   };
 }
 
@@ -513,20 +537,28 @@ export const B_next = (prev: Val, initial: string, schema: Internal, expected: I
 // that would break the val.checks "absent iff no checks" invariant.
 export const B_refine = (val: Val, schema: Internal = val.s, checks?: Check[], expected: Internal = val.e): Val => {
   const shouldLink = val.v !== _var;
+  // Canonical Val field order (see B_operationArg).
   const nextVal: Val = {
-    prev: val,
-    i: val.i,
+    b: undefined,
+    p: undefined,
     v: shouldLink ? _prevVar : _var,
-    f: val.f,
+    i: val.i,
     s: schema,
+    io: undefined,
     e: expected,
+    prev: val,
+    f: val.f,
+    d: val.d,
+    fv: undefined,
     cp: "",
     hd: "",
+    fz: undefined,
     vc: checks,
+    u: undefined,
+    t: val.t,
     path: val.path,
     g: val.g,
-    t: val.t,
-    d: val.d,
+    o: undefined,
   };
   if (shouldLink) {
     B_linkVar(val, nextVal);
@@ -617,23 +649,34 @@ export const B_dynamicScope = (from: Val, locationVar: string): Val => {
   // dict sources; the `unknown` fallback keeps a misuse safe instead of crashing.
   const schemaAdditionalItems = from.s.additionalItems;
   const expectedAdditionalItems = from.e.additionalItems;
+  // Canonical Val field order (see B_operationArg).
   return {
+    b: undefined,
+    p: from,
     v: _notVarBeforeValidation,
     i: `${from.v()}[${locationVar}]`,
-    f: from.f,
     s:
       schemaAdditionalItems !== undefined && typeof schemaAdditionalItems !== "string"
         ? schemaAdditionalItems
         : unknown,
+    io: undefined,
     e:
       expectedAdditionalItems !== undefined && typeof expectedAdditionalItems !== "string"
         ? expectedAdditionalItems
         : unknown,
+    prev: undefined,
+    f: from.f,
+    d: undefined,
+    fv: undefined,
     cp: "",
     hd: "",
-    p: from,
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: undefined,
     path: pathEmpty,
     g: from.g,
+    o: undefined,
   };
 }
 
@@ -684,21 +727,28 @@ export const B_scope = (val: Val): Val => {
   const shouldLink = val.v !== _var;
 
   // TODO: Simplify bond
+  // Canonical Val field order (see B_operationArg).
   const nextVal: Val = {
+    b: val,
+    p: undefined,
+    v: shouldLink ? _bondVar : _var,
     i: val.i,
     s: val.s,
+    io: val.io,
     e: val.e,
+    prev: undefined,
     f: flagNone,
-    path: val.path,
-    g: val.g,
-    v: shouldLink ? _bondVar : _var,
-    b: val,
+    d: val.d, // See the aliasing note on B_next's `d: prev.d` above.
+    fv: undefined,
     cp: "",
     hd: "",
+    fz: undefined,
+    vc: undefined,
     u: false,
     t: false,
-    io: val.io,
-    d: val.d, // See the aliasing note on B_next's `d: prev.d` above.
+    path: val.path,
+    g: val.g,
+    o: undefined,
   };
   if (shouldLink) {
     B_linkVar(val, nextVal);

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -1,10 +1,10 @@
 import { Literal_parse, isArrayCond, jsonName, objectTagCond, setHas, unit } from "./primitives";
 import { baseSchema, getOrRethrow, panic, unknown, updateOutput } from "./schema";
 import { getOutputSchema, nestedLoc, nestedOptionParser, never_, parse, parseDynamic, typeCheckCond } from "./parse";
-import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_inlineLocation, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_varWithoutAllocation, Builder, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
+import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_varWithoutAllocation, Builder, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
 import { AdditionalItems, Check, ErrorDetails, Internal, SuryErrorRecord, U, Val, immutableEmptyArray, immutableEmptyObject, isLiteral, isOptional } from "./types";
 import { flagUnsafeHas, valFlagAsync, valFlagNone } from "./flags";
-import { pathConcat, pathFromInlinedLocation } from "./path";
+import { inlinedValueFromString, pathConcat, pathFromInlinedLocation } from "./path";
 import { Tag, arrayTag, nullTag, numberTag, objectTag, tagFlagArray, tagFlagFunction, tagFlagInstance, tagFlagNaN, tagFlagNever, tagFlagNull, tagFlagObject, tagFlagRef, tagFlagUndefined, tagFlagUnion, tagFlagUnknown, tagFlags, undefinedTag, unionTag, unknownTag } from "./tags";
 
 // An object/array val (`makeObjectVal`'s result) reuses the plain `Val`
@@ -73,13 +73,13 @@ export const completeObjectVal = (objectVal: Val): Val => {
       optionalSettingCode = (objectVar: string) => {
         return (
           (existingFn === U ? "" : existingFn(objectVar)) +
-          `if(${val.v()}!==void 0){${objectVar}[${B_inlineLocation(objectVal.g, key)}]=${val.i}}`
+          `if(${val.v()}!==void 0){${objectVar}[${inlinedValueFromString(key)}]=${val.i}}`
         );
       };
     } else {
       inline =
         inline +
-        (isArray ? `${val.i}` : `${B_inlineLocation(objectVal.g, key)}:${val.i}`) +
+        (isArray ? `${val.i}` : `${inlinedValueFromString(key)}:${val.i}`) +
         ",";
     }
   }
@@ -459,7 +459,7 @@ export const objectDecoder = (unknownInput: Val): Val => {
           if (idx !== 0) {
             objectVal.cp = objectVal.cp + "&&";
           }
-          objectVal.cp = objectVal.cp + `${keyVar}!==${B_inlineLocation(input.g, key)}`;
+          objectVal.cp = objectVal.cp + `${keyVar}!==${inlinedValueFromString(key)}`;
         }
       }
       objectVal.cp =
@@ -1415,7 +1415,7 @@ export const valGet = (parent: Val, location: string): Val => {
       }
     }
 
-    const pathAppend = pathFromInlinedLocation(B_inlineLocation(parent.g, location));
+    const pathAppend = pathFromInlinedLocation(inlinedValueFromString(location));
 
     // Canonical Val field order (see B_operationArg in builder.ts).
     const item: Val = {

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -1,7 +1,7 @@
 import { Literal_parse, isArrayCond, jsonName, objectTagCond, setHas, unit } from "./primitives";
 import { baseSchema, getOrRethrow, panic, unknown, updateOutput } from "./schema";
 import { getOutputSchema, nestedLoc, nestedOptionParser, never_, parse, parseDynamic, typeCheckCond } from "./parse";
-import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_inlineLocation, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_val, B_varWithoutAllocation, Builder, U, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
+import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_inlineLocation, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_varWithoutAllocation, Builder, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
 import { AdditionalItems, Check, ErrorDetails, Internal, SuryErrorRecord, Val, immutableEmptyArray, immutableEmptyObject, isLiteral, isOptional } from "./types";
 import { flagUnsafeHas, valFlagAsync, valFlagNone } from "./flags";
 import { pathConcat, pathFromInlinedLocation } from "./path";
@@ -17,12 +17,13 @@ const isItemSchema = (x: AdditionalItems | undefined): x is Internal =>
 type CheckCache = { contents: Check[] | undefined };
 
 export const makeObjectVal = (prev: Val, schema: Internal): Val => {
-  return B_val(
-    U,
-    U,
-    _notVar,
-    "",
-    (schema.type === arrayTag
+  // Canonical Val field order (see B_operationArg in builder.ts).
+  return {
+    b: undefined,
+    p: undefined,
+    v: _notVar,
+    i: "",
+    s: (schema.type === arrayTag
       ? {
           type: arrayTag,
           items: [],
@@ -36,17 +37,22 @@ export const makeObjectVal = (prev: Val, schema: Internal): Val => {
           additionalItems: "strict",
           decoder: objectDecoder,
         }) as Internal,
-    U,
-    prev.e,
+    io: undefined,
+    e: prev.e,
     prev,
-    valFlagNone,
-    Object.create(null),
-    U,
-    U,
-    true,
-    prev.path,
-    prev.g
-  );
+    f: valFlagNone,
+    d: Object.create(null),
+    fv: undefined,
+    cp: "",
+    hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: true,
+    path: prev.path,
+    g: prev.g,
+    o: undefined,
+  };
 }
 export const completeObjectVal = (objectVal: Val): Val => {
   const isArray = objectVal.s.type === arrayTag;
@@ -1408,23 +1414,29 @@ export const valGet = (parent: Val, location: string): Val => {
 
     const pathAppend = pathFromInlinedLocation(B_inlineLocation(parent.g, location));
 
-    const item = B_val(
-      U,
-      parent,
-      _notVarAtParent,
-      isLiteral(schema) ? B_inlineConst(parent, schema) : `${parent.v()}${pathAppend}`,
-      schema,
-      U,
-      schema,
-      U,
-      valFlagNone,
-      U,
-      U,
-      U,
-      U,
-      pathConcat(parent.path, pathAppend),
-      parent.g
-    );
+    // Canonical Val field order (see B_operationArg in builder.ts).
+    const item: Val = {
+      b: undefined,
+      p: parent,
+      v: _notVarAtParent,
+      i: isLiteral(schema) ? B_inlineConst(parent, schema) : `${parent.v()}${pathAppend}`,
+      s: schema,
+      io: undefined,
+      e: schema,
+      prev: undefined,
+      f: valFlagNone,
+      d: undefined,
+      fv: undefined,
+      cp: "",
+      hd: "",
+      fz: undefined,
+      vc: undefined,
+      u: undefined,
+      t: undefined,
+      path: pathConcat(parent.path, pathAppend),
+      g: parent.g,
+      o: undefined,
+    };
     vals[location] = item;
     return item;
   }

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -17,11 +17,12 @@ const isItemSchema = (x: AdditionalItems | undefined): x is Internal =>
 type CheckCache = { contents: Check[] | undefined };
 
 export const makeObjectVal = (prev: Val, schema: Internal): Val => {
+  // Canonical Val field order (see B_operationArg in builder.ts).
   return {
-    prev,
+    b: undefined,
+    p: undefined,
     v: _notVar,
     i: "",
-    f: valFlagNone,
     s: (schema.type === arrayTag
       ? {
           type: arrayTag,
@@ -36,13 +37,21 @@ export const makeObjectVal = (prev: Val, schema: Internal): Val => {
           additionalItems: "strict",
           decoder: objectDecoder,
         }) as Internal,
+    io: undefined,
     e: prev.e,
+    prev,
+    f: valFlagNone,
     d: Object.create(null),
-    t: true,
+    fv: undefined,
     cp: "",
     hd: "",
+    fz: undefined,
+    vc: undefined,
+    u: undefined,
+    t: true,
     path: prev.path,
     g: prev.g,
+    o: undefined,
   };
 }
 export const completeObjectVal = (objectVal: Val): Val => {
@@ -1405,17 +1414,28 @@ export const valGet = (parent: Val, location: string): Val => {
 
     const pathAppend = pathFromInlinedLocation(B_inlineLocation(parent.g, location));
 
+    // Canonical Val field order (see B_operationArg in builder.ts).
     const item: Val = {
+      b: undefined,
+      p: parent,
       v: _notVarAtParent,
       i: isLiteral(schema) ? B_inlineConst(parent, schema) : `${parent.v()}${pathAppend}`,
-      f: valFlagNone,
       s: schema,
+      io: undefined,
       e: schema,
+      prev: undefined,
+      f: valFlagNone,
+      d: undefined,
+      fv: undefined,
       cp: "",
       hd: "",
+      fz: undefined,
+      vc: undefined,
+      u: undefined,
+      t: undefined,
       path: pathConcat(parent.path, pathAppend),
       g: parent.g,
-      p: parent,
+      o: undefined,
     };
     vals[location] = item;
     return item;

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -1,7 +1,7 @@
 import { Literal_parse, isArrayCond, jsonName, objectTagCond, setHas, unit } from "./primitives";
 import { baseSchema, getOrRethrow, panic, unknown, updateOutput } from "./schema";
 import { getOutputSchema, nestedLoc, nestedOptionParser, never_, parse, parseDynamic, typeCheckCond } from "./parse";
-import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_inlineLocation, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_varWithoutAllocation, Builder, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
+import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_inlineLocation, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_val, B_varWithoutAllocation, Builder, U, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
 import { AdditionalItems, Check, ErrorDetails, Internal, SuryErrorRecord, Val, immutableEmptyArray, immutableEmptyObject, isLiteral, isOptional } from "./types";
 import { flagUnsafeHas, valFlagAsync, valFlagNone } from "./flags";
 import { pathConcat, pathFromInlinedLocation } from "./path";
@@ -17,13 +17,12 @@ const isItemSchema = (x: AdditionalItems | undefined): x is Internal =>
 type CheckCache = { contents: Check[] | undefined };
 
 export const makeObjectVal = (prev: Val, schema: Internal): Val => {
-  // Canonical Val field order (see B_operationArg in builder.ts).
-  return {
-    b: undefined,
-    p: undefined,
-    v: _notVar,
-    i: "",
-    s: (schema.type === arrayTag
+  return B_val(
+    U,
+    U,
+    _notVar,
+    "",
+    (schema.type === arrayTag
       ? {
           type: arrayTag,
           items: [],
@@ -37,22 +36,17 @@ export const makeObjectVal = (prev: Val, schema: Internal): Val => {
           additionalItems: "strict",
           decoder: objectDecoder,
         }) as Internal,
-    io: undefined,
-    e: prev.e,
+    U,
+    prev.e,
     prev,
-    f: valFlagNone,
-    d: Object.create(null),
-    fv: undefined,
-    cp: "",
-    hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
-    t: true,
-    path: prev.path,
-    g: prev.g,
-    o: undefined,
-  };
+    valFlagNone,
+    Object.create(null),
+    U,
+    U,
+    true,
+    prev.path,
+    prev.g
+  );
 }
 export const completeObjectVal = (objectVal: Val): Val => {
   const isArray = objectVal.s.type === arrayTag;
@@ -1414,29 +1408,23 @@ export const valGet = (parent: Val, location: string): Val => {
 
     const pathAppend = pathFromInlinedLocation(B_inlineLocation(parent.g, location));
 
-    // Canonical Val field order (see B_operationArg in builder.ts).
-    const item: Val = {
-      b: undefined,
-      p: parent,
-      v: _notVarAtParent,
-      i: isLiteral(schema) ? B_inlineConst(parent, schema) : `${parent.v()}${pathAppend}`,
-      s: schema,
-      io: undefined,
-      e: schema,
-      prev: undefined,
-      f: valFlagNone,
-      d: undefined,
-      fv: undefined,
-      cp: "",
-      hd: "",
-      fz: undefined,
-      vc: undefined,
-      u: undefined,
-      t: undefined,
-      path: pathConcat(parent.path, pathAppend),
-      g: parent.g,
-      o: undefined,
-    };
+    const item = B_val(
+      U,
+      parent,
+      _notVarAtParent,
+      isLiteral(schema) ? B_inlineConst(parent, schema) : `${parent.v()}${pathAppend}`,
+      schema,
+      U,
+      schema,
+      U,
+      valFlagNone,
+      U,
+      U,
+      U,
+      U,
+      pathConcat(parent.path, pathAppend),
+      parent.g
+    );
     vals[location] = item;
     return item;
   }

--- a/packages/sury/src/composites.ts
+++ b/packages/sury/src/composites.ts
@@ -2,7 +2,7 @@ import { Literal_parse, isArrayCond, jsonName, objectTagCond, setHas, unit } fro
 import { baseSchema, getOrRethrow, panic, unknown, updateOutput } from "./schema";
 import { getOutputSchema, nestedLoc, nestedOptionParser, never_, parse, parseDynamic, typeCheckCond } from "./parse";
 import { B_addObjectField, B_addKey, B_scope, B_asyncVal, B_dynamicScope, B_embed, B_failWithArg, B_hoistChildChecks, B_hoistDecl, B_inlineConst, B_inlineLocation, B_isHoistable, B_makeInvalidInputDetails, B_markOutput, B_merge, B_mergeWithPathPrepend, B_next, B_nextConst, B_pushCheck, B_refine, B_throw, B_unsupportedDecode, B_varWithoutAllocation, Builder, _notVar, _notVarAtParent, _var, failInvalidType } from "./builder";
-import { AdditionalItems, Check, ErrorDetails, Internal, SuryErrorRecord, Val, immutableEmptyArray, immutableEmptyObject, isLiteral, isOptional } from "./types";
+import { AdditionalItems, Check, ErrorDetails, Internal, SuryErrorRecord, U, Val, immutableEmptyArray, immutableEmptyObject, isLiteral, isOptional } from "./types";
 import { flagUnsafeHas, valFlagAsync, valFlagNone } from "./flags";
 import { pathConcat, pathFromInlinedLocation } from "./path";
 import { Tag, arrayTag, nullTag, numberTag, objectTag, tagFlagArray, tagFlagFunction, tagFlagInstance, tagFlagNaN, tagFlagNever, tagFlagNull, tagFlagObject, tagFlagRef, tagFlagUndefined, tagFlagUnion, tagFlagUnknown, tagFlags, undefinedTag, unionTag, unknownTag } from "./tags";
@@ -12,15 +12,15 @@ import { Tag, arrayTag, nullTag, numberTag, objectTag, tagFlagArray, tagFlagFunc
 
 // Narrows the dict-value-schema-or-mode union down to the schema case.
 const isItemSchema = (x: AdditionalItems | undefined): x is Internal =>
-  x !== undefined && typeof x !== "string";
+  x !== U && typeof x !== "string";
 
 type CheckCache = { contents: Check[] | undefined };
 
 export const makeObjectVal = (prev: Val, schema: Internal): Val => {
   // Canonical Val field order (see B_operationArg in builder.ts).
   return {
-    b: undefined,
-    p: undefined,
+    b: U,
+    p: U,
     v: _notVar,
     i: "",
     s: (schema.type === arrayTag
@@ -37,28 +37,28 @@ export const makeObjectVal = (prev: Val, schema: Internal): Val => {
           additionalItems: "strict",
           decoder: objectDecoder,
         }) as Internal,
-    io: undefined,
+    io: U,
     e: prev.e,
     prev,
     f: valFlagNone,
     d: Object.create(null),
-    fv: undefined,
+    fv: U,
     cp: "",
     hd: "",
-    fz: undefined,
-    vc: undefined,
-    u: undefined,
+    fz: U,
+    vc: U,
+    u: U,
     t: true,
     path: prev.path,
     g: prev.g,
-    o: undefined,
+    o: U,
   };
 }
 export const completeObjectVal = (objectVal: Val): Val => {
   const isArray = objectVal.s.type === arrayTag;
   let inline = "";
   let promiseAllContent = "";
-  let optionalSettingCode: ((objectVar: string) => string) | undefined = undefined;
+  let optionalSettingCode: ((objectVar: string) => string) | undefined = U;
 
   const keys = Object.keys(objectVal.d!);
 
@@ -72,7 +72,7 @@ export const completeObjectVal = (objectVal: Val): Val => {
       const existingFn = optionalSettingCode as ((objectVar: string) => string) | undefined;
       optionalSettingCode = (objectVar: string) => {
         return (
-          (existingFn === undefined ? "" : existingFn(objectVar)) +
+          (existingFn === U ? "" : existingFn(objectVar)) +
           `if(${val.v()}!==void 0){${objectVar}[${B_inlineLocation(objectVal.g, key)}]=${val.i}}`
         );
       };
@@ -108,7 +108,7 @@ export const completeObjectVal = (objectVal: Val): Val => {
     valWithRequired.io = true;
     return valWithRequired;
   } else {
-    if (optionalSettingCode === undefined) {
+    if (optionalSettingCode === U) {
       return valWithRequired;
     } else {
       const code = optionalSettingCode(valWithRequired.v());
@@ -204,7 +204,7 @@ export const arrayDecoder = (unknownInput: Val): Val => {
         itemOutput,
         input,
         iteratorVar,
-        hasTransform ? () => B_addKey(output2, iteratorVar, itemOutput) : undefined,
+        hasTransform ? () => B_addKey(output2, iteratorVar, itemOutput) : U,
       );
 
       if (hasTransform || itemCode !== "") {
@@ -322,7 +322,7 @@ export const objectDecoder = (unknownInput: Val): Val => {
   const expectedAdditionalItems = expectedSchema.additionalItems;
   const dictItem: Internal | undefined = isItemSchema(expectedAdditionalItems)
     ? expectedAdditionalItems
-    : undefined;
+    : U;
   // Only a dict source can be iterated dynamically (`for..in`). A fixed-property
   // object source coerced into a dict target reuses the static object-literal
   // construction below, driven by the source's known keys.
@@ -331,9 +331,9 @@ export const objectDecoder = (unknownInput: Val): Val => {
 
   let output: Val;
   // dict<unknown> target: any object/dict is already a valid value, pass through.
-  if (dictItem !== undefined && dictItem === unknown) {
+  if (dictItem !== U && dictItem === unknown) {
     output = input;
-  } else if (dictItem !== undefined && sourceIsDict) {
+  } else if (dictItem !== U && sourceIsDict) {
     const inputVar = input.v();
     const keyVar = B_varWithoutAllocation(input.g);
     const itemInput = B_dynamicScope(input, keyVar);
@@ -349,7 +349,7 @@ export const objectDecoder = (unknownInput: Val): Val => {
       itemOutput,
       input,
       keyVar,
-      hasTransform ? () => B_addKey(output2, keyVar, itemOutput) : undefined,
+      hasTransform ? () => B_addKey(output2, keyVar, itemOutput) : U,
     );
 
     if (hasTransform || itemCode !== "") {
@@ -369,7 +369,7 @@ export const objectDecoder = (unknownInput: Val): Val => {
     } else {
       output = output2;
     }
-  } else if (dictItem !== undefined) {
+  } else if (dictItem !== U) {
     const itemSchema = dictItem;
     // Encode a fixed-property object into a dict: build an object literal from
     // the SOURCE's keys, coercing every value to the dict's value schema.
@@ -524,15 +524,15 @@ export const unionIsPriority = (tagFlag: number, byKey: Record<string, unknown[]
 export const unionIsSelfDecodeNoop = (schema: Internal): boolean => {
   const additionalItems = schema.additionalItems;
   return (
-    schema.to === undefined &&
-    schema.parser === undefined &&
+    schema.to === U &&
+    schema.parser === U &&
     !flagUnsafeHas(tagFlags[schema.type]!, tagFlagRef) &&
-    (schema.anyOf !== undefined ? schema.anyOf.every(unionIsSelfDecodeNoop) : true) &&
-    (schema.items !== undefined ? schema.items.every(unionIsSelfDecodeNoop) : true) &&
-    (schema.properties !== undefined
+    (schema.anyOf !== U ? schema.anyOf.every(unionIsSelfDecodeNoop) : true) &&
+    (schema.items !== U ? schema.items.every(unionIsSelfDecodeNoop) : true) &&
+    (schema.properties !== U
       ? Object.values(schema.properties).every(unionIsSelfDecodeNoop)
       : true) &&
-    (additionalItems !== undefined && typeof additionalItems !== "string"
+    (additionalItems !== U && typeof additionalItems !== "string"
       ? unionIsSelfDecodeNoop(additionalItems)
       : true)
   );
@@ -541,7 +541,7 @@ export const unionIsSelfDecodeNoop = (schema: Internal): boolean => {
 export const unionIsWiderSchema = (schemaAnyOf: Internal[], inputAnyOf: Internal[]): boolean => {
   return inputAnyOf.every((inputSchema, idx) => {
     const schema = schemaAnyOf[idx];
-    if (schema !== undefined) {
+    if (schema !== U) {
       return (
         !flagUnsafeHas(
           tagFlags[inputSchema.type]!,
@@ -549,7 +549,7 @@ export const unionIsWiderSchema = (schemaAnyOf: Internal[], inputAnyOf: Internal
         ) &&
         inputSchema.type === schema.type &&
         inputSchema.const === schema.const &&
-        inputSchema.to === undefined
+        inputSchema.to === U
       );
     } else {
       return false;
@@ -560,7 +560,7 @@ export const unionIsWiderSchema = (schemaAnyOf: Internal[], inputAnyOf: Internal
 // The union's own `.to` chain which is applied per case during decoding.
 // None when the union has a custom parser owning the `.to` conversion
 export const unionGetToPerCase = (schema: Internal): Internal | undefined => {
-  return schema.parser === undefined && schema.to !== undefined ? schema.to : undefined;
+  return schema.parser === U && schema.to !== U ? schema.to : U;
 }
 
 // Whether a union-typed input can be decoded by dispatching
@@ -577,8 +577,8 @@ export const unionCanDispatchPerVariant = (inputAnyOf: Internal[], target: Inter
     // transformed unions) aren't supported per-variant yet
     !inputAnyOf.some(
       (v) =>
-        v.to !== undefined ||
-        v.parser !== undefined ||
+        v.to !== U ||
+        v.parser !== U ||
         flagUnsafeHas(tagFlags[v.type]!, tagFlagRef),
     )
   );
@@ -591,7 +591,7 @@ export const unionPerVariantVal = (input: Val, target: Internal): Val => {
   return B_refine(
     input,
     unknown,
-    undefined,
+    U,
     updateOutput<Internal>(input.s, (mut) => {
       mut.to = target;
     }),
@@ -604,7 +604,7 @@ export const unionEncoder = (input: Val, target: Internal): Val => {
   const inputAnyOf = input.s.anyOf!;
   if (
     target.type === unionTag &&
-    unionGetToPerCase(target) === undefined &&
+    unionGetToPerCase(target) === U &&
     unionIsWiderSchema(target.anyOf!, inputAnyOf)
   ) {
     // The target union decoder passes a narrower union input through as-is
@@ -627,18 +627,18 @@ export const unionDecoder: Builder = (input: Val) => {
     // The input val is already of the union type (trusted self-decode).
     // Only allowed when no variant transforms the value
     (input.s === selfSchema &&
-      toPerCase === undefined &&
+      toPerCase === U &&
       schemas.every(unionIsSelfDecodeNoop)) ||
     (flagUnsafeHas(initialInputTagFlag, tagFlagUnion) &&
       unionIsWiderSchema(schemas, input.s.anyOf!) &&
-      toPerCase === undefined) ||
+      toPerCase === U) ||
     (input.io! && input.e === input.s)
   ) {
     return input;
   } else {
     if (
       flagUnsafeHas(initialInputTagFlag, tagFlagUnion) ||
-      (input.s.encoder === undefined && flagUnsafeHas(initialInputTagFlag, tagFlagRef))
+      (input.s.encoder === U && flagUnsafeHas(initialInputTagFlag, tagFlagRef))
     ) {
       input.s = unknown;
     }
@@ -691,7 +691,7 @@ export const unionDecoder: Builder = (input: Val) => {
               input.path,
               args[0],
               true,
-              args.length > 1 ? (Array.from(args).slice(1) as SuryErrorRecord[]) : undefined,
+              args.length > 1 ? (Array.from(args).slice(1) as SuryErrorRecord[]) : U,
             ),
           );
         },
@@ -794,7 +794,7 @@ export const unionDecoder: Builder = (input: Val) => {
         if (!itemSkipped && itemCond) {
           if (itemCode) {
             const existing = byDiscriminant[itemCond];
-            if (existing !== undefined) {
+            if (existing !== U) {
               if (Array.isArray(existing)) {
                 existing.push(itemCode);
               } else {
@@ -920,19 +920,19 @@ export const unionDecoder: Builder = (input: Val) => {
       // Call each source refiner at most once so its predicate is embedded
       // in `input.global.embeded` once and every case references the same
       // `e[N]`. `B_embed` is append-only, so a per-case call would duplicate.
-      const cachedRefinerChecks: CheckCache = { contents: undefined };
-      const cachedInputRefinerChecks: CheckCache = { contents: undefined };
+      const cachedRefinerChecks: CheckCache = { contents: U };
+      const cachedInputRefinerChecks: CheckCache = { contents: U };
       const attach = (
         current: ((input: Val) => Check[]) | undefined,
         source: ((input: Val) => Check[]) | undefined,
         cache: CheckCache,
       ): ((input: Val) => Check[]) | undefined => {
-        if (source === undefined) {
+        if (source === U) {
           return current;
         } else {
           const fn = source;
           const getCached = (input: Val): Check[] => {
-            if (cache.contents !== undefined) {
+            if (cache.contents !== U) {
               return cache.contents;
             } else {
               const checks = fn(input);
@@ -940,7 +940,7 @@ export const unionDecoder: Builder = (input: Val) => {
               return checks;
             }
           };
-          if (current === undefined) {
+          if (current === U) {
             return getCached;
           } else {
             const existing = current;
@@ -957,11 +957,11 @@ export const unionDecoder: Builder = (input: Val) => {
       };
       return (mut: Internal) => {
         const r = attach(mut.refiner, unionRefiner, cachedRefinerChecks);
-        if (r !== undefined) {
+        if (r !== U) {
           mut.refiner = r;
         }
         const ir = attach(mut.inputRefiner, unionInputRefiner, cachedInputRefinerChecks);
-        if (ir !== undefined) {
+        if (ir !== U) {
           mut.inputRefiner = ir;
         }
       };
@@ -985,7 +985,7 @@ export const unionDecoder: Builder = (input: Val) => {
 
     for (let idx = 0; idx <= lastIdx; idx++) {
       const schema =
-        toPerCase !== undefined
+        toPerCase !== U
           ? updateOutput<Internal>(schemas[idx]!, (mut) => {
               appendUnionRefiners(mut);
               mut.to = toPerCase;
@@ -1004,7 +1004,7 @@ export const unionDecoder: Builder = (input: Val) => {
         // skip it
       } else {
         const initialArr = byKey[key];
-        if (initialArr !== undefined) {
+        if (initialArr !== U) {
           const arr = initialArr;
           if (
             flagUnsafeHas(tagFlag, tagFlagObject) &&
@@ -1087,7 +1087,7 @@ export const unionDecoder: Builder = (input: Val) => {
           } catch (_) {
             // Discard any checks parse managed to push before throwing,
             // so the deopt path doesn't see leftover partial state.
-            typeValidationInput.vc = undefined;
+            typeValidationInput.vc = U;
             typeValidationOutput = typeValidationInput;
           }
 
@@ -1107,7 +1107,7 @@ export const unionDecoder: Builder = (input: Val) => {
 
           let shouldDeopt = true;
           let valRef: Val | undefined = typeValidationOutput;
-          while (valRef !== undefined && shouldDeopt) {
+          while (valRef !== U && shouldDeopt) {
             const v: Val = valRef;
             valRef = v.prev;
             // Deopt to a try/catch block unless every level's checks are
@@ -1231,7 +1231,7 @@ export const unionDecoder: Builder = (input: Val) => {
     // coercing to the same `.to` target now produce structurally-identical (but
     // not identity-equal) outputs; `toJSONSchema` collapses the duplicate.
     o.s = outputAnyOf.length ? unionFactory(outputAnyOf) : never_();
-    if (toPerCase !== undefined) {
+    if (toPerCase !== U) {
       o.io = true;
       o.e = getOutputSchema(toPerCase);
     } else {
@@ -1257,7 +1257,7 @@ export const unionFactory = (schemas: Internal[]): Internal => {
 
     schemas.forEach((schema) => {
       // Check if the union is not transformed
-      if (schema.type === unionTag && schema.to === undefined) {
+      if (schema.type === unionTag && schema.to === U) {
         schema.anyOf!.forEach((item) => {
           anyOf.add(item);
         });
@@ -1325,10 +1325,10 @@ export const optionFactory = (item: Internal, unitSchema: Internal = unit()): In
           mutHas[unitSchema.type] = true;
           newAnyOf.push(unitSchema);
           toPush = nestedOption(schema);
-        } else if (schemaOut.properties !== undefined) {
+        } else if (schemaOut.properties !== U) {
           const properties = schemaOut.properties;
           const nestedSchema = properties[nestedLoc];
-          if (nestedSchema !== undefined) {
+          if (nestedSchema !== U) {
             toPush = updateOutput<Internal>(schema, (mut) => {
               // FIXME: dict{}
               const properties: Record<string, Internal> = {};
@@ -1366,7 +1366,7 @@ export const option = (item: Internal): Internal => {
 
 export const valGet = (parent: Val, location: string): Val => {
   let vals: Record<string, Val>;
-  if (parent.d !== undefined) {
+  if (parent.d !== U) {
     vals = parent.d;
   } else {
     const d: Record<string, Val> = Object.create(null);
@@ -1375,7 +1375,7 @@ export const valGet = (parent: Val, location: string): Val => {
   }
 
   const existing = vals[location];
-  if (existing !== undefined) {
+  if (existing !== U) {
     return B_scope(existing);
   } else {
     let locationSchema: Internal | undefined;
@@ -1385,7 +1385,7 @@ export const valGet = (parent: Val, location: string): Val => {
       locationSchema = parent.s.items![Number(location)];
     }
     let schema: Internal;
-    if (locationSchema !== undefined) {
+    if (locationSchema !== U) {
       schema = locationSchema;
     } else {
       const additionalItems = parent.s.additionalItems;
@@ -1416,26 +1416,26 @@ export const valGet = (parent: Val, location: string): Val => {
 
     // Canonical Val field order (see B_operationArg in builder.ts).
     const item: Val = {
-      b: undefined,
+      b: U,
       p: parent,
       v: _notVarAtParent,
       i: isLiteral(schema) ? B_inlineConst(parent, schema) : `${parent.v()}${pathAppend}`,
       s: schema,
-      io: undefined,
+      io: U,
       e: schema,
-      prev: undefined,
+      prev: U,
       f: valFlagNone,
-      d: undefined,
-      fv: undefined,
+      d: U,
+      fv: U,
       cp: "",
       hd: "",
-      fz: undefined,
-      vc: undefined,
-      u: undefined,
-      t: undefined,
+      fz: U,
+      vc: U,
+      u: U,
+      t: U,
       path: pathConcat(parent.path, pathAppend),
       g: parent.g,
-      o: undefined,
+      o: U,
     };
     vals[location] = item;
     return item;

--- a/packages/sury/src/factory.ts
+++ b/packages/sury/src/factory.ts
@@ -1,4 +1,4 @@
-import { B_addObjectField, B_mergeObjectFields, B_scope, B_inlineLocation, B_invalidOperation, B_markOutput, B_merge, B_nextConst, Builder, _notVarAtParent } from "./builder";
+import { B_addObjectField, B_mergeObjectFields, B_scope, B_invalidOperation, B_markOutput, B_merge, B_nextConst, Builder, _notVarAtParent } from "./builder";
 import { Literal_parse, literalDecoder, unit } from "./primitives";
 import { Option_getOr, TupleCtx } from "./operations";
 import { arrayDecoder, completeObjectVal, makeObjectVal, objectDecoder, optionFactory, unionFactory, valGet } from "./composites";
@@ -515,7 +515,7 @@ const getShapedSerializerOutput = (
           input,
           acc !== U && acc.properties !== U ? acc.properties[location] : U,
           childSchema,
-          pathConcat(path, pathFromInlinedLocation(B_inlineLocation(input.g, location)))
+          pathConcat(path, pathFromInlinedLocation(inlinedValueFromString(location)))
         ),
       (v) => {
         v.e = resolvedTargetSchema;

--- a/packages/sury/src/factory.ts
+++ b/packages/sury/src/factory.ts
@@ -4,7 +4,7 @@ import { Option_getOr, TupleCtx } from "./operations";
 import { arrayDecoder, completeObjectVal, makeObjectVal, objectDecoder, optionFactory, unionFactory, valGet } from "./composites";
 import { getOutputSchema, parse, reverse } from "./parse";
 import { baseSchema, copySchema, globalConfig, panic, updateOutput } from "./schema";
-import { Internal, Val, immutableEmptyArray, isLiteral, isSchemaObject, itemSymbol, toExpression } from "./types";
+import { Internal, U, Val, immutableEmptyArray, isLiteral, isSchemaObject, itemSymbol, toExpression } from "./types";
 import { Path, inlinedValueFromString, pathConcat, pathEmpty, pathFromInlinedLocation } from "./path";
 import { arrayTag, instanceTag, objectTag } from "./tags";
 
@@ -51,7 +51,7 @@ const makeFieldOr = (field: (location: string, schema: Internal) => unknown) =>
 const proxifyShapedSchema = (schema: Internal, from: string[], fromFlattened?: number): unknown => {
   const mut = copySchema(getOutputSchema(schema));
   mut.from = from;
-  if (fromFlattened !== undefined) {
+  if (fromFlattened !== U) {
     mut.fromFlattened = fromFlattened;
   }
   return new Proxy(mut, {
@@ -62,15 +62,15 @@ const proxifyShapedSchema = (schema: Internal, from: string[], fromFlattened?: n
         const location = prop as string;
 
         let maybeField: Internal | undefined;
-        if (target.properties !== undefined) {
+        if (target.properties !== U) {
           maybeField = target.properties[location];
-        } else if (target.items !== undefined) {
+        } else if (target.items !== U) {
           // If there are no properties, then it must be Tuple
           maybeField = target.items[location as unknown as number];
         } else {
-          maybeField = undefined;
+          maybeField = U;
         }
-        if (maybeField === undefined) {
+        if (maybeField === U) {
           panic(`Cannot read property "${location}" of ${toExpression(target)}`);
         }
 
@@ -103,7 +103,7 @@ function schemaNested(this: AdvancedObjectCtx & Record<string, unknown>, fieldNa
   const cacheId = `~${fieldName}`;
 
   const cachedCtx = parentCtx[cacheId] as AdvancedObjectCtx | undefined;
-  if (cachedCtx !== undefined) {
+  if (cachedCtx !== U) {
     return cachedCtx;
   } else {
     const properties = Object.create(null) as Record<string, Internal>;
@@ -183,7 +183,7 @@ export const schemaObject = (
   if (typeof definer !== "function") {
     return definitionToSchema(definer);
   }
-  let flattened: Internal[] | undefined = void 0;
+  let flattened: Internal[] | undefined = U;
   const properties = Object.create(null) as Record<string, Internal>;
 
   const flatten = (schema: Internal): unknown => {
@@ -194,9 +194,9 @@ export const schemaObject = (
         const key = flattenedKeys[idx]!;
         const flattenedSchema = flattenedProperties[key]!;
         const existing = properties[key];
-        if (existing !== undefined && existing === flattenedSchema) {
+        if (existing !== U && existing === flattenedSchema) {
           // Same field flattened in from two places — already registered, skip.
-        } else if (existing !== undefined) {
+        } else if (existing !== U) {
           panic(`The field "${key}" defined twice with incompatible schemas`);
         } else {
           properties[key] = flattenedSchema;
@@ -240,7 +240,7 @@ export const schemaObject = (
   mut.decoder = objectDecoder;
   mut.parser = shapedParser;
   mut.to = definitionToShapedSchema(definition);
-  if (flattened !== undefined) {
+  if (flattened !== U) {
     mut.flattened = flattened;
   }
   return mut;
@@ -295,7 +295,7 @@ const getValByFrom = (input: Val, from: string[], idx: number): Val => {
   // the right `input.fv[fromFlattened]` before calling this) — this walk only
   // needs to handle a plain nested `from` path.
   const key = from[idx];
-  if (key !== undefined) {
+  if (key !== U) {
     return getValByFrom(input.d![key]!, from, idx + 1);
   } else {
     return input;
@@ -315,16 +315,16 @@ const assembleShapedObject = (
 ): Val => {
   const output = makeObjectVal(input, schema);
   output.io = true;
-  if (init !== undefined) {
+  if (init !== U) {
     init(output);
   }
-  if (schema.items !== undefined) {
+  if (schema.items !== U) {
     const items = schema.items;
     for (let idx = 0; idx < items.length; idx++) {
       const location = String(idx);
       B_addObjectField(output, location, field(location, items[idx]!));
     }
-  } else if (schema.properties !== undefined) {
+  } else if (schema.properties !== U) {
     const properties = schema.properties;
     const keys = Object.keys(properties);
     for (let idx = 0; idx < keys.length; idx++) {
@@ -334,7 +334,7 @@ const assembleShapedObject = (
         B_addObjectField(output, location, field(location, properties[location]!));
       }
     }
-  } else if (onMissing !== undefined) {
+  } else if (onMissing !== U) {
     onMissing();
   } else {
     panic(
@@ -347,11 +347,11 @@ const assembleShapedObject = (
 
 const getShapedParserOutput = (input: Val, targetSchema: Internal): Val => {
   let v: Val;
-  if (targetSchema.fromFlattened !== undefined) {
+  if (targetSchema.fromFlattened !== U) {
     v = B_scope(
       getValByFrom(input.fv![targetSchema.fromFlattened]!, targetSchema.from!, 0)
     );
-  } else if (targetSchema.from !== undefined) {
+  } else if (targetSchema.from !== U) {
     v = B_scope(getValByFrom(input, targetSchema.from, 0));
   } else if (isLiteral(targetSchema)) {
     v = B_nextConst(input, targetSchema);
@@ -360,14 +360,14 @@ const getShapedParserOutput = (input: Val, targetSchema: Internal): Val => {
       getShapedParserOutput(input, childSchema)
     );
   }
-  v.prev = undefined;
+  v.prev = U;
   v.e = targetSchema;
   return v;
 }
 
 const shapedParser: Builder = (input: Val) => {
   const flattened = input.e.flattened;
-  if (flattened !== undefined) {
+  if (flattened !== U) {
     const flattenedVals: Val[] = [];
     for (let idx = 0; idx < flattened.length; idx++) {
       const flattenedSchema = flattened[idx]!;
@@ -377,7 +377,7 @@ const shapedParser: Builder = (input: Val) => {
       // would re-apply field-level transforms on the already-transformed value
       // (issue #271).
       let flattenedVal: Val;
-      if (flattenedSchema.to !== undefined) {
+      if (flattenedSchema.to !== U) {
         // The flattened schema has its own reshape/transform. Mark the input as
         // output so the parse loop skips the decoder and runs only that `.to`,
         // reading the decoded fields back through the shared `vals`.
@@ -399,7 +399,7 @@ const shapedParser: Builder = (input: Val) => {
         // from `prev` (as getShapedParserOutput does) so `merge` doesn't
         // re-emit the parent's declarations. Done before markOutput so any
         // refiner wrap it adds still points at the assembled object.
-        assembled.prev = undefined;
+        assembled.prev = U;
         flattenedVal = B_markOutput(assembled, assembled);
       }
       flattenedVals.push(flattenedVal);
@@ -416,16 +416,16 @@ const shapedParser: Builder = (input: Val) => {
 }
 
 const prepareShapedSerializerAcc = (acc: ShapedSerializerAcc, input: Val): void => {
-  if (input.e.from !== undefined) {
+  if (input.e.from !== U) {
     const from = input.e.from;
     const fromFlattened = input.e.fromFlattened;
     let accAtFrom: ShapedSerializerAcc;
-    if (fromFlattened !== undefined) {
-      if (acc.flattened === undefined) {
+    if (fromFlattened !== U) {
+      if (acc.flattened === U) {
         acc.flattened = [];
       }
       const existing = acc.flattened[fromFlattened];
-      if (existing === undefined) {
+      if (existing === U) {
         const newAcc: ShapedSerializerAcc = {};
         acc.flattened[fromFlattened] = newAcc;
         accAtFrom = newAcc;
@@ -438,7 +438,7 @@ const prepareShapedSerializerAcc = (acc: ShapedSerializerAcc, input: Val): void 
     for (let idx = 0; idx < from.length; idx++) {
       const key = from[idx]!;
       let p: Record<string, ShapedSerializerAcc>;
-      if (accAtFrom.properties !== undefined) {
+      if (accAtFrom.properties !== U) {
         p = accAtFrom.properties;
       } else {
         p = {};
@@ -446,7 +446,7 @@ const prepareShapedSerializerAcc = (acc: ShapedSerializerAcc, input: Val): void 
         accAtFrom.properties = p;
       }
       const existingAcc = p[key];
-      if (existingAcc !== undefined) {
+      if (existingAcc !== U) {
         accAtFrom = existingAcc;
       } else {
         const newAcc: ShapedSerializerAcc = {};
@@ -455,7 +455,7 @@ const prepareShapedSerializerAcc = (acc: ShapedSerializerAcc, input: Val): void 
       }
     }
     accAtFrom.val = input;
-  } else if (input.d !== undefined) {
+  } else if (input.d !== U) {
     const vals = input.d;
     const keys = Object.keys(vals);
     for (let idx = 0; idx < keys.length; idx++) {
@@ -470,7 +470,7 @@ const getShapedSerializerOutput = (
   targetSchema: Internal,
   path: Path
 ): Val => {
-  if (acc !== undefined && acc.val !== undefined) {
+  if (acc !== U && acc.val !== U) {
     // Placement of an already-decoded val — don't overwrite its schema (#284);
     // parse only re-advances `e` and emits nothing for an output val
     const v = B_scope(acc.val);
@@ -479,7 +479,7 @@ const getShapedSerializerOutput = (
     return parse(v);
   } else if (isLiteral(targetSchema)) {
     const v = B_nextConst(input, targetSchema, targetSchema);
-    v.prev = undefined;
+    v.prev = U;
     v.p = input;
     v.v = _notVarAtParent;
     v.io = true;
@@ -487,13 +487,13 @@ const getShapedSerializerOutput = (
   } else {
     // When acc is undefined (discriminant field with no input), follow the to chain
     // to get the actual output schema properties (e.g., for reversed transformed objects)
-    const resolvedTargetSchema = acc === undefined ? getOutputSchema(targetSchema) : targetSchema;
+    const resolvedTargetSchema = acc === U ? getOutputSchema(targetSchema) : targetSchema;
 
     const missingInput = (): never => {
       // PORT-NOTE: the source shadows `path` here; renamed to `path2` (TS
       // can't redeclare a parameter in the same scope).
       const path2 =
-        targetSchema.from !== undefined
+        targetSchema.from !== U
           ? path + targetSchema.from.map((item) => `["${item}"]`).join("")
           : path;
       return B_invalidOperation(
@@ -503,7 +503,7 @@ const getShapedSerializerOutput = (
     };
 
     // A dict-like target has no fixed locations to walk without an input acc
-    if (acc === undefined && typeof resolvedTargetSchema.additionalItems === objectTag) {
+    if (acc === U && typeof resolvedTargetSchema.additionalItems === objectTag) {
       return missingInput();
     }
 
@@ -513,17 +513,17 @@ const getShapedSerializerOutput = (
       (location, childSchema) =>
         getShapedSerializerOutput(
           input,
-          acc !== undefined && acc.properties !== undefined ? acc.properties[location] : undefined,
+          acc !== U && acc.properties !== U ? acc.properties[location] : U,
           childSchema,
           pathConcat(path, pathFromInlinedLocation(B_inlineLocation(input.g, location)))
         ),
       (v) => {
         v.e = resolvedTargetSchema;
-        v.prev = undefined;
+        v.prev = U;
         v.p = input;
         v.v = _notVarAtParent;
         const flattened = resolvedTargetSchema.flattened;
-        if (flattened !== undefined && acc !== undefined && acc.flattened !== undefined) {
+        if (flattened !== U && acc !== U && acc.flattened !== U) {
           const flattenedSchemas = flattened;
           const flattenedAcc = acc.flattened;
           flattenedAcc.forEach((acc, idx) => {
@@ -570,7 +570,7 @@ export const definitionToSchema = (definition: unknown): Internal => {
     if (isSchemaObject(node)) {
       return node as Internal;
     } else {
-      return undefined;
+      return U;
     }
   });
 }
@@ -581,7 +581,7 @@ const traverseDefinition = (
 ): Internal => {
   if (typeof definition === objectTag && definition !== null) {
     const s = onNode(definition);
-    if (s !== undefined) {
+    if (s !== U) {
       return s;
     } else {
       if (Array.isArray(definition)) {

--- a/packages/sury/src/formats.ts
+++ b/packages/sury/src/formats.ts
@@ -4,7 +4,7 @@ import { bool, float, inputToString, jsonName, literalDecoder, nullLiteral, numb
 import { baseSchema, cached, copySchema, unknown } from "./schema";
 import { B_addObjectField, B_embed, B_embedInvalidInput, B_failWithErrorMessage, B_next, B_nextConst, B_refine, B_unsupportedDecode, B_varWithoutAllocation, _var, failInvalidType } from "./builder";
 import { getDecoder, instanceDecoder, parse, reverse } from "./parse";
-import { Internal, SchemaErrorMessage, Val, isLiteral } from "./types";
+import { Internal, SchemaErrorMessage, U, Val, isLiteral } from "./types";
 import { Builder, Encoder } from "./builder";
 import { flagUnsafeHas } from "./flags";
 import { inlinedValueFromString } from "./path";
@@ -19,16 +19,16 @@ export const jsonEncoderFn = (input: Val, target: Internal): Val => {
       tagFlagString | tagFlagBoolean | tagFlagNumber | tagFlagNull,
     )
   ) {
-    return parse(B_refine(input, unknown, undefined, target));
+    return parse(B_refine(input, unknown, U, target));
   } else if (flagUnsafeHas(toTagFlag, (tagFlagUndefined | tagFlagNaN))) {
     const jsonExpected = copySchema(nullLiteral());
     jsonExpected.to = target;
-    return parse(B_refine(input, unknown, undefined, jsonExpected));
+    return parse(B_refine(input, unknown, U, jsonExpected));
   } else if (flagUnsafeHas(toTagFlag, tagFlagArray)) {
     // Validate that the input is an array
     // and then update the schema to be an array of json instead of array of unknown
     const jsonExpected = array(unknown);
-    const output = parse(B_refine(input, unknown, undefined, jsonExpected));
+    const output = parse(B_refine(input, unknown, U, jsonExpected));
     output.s.additionalItems = json();
     output.e = target;
     output.io = false;
@@ -37,7 +37,7 @@ export const jsonEncoderFn = (input: Val, target: Internal): Val => {
     // Validate that the input is an object
     // and then update the schema to be an object of json instead of object of unknown
     const jsonExpected = dictFactory(unknown);
-    const output = parse(B_refine(input, unknown, undefined, jsonExpected));
+    const output = parse(B_refine(input, unknown, U, jsonExpected));
     output.s.additionalItems = json();
     output.e = target;
     output.io = false;
@@ -48,7 +48,7 @@ export const jsonEncoderFn = (input: Val, target: Internal): Val => {
     // For non-JSON types (bigint, instance, etc.), decode through string
     const jsonExpected = copySchema(string());
     jsonExpected.to = target;
-    return parse(B_refine(input, unknown, undefined, jsonExpected));
+    return parse(B_refine(input, unknown, U, jsonExpected));
   }
 }
 
@@ -86,12 +86,12 @@ export const jsonDecoderFn = (input: Val): Val => {
         ? json()
         : input.s.additionalItems;
     expected.to = input.e.to;
-    return parse(B_refine(input, undefined, undefined, expected));
+    return parse(B_refine(input, U, U, expected));
   } else if (flagUnsafeHas(inputTagFlag, tagFlagObject)) {
     if (typeof input.s.additionalItems === "object") {
       const expected = dictFactory(json());
       expected.to = input.e.to;
-      return parse(B_refine(input, undefined, undefined, expected));
+      return parse(B_refine(input, U, U, expected));
     } else {
       const jsonVal = makeObjectVal(input, input.s);
       jsonVal.e = json();
@@ -239,7 +239,7 @@ export const jsonString = /* @__PURE__ */ (() => {
         jsonStringConstSchema.const = constSchemaToJsonStringConst(input, target);
         jsonStringConstSchema.to = target;
         jsonStringConstSchema.decoder = literalDecoder;
-        return B_refine(input, undefined, undefined, jsonStringConstSchema);
+        return B_refine(input, U, U, jsonStringConstSchema);
       } else {
         const outputVar = B_varWithoutAllocation(input.g);
 
@@ -300,11 +300,11 @@ export const jsonString = /* @__PURE__ */ (() => {
     } else if (flagUnsafeHas(inputTagFlag, tagFlagBigint)) {
       return B_next(input, `"\\""+${input.i}+"\\""`, expectedSchema);
     } else if (flagUnsafeHas(inputTagFlag, (tagFlagObject | tagFlagArray))) {
-      const jsonVal = parse(B_refine(input, undefined, undefined, json()));
+      const jsonVal = parse(B_refine(input, U, U, json()));
       return B_next(
         jsonVal,
         `JSON.stringify(${jsonVal.i}${
-          expectedSchema.space === 0 || expectedSchema.space === undefined
+          expectedSchema.space === 0 || expectedSchema.space === U
             ? ""
             : `,null,${expectedSchema.space}`
         })`,
@@ -348,7 +348,7 @@ export const uint8Array = (): Internal => {
         input = instanceDecoder(input);
       }
 
-      if (inputArg.e.to !== undefined && inputArg.e.parser === undefined) {
+      if (inputArg.e.to !== U && inputArg.e.parser === U) {
         const to = inputArg.e.to;
         const toTagFlag = tagFlags[to.type]!;
         if (flagUnsafeHas(toTagFlag, tagFlagString)) {
@@ -554,41 +554,41 @@ export type Meta<Value> = {
 // TODO: Better test reverse
 export const meta = <Value>(schema: Internal, data: Meta<Value>): Internal => {
   const mut = copySchema(schema);
-  if (data.name !== undefined) {
+  if (data.name !== U) {
     if (data.name === "") {
-      mut.name = undefined;
+      mut.name = U;
     } else {
       mut.name = data.name;
     }
   }
-  if (data.title !== undefined) {
+  if (data.title !== U) {
     if (data.title === "") {
-      mut.title = undefined;
+      mut.title = U;
     } else {
       mut.title = data.title;
     }
   }
-  if (data.description !== undefined) {
+  if (data.description !== U) {
     if (data.description === "") {
-      mut.description = undefined;
+      mut.description = U;
     } else {
       mut.description = data.description;
     }
   }
-  if (data.deprecated !== undefined) {
+  if (data.deprecated !== U) {
     mut.deprecated = data.deprecated;
   }
-  if (data.examples !== undefined) {
+  if (data.examples !== U) {
     if (data.examples.length === 0) {
       delete mut.examples;
     } else {
       mut.examples = data.examples.map(getDecoder(reverse(schema)));
     }
   }
-  if (data.errorMessage !== undefined) {
+  if (data.errorMessage !== U) {
     const em = data.errorMessage;
     if (Object.keys(em).length === 0) {
-      mut.errorMessage = undefined;
+      mut.errorMessage = U;
     } else {
       mut.errorMessage = em;
     }

--- a/packages/sury/src/jsapi.ts
+++ b/packages/sury/src/jsapi.ts
@@ -4,7 +4,7 @@ import { B_embed, B_failWithArg, B_invalidInputBuilder, B_makeInvalidConversionD
 import { definitionToSchema } from "./factory";
 import { objectDecoder, unionFactory } from "./composites";
 import { Option_getOr, Option_getOrWith, getAssertResult, internalRefine, nullAsUnit, transform } from "./operations";
-import { Check, Internal, Val, isSchemaObject } from "./types";
+import { Check, Internal, U, Val, isSchemaObject } from "./types";
 import { Builder } from "./builder";
 import { flagDisableNanNumberValidation } from "./flags";
 import { functionTag, objectTag, stringTag } from "./tags";
@@ -74,14 +74,14 @@ export const js_to = /* @__PURE__ */ (() => {
     maybeEncoder?: (target: unknown) => unknown,
   ) => {
     return updateOutput(schema, (mut) => {
-      if (maybeEncoder !== undefined) {
+      if (maybeEncoder !== U) {
         const targetMut = copySchema(target);
         targetMut.serializer = customBuilder(maybeEncoder);
         mut.to = targetMut;
       } else {
         mut.to = target;
       }
-      if (maybeDecoder !== undefined) {
+      if (maybeDecoder !== U) {
         mut.parser = customBuilder(maybeDecoder);
       }
     });
@@ -95,13 +95,13 @@ export const js_refine = (
 ) => {
   const message = refineOptions?.error ?? "Refinement failed";
   const extraPath =
-    refineOptions?.path !== undefined ? pathFromArray(refineOptions.path) : pathEmpty;
+    refineOptions?.path !== U ? pathFromArray(refineOptions.path) : pathEmpty;
   return internalRefine(schema, (_: Internal) => (input: Val): Check[] => {
     const embeddedCheck = B_embed(input, refineCheck);
     return [
       {
         c: (inputVar: string) => `${embeddedCheck}(${inputVar})`,
-        f: B_invalidInputBuilder(undefined, extraPath, message),
+        f: B_invalidInputBuilder(U, extraPath, message),
       },
     ];
   });
@@ -123,9 +123,9 @@ export const js_asyncDecoderAssert = (
 export const js_optional = (schema: Internal, maybeOr: unknown): Internal => {
   // TODO: maybeOr should be part of the unit schema
   schema = unionFactory([schema, unit()]);
-  if (maybeOr !== undefined && typeof maybeOr === functionTag) {
+  if (maybeOr !== U && typeof maybeOr === functionTag) {
     return Option_getOrWith(schema, maybeOr as () => unknown);
-  } else if (maybeOr !== undefined) {
+  } else if (maybeOr !== U) {
     return Option_getOr(schema, maybeOr);
   } else {
     return schema;
@@ -134,7 +134,7 @@ export const js_optional = (schema: Internal, maybeOr: unknown): Internal => {
 
 export const js_nullable = (schema: Internal, maybeOr: unknown): Internal => {
   // TODO: maybeOr should be part of the unit schema
-  if (maybeOr !== undefined) {
+  if (maybeOr !== U) {
     const schema2 = unionFactory([schema, nullAsUnit()]);
     if (typeof maybeOr === functionTag) {
       return Option_getOrWith(schema2, maybeOr as () => unknown);
@@ -171,7 +171,7 @@ export const js_merge = (s1: Internal, s2: Internal): Internal => {
     mut.decoder = objectDecoder;
     result = mut;
   }
-  if (result !== undefined) {
+  if (result !== U) {
     return result;
   } else {
     return panic(
@@ -184,7 +184,7 @@ export const js_merge = (s1: Internal, s2: Internal): Internal => {
 // export even though Node types declare a `global` var.
 export const global = (override: GlobalConfigOverride): void => {
   globalConfig.a =
-    override.defaultAdditionalItems !== undefined
+    override.defaultAdditionalItems !== U
       ? override.defaultAdditionalItems
       : initialOnAdditionalItems;
   globalConfig.f =

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -6,7 +6,7 @@ import { SuryError, baseSchema, getOrRethrow, panic, unknown } from "./schema";
 import { Literal_parse, bool, float, int, jsonName, string } from "./primitives";
 import { B_makeInvalidInputDetails, B_operationArg } from "./builder";
 import { never_, parse, reverse } from "./parse";
-import { Internal, isLiteral, isOptional, toExpression } from "./types";
+import { Internal, U, isLiteral, isOptional, toExpression } from "./types";
 import { Path, pathConcat, pathDynamic, pathEmpty, pathFromLocation } from "./path";
 import { flagNone, flagUnsafeHas } from "./flags";
 import { arrayTag, booleanTag, neverTag, nullTag, numberTag, objectTag, refTag, stringTag, tagFlagArray, tagFlagObject, tagFlagUnion, tagFlags, undefinedTag, unionTag, unknownTag } from "./tags";
@@ -172,26 +172,26 @@ const applyMetadataOverlay = (
   schema: Internal,
   defs: Record<string, Internal>
 ): void => {
-  if (schema.description !== undefined) {
+  if (schema.description !== U) {
     jsonSchema.description = schema.description;
   }
-  if (schema.title !== undefined) {
+  if (schema.title !== U) {
     jsonSchema.title = schema.title;
   }
-  if (schema.deprecated !== undefined) {
+  if (schema.deprecated !== U) {
     jsonSchema.deprecated = schema.deprecated;
   }
-  if (schema.examples !== undefined) {
+  if (schema.examples !== U) {
     // If a schema is Jsonable, then examples are Jsonable too.
     jsonSchema.examples = schema.examples;
   }
-  if (schema["$defs"] !== undefined) {
+  if (schema["$defs"] !== U) {
     Object.assign(defs, schema["$defs"]);
   }
   const metadataRawSchema = Metadata_get(schema, jsonSchemaMetadataId) as
     | JSONSchemaT
     | undefined;
-  if (metadataRawSchema !== undefined) {
+  if (metadataRawSchema !== U) {
     Object.assign(jsonSchema, metadataRawSchema);
   }
 }
@@ -205,7 +205,7 @@ const encodeToJsonSchema = (
 ): JSONSchemaT | undefined => {
   const schemaInternal = schema;
   const reversed = reverse(schemaInternal);
-  const input = B_operationArg(unknown, reversed, flagNone, undefined);
+  const input = B_operationArg(unknown, reversed, flagNone, U);
   try {
     const output = parse(input);
     // The parse produces a val whose .schema reflects the
@@ -215,7 +215,7 @@ const encodeToJsonSchema = (
     getOrRethrow(exn);
 
     // Parse failed — caller falls through to normal tag-based logic.
-    return undefined;
+    return U;
   }
 }
 
@@ -243,8 +243,8 @@ const internalToJSONSchema = (
     !(flagUnsafeHas(tagFlag, tagFlagUnion) && !!schemaInternal.parser);
   const encoded = hasUserTo
     ? encodeToJsonSchema(schema, path, defs, parent, target)
-    : undefined;
-  if (encoded !== undefined) {
+    : U;
+  if (encoded !== U) {
     applyMetadataOverlay(encoded, schema, defs);
     return encoded;
   } else {
@@ -289,16 +289,16 @@ const internalToJSONSchemaBase = (
       default:
         break;
     }
-    if (schema.minLength !== undefined) {
+    if (schema.minLength !== U) {
       jsonSchema.minLength = schema.minLength;
     }
-    if (schema.maxLength !== undefined) {
+    if (schema.maxLength !== U) {
       jsonSchema.maxLength = schema.maxLength;
     }
-    if (schema.pattern !== undefined) {
+    if (schema.pattern !== U) {
       jsonSchema.pattern = schema.pattern.source;
     }
-    if (const_ !== undefined) {
+    if (const_ !== U) {
       setConstOrEnum(const_);
     }
   } else if (tag === numberTag) {
@@ -315,19 +315,19 @@ const internalToJSONSchemaBase = (
     } else {
       jsonSchema.type = "number";
     }
-    if (schema.minimum !== undefined) {
+    if (schema.minimum !== U) {
       jsonSchema.minimum = schema.minimum;
     }
-    if (schema.maximum !== undefined) {
+    if (schema.maximum !== U) {
       jsonSchema.maximum = schema.maximum;
     }
-    if (const_ !== undefined) {
+    if (const_ !== U) {
       setConstOrEnum(const_);
     }
   } else if (tag === booleanTag) {
     const const_ = schema.const as boolean | undefined;
     jsonSchema.type = "boolean";
-    if (const_ !== undefined) {
+    if (const_ !== U) {
       setConstOrEnum(const_);
     }
   } else if (tag === arrayTag) {
@@ -342,10 +342,10 @@ const internalToJSONSchemaBase = (
         target
       );
       jsonSchema.type = "array";
-      if (schema.minItems !== undefined) {
+      if (schema.minItems !== U) {
         jsonSchema.minItems = schema.minItems;
       }
-      if (schema.maxItems !== undefined) {
+      if (schema.maxItems !== U) {
         jsonSchema.maxItems = schema.maxItems;
       }
     } else {
@@ -403,7 +403,7 @@ const internalToJSONSchemaBase = (
 
     const itemsNumber = items.length;
 
-    if (schema.default !== undefined) {
+    if (schema.default !== U) {
       jsonSchema.default = schema.default;
     }
 
@@ -416,7 +416,7 @@ const internalToJSONSchemaBase = (
         const t = definition;
         if (t.type === "null") {
           return true;
-        } else if (t.enum !== undefined && t.enum.length === 1 && t.enum[0] === null) {
+        } else if (t.enum !== U && t.enum.length === 1 && t.enum[0] === null) {
           return true;
         } else {
           return false;
@@ -517,7 +517,7 @@ const internalToJSONSchemaBase = (
         })(),
         flagUnsafeHas(tagFlags[parent.type]!, tagFlagUnion) ? parent : schema,
         path,
-        undefined,
+        U,
         false
       )
     );
@@ -543,7 +543,7 @@ const targetSchemaUri = (target: JsonSchemaTarget): string | undefined => {
       return "https://json-schema.org/draft/2020-12/schema";
     // OpenAPI 3.0 has no `$schema` property.
     case "openapi-3.0":
-      return undefined;
+      return U;
     default: {
       const unsupported = target;
       throw new SuryError({
@@ -562,12 +562,12 @@ export const toJSONSchema = (schema: Internal, options?: toJSONSchemaOptions): J
   // for openapi-3.0, which stamps no `$schema`).
   let target: JsonSchemaTarget;
   let schemaUri: string | undefined;
-  if (options !== undefined) {
-    target = options.target !== undefined ? options.target : "draft-07";
+  if (options !== U) {
+    target = options.target !== U ? options.target : "draft-07";
     schemaUri = targetSchemaUri(target);
   } else {
     target = "draft-07";
-    schemaUri = undefined;
+    schemaUri = U;
   }
   const defs: Record<string, Internal> = {};
   const jsonSchema = internalToJSONSchema(schema, pathEmpty, defs, schema, target);
@@ -593,7 +593,7 @@ export const toJSONSchema = (schema: Internal, options?: toJSONSchemaOptions): J
     });
     jsonSchema.$defs = jsonSchemDefs;
   }
-  if (schemaUri !== undefined) {
+  if (schemaUri !== U) {
     jsonSchema.$schema = schemaUri;
   }
   return jsonSchema;
@@ -623,7 +623,7 @@ export const extendJSONSchema = (schema: Internal, jsonSchema: JSONSchemaT): Int
   return Metadata_set(
     schema,
     jsonSchemaMetadataId,
-    existingSchemaExtend !== undefined
+    existingSchemaExtend !== U
       ? jsonSchemaMerge(existingSchemaExtend, jsonSchema)
       : jsonSchema
   );
@@ -647,14 +647,14 @@ const primitiveToSchema = (primitive: unknown): Internal => {
 const toIntSchema = (jsonSchema: JSONSchemaT): Internal => {
   let schema = int();
   // TODO: Support jsonSchema.multipleOf
-  if (jsonSchema.minimum !== undefined) {
+  if (jsonSchema.minimum !== U) {
     schema = intMin(schema, jsonSchema.minimum | 0);
-  } else if (jsonSchema.exclusiveMinimum !== undefined) {
+  } else if (jsonSchema.exclusiveMinimum !== U) {
     schema = intMin(schema, (jsonSchema.exclusiveMinimum + 1) | 0);
   }
-  if (jsonSchema.maximum !== undefined) {
+  if (jsonSchema.maximum !== U) {
     schema = intMax(schema, jsonSchema.maximum | 0);
-  } else if (jsonSchema.exclusiveMinimum !== undefined) {
+  } else if (jsonSchema.exclusiveMinimum !== U) {
     schema = intMax(schema, (jsonSchema.exclusiveMinimum - 1) | 0);
   }
   return schema;
@@ -664,7 +664,7 @@ const definitionToDefaultValue = (definition: JSONSchemaDefinition): unknown => 
   if (typeof definition !== "boolean") {
     return definition.default;
   } else {
-    return undefined;
+    return U;
   }
 }
 
@@ -685,7 +685,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
   if (jsonSchema.nullable) {
     schema = null_(fromJSONSchema(jsonSchemaMerge(jsonSchema, { nullable: false })));
   } else if (jsonSchema.type === "object") {
-    if (jsonSchema.properties !== undefined) {
+    if (jsonSchema.properties !== U) {
       const properties = jsonSchema.properties;
       const obj: Record<string, Internal> = {};
       Object.keys(properties).forEach((key) => {
@@ -693,7 +693,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
         let propertySchema = jsonDefinitionToSchema(property);
         if (!jsonSchema.required?.includes(key)) {
           const defaultValue = definitionToDefaultValue(property);
-          if (defaultValue !== undefined) {
+          if (defaultValue !== U) {
             propertySchema = Option_getOr(option(propertySchema), defaultValue);
           } else {
             propertySchema = option(propertySchema);
@@ -707,7 +707,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
       }
     } else {
       const additionalProperties = jsonSchema.additionalProperties;
-      if (additionalProperties !== undefined) {
+      if (additionalProperties !== U) {
         if (additionalProperties === true) {
           schema = dict(anySchema);
         } else if (additionalProperties === false) {
@@ -722,14 +722,14 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
 
     // TODO: jsonSchema.anyOf and jsonSchema.oneOf support
   } else if (jsonSchema.type === "array") {
-    if (jsonSchema.prefixItems !== undefined) {
+    if (jsonSchema.prefixItems !== U) {
       // draft-2020-12 describes tuples with `prefixItems` instead of an
       // `items` array.
       const prefixItems = jsonSchema.prefixItems;
       schema = tuple((s: { item: (idx: number, schema: Internal) => unknown }) =>
         prefixItems.map((d, idx) => s.item(idx, jsonDefinitionToSchema(d)))
       );
-    } else if (jsonSchema.items !== undefined) {
+    } else if (jsonSchema.items !== U) {
       const items = jsonSchema.items;
       if (Array.isArray(items)) {
         schema = tuple((s: { item: (idx: number, schema: Internal) => unknown }) =>
@@ -741,13 +741,13 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
     } else {
       schema = array(anySchema);
     }
-    if (jsonSchema.minItems !== undefined) {
+    if (jsonSchema.minItems !== U) {
       schema = arrayMinLength(schema, jsonSchema.minItems);
     }
-    if (jsonSchema.maxItems !== undefined) {
+    if (jsonSchema.maxItems !== U) {
       schema = arrayMaxLength(schema, jsonSchema.maxItems);
     }
-  } else if (jsonSchema.anyOf !== undefined) {
+  } else if (jsonSchema.anyOf !== U) {
     const definitions = jsonSchema.anyOf;
     if (definitions.length === 0) {
       schema = anySchema;
@@ -756,7 +756,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
     } else {
       schema = union(definitions.map(jsonDefinitionToSchema));
     }
-  } else if (jsonSchema.allOf !== undefined) {
+  } else if (jsonSchema.allOf !== U) {
     const definitions = jsonSchema.allOf;
     if (definitions.length === 0) {
       schema = anySchema;
@@ -778,7 +778,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
         "Should pass for all schemas of the allOf property."
       );
     }
-  } else if (jsonSchema.oneOf !== undefined) {
+  } else if (jsonSchema.oneOf !== U) {
     const definitions = jsonSchema.oneOf;
     if (definitions.length === 0) {
       schema = anySchema;
@@ -802,7 +802,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
         "Should pass exactly one schema according to the oneOf property."
       );
     }
-  } else if (jsonSchema.not !== undefined) {
+  } else if (jsonSchema.not !== U) {
     const not = jsonSchema.not;
     schema = refine(
       anySchema,
@@ -817,7 +817,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
       "Should NOT be valid against schema in the not property."
     );
     // needs to come before primitives
-  } else if (jsonSchema.enum !== undefined) {
+  } else if (jsonSchema.enum !== U) {
     const primitives = jsonSchema.enum;
     if (primitives.length === 0) {
       schema = anySchema;
@@ -826,7 +826,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
     } else {
       schema = union(primitives.map(primitiveToSchema));
     }
-  } else if (jsonSchema.const !== undefined) {
+  } else if (jsonSchema.const !== U) {
     schema = primitiveToSchema(jsonSchema.const);
   } else if (Array.isArray(jsonSchema.type)) {
     const types = jsonSchema.type;
@@ -843,13 +843,13 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
     } else {
       schema = string();
     }
-    if (jsonSchema.pattern !== undefined) {
+    if (jsonSchema.pattern !== U) {
       schema = pattern(schema, new RegExp(jsonSchema.pattern));
     }
-    if (jsonSchema.minLength !== undefined) {
+    if (jsonSchema.minLength !== U) {
       schema = stringMinLength(schema, jsonSchema.minLength);
     }
-    if (jsonSchema.maxLength !== undefined) {
+    if (jsonSchema.maxLength !== U) {
       schema = stringMaxLength(schema, jsonSchema.maxLength);
     }
   } else if (jsonSchema.type === "integer") {
@@ -860,14 +860,14 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
     schema = toIntSchema(jsonSchema);
   } else if (jsonSchema.type === "number") {
     schema = float();
-    if (jsonSchema.minimum !== undefined) {
+    if (jsonSchema.minimum !== U) {
       schema = floatMin(schema, jsonSchema.minimum);
-    } else if (jsonSchema.exclusiveMinimum !== undefined) {
+    } else if (jsonSchema.exclusiveMinimum !== U) {
       schema = floatMin(schema, jsonSchema.exclusiveMinimum + 1);
     }
-    if (jsonSchema.maximum !== undefined) {
+    if (jsonSchema.maximum !== U) {
       schema = floatMax(schema, jsonSchema.maximum);
-    } else if (jsonSchema.exclusiveMinimum !== undefined) {
+    } else if (jsonSchema.exclusiveMinimum !== U) {
       schema = floatMax(schema, jsonSchema.exclusiveMinimum - 1);
     }
   } else if (jsonSchema.type === "boolean") {
@@ -875,9 +875,9 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
   } else if (jsonSchema.type === "null") {
     schema = schemaFactory(null);
   } else if (
-    jsonSchema.if !== undefined &&
-    jsonSchema.then !== undefined &&
-    jsonSchema.else !== undefined
+    jsonSchema.if !== U &&
+    jsonSchema.then !== U &&
+    jsonSchema.else !== U
   ) {
     const ifSchema = jsonDefinitionToSchema(jsonSchema.if);
     const thenSchema = jsonDefinitionToSchema(jsonSchema.then);
@@ -905,7 +905,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
       },
       "Should pass the if/then/else schema validation."
     );
-  } else if (jsonSchema.type !== undefined) {
+  } else if (jsonSchema.type !== U) {
     throw new SuryError({
       code: "invalid_operation",
       path: pathEmpty,
@@ -916,10 +916,10 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
   }
 
   if (
-    jsonSchema.description !== undefined ||
-    jsonSchema.deprecated !== undefined ||
-    jsonSchema.examples !== undefined ||
-    jsonSchema.title !== undefined
+    jsonSchema.description !== U ||
+    jsonSchema.deprecated !== U ||
+    jsonSchema.examples !== U ||
+    jsonSchema.title !== U
   ) {
     schema = meta(schema, {
       title: jsonSchema.title,

--- a/packages/sury/src/operations.ts
+++ b/packages/sury/src/operations.ts
@@ -4,7 +4,7 @@ import { SuryError, baseSchema, cached, configurableValueOptions, copySchema, ge
 import type { JSONSchemaT, StandardJsonSchemaOptions } from "./jsonschema";
 import { compileDecoder, getDecoder, getOutputSchema, isAsyncInternal, reverse } from "./parse";
 import { B_effectCtx, B_embed, B_embedTransformation, B_inlineConst, B_invalidInputBuilder, B_invalidOperation, B_mergeWithPathPrepend, B_next, B_refine, B_varWithoutAllocation, EffectCtx, _var } from "./builder";
-import { AdditionalItems, Check, Internal, SchemaErrorMessage, SuryErrorRecord, Val, s, toExpression, vendor } from "./types";
+import { AdditionalItems, Check, Internal, SchemaErrorMessage, SuryErrorRecord, U, Val, s, toExpression, vendor } from "./types";
 import { Builder } from "./builder";
 import { flagAsync, valFlagAsync } from "./flags";
 import { pathEmpty, pathFromArray, pathToArray } from "./path";
@@ -26,13 +26,13 @@ export const recursiveDecoder: Builder = (input) => {
   let recOperation = "";
 
   const fn = (def as unknown as Record<string, unknown>)[key];
-  if (fn !== undefined) {
+  if (fn !== U) {
     // Circular reference (fn === 0) or already compiled
     recOperation = fn === 0 ? B_embed(input, def) + `["${key}"]` : B_embed(input, fn);
   } else {
     // Optimistic compilation with recompile if assumptions were wrong
-    let assumedHasTransform = def.hasTransform !== undefined ? def.hasTransform : false;
-    let assumedIsAsync = def.isAsync !== undefined ? def.isAsync : false;
+    let assumedHasTransform = def.hasTransform !== U ? def.hasTransform : false;
+    let assumedIsAsync = def.isAsync !== U ? def.isAsync : false;
     let compileNeeded = true;
     let finalFn: unknown = 0;
 
@@ -41,10 +41,10 @@ export const recursiveDecoder: Builder = (input) => {
 
       // Set optimistic values on def before compiling (if not already set)
       // Inner circular references will read these values
-      if (def.hasTransform === undefined) {
+      if (def.hasTransform === U) {
         def.hasTransform = assumedHasTransform;
       }
-      if (def.isAsync === undefined) {
+      if (def.isAsync === U) {
         def.isAsync = assumedIsAsync;
       }
 
@@ -103,16 +103,16 @@ export const recursiveDecoder: Builder = (input) => {
     }
   } else {
     // No transform: call for validation but don't capture result
-    output = B_refine(input, expectedSchema, undefined, expectedSchema);
+    output = B_refine(input, expectedSchema, U, expectedSchema);
     output.cp = `${recOperation}(${input.i});`;
   }
 
-  output.prev = undefined;
+  output.prev = U;
   output.cp = outputDecl + B_mergeWithPathPrepend(output, input);
 
   // Un-finalize: this val may be reused as input to a subsequent parser (e.g.
   // S.transform on a recursive schema) and must accept hoisted decls again.
-  output.fz = undefined;
+  output.fz = U;
   output.prev = input;
 
   return output;
@@ -159,7 +159,7 @@ export const getStandardJSONSchema = (
   options: StandardJsonSchemaOptions,
   isOutput: boolean
 ): JSONSchemaT => {
-  if (standardJSONSchemaConverter !== undefined) {
+  if (standardJSONSchemaConverter !== U) {
     return standardJSONSchemaConverter(schema, options, isOutput);
   } else {
     throw new SuryError({
@@ -199,7 +199,7 @@ Object.defineProperty(schemaPrototype, "~standard", {
               {
                 message: error.reason,
                 path:
-                  error.path === pathEmpty ? undefined : pathToArray(error.path),
+                  error.path === pathEmpty ? U : pathToArray(error.path),
               },
             ],
           };
@@ -227,7 +227,7 @@ Object.defineProperty(schemaPrototype, "~standard", {
 
 export const getAssertResult = (): Internal => {
   return cached("a", undefinedTag, (s) => {
-    s.const = void 0;
+    s.const = U;
     s.decoder = literalDecoder;
     s.noValidation = true;
   });
@@ -246,8 +246,8 @@ export const assertAsyncOrThrow = (any: unknown, schema: Internal): Promise<void
 }
 
 export const isAsync = (schema: Internal): boolean => {
-  if (schema.isAsync === undefined) {
-    return isAsyncInternal(schema, undefined);
+  if (schema.isAsync === U) {
+    return isAsyncInternal(schema, U);
   } else {
     return schema.isAsync;
   }
@@ -318,7 +318,7 @@ export const recursive = (name: string, fn: (schema: Internal) => Internal): Int
   refSchema.decoder = recursiveDecoder;
 
   // This is for mutual recursion
-  const isNestedRec = globalConfig.d !== undefined;
+  const isNestedRec = globalConfig.d !== U;
   if (!isNestedRec) {
     globalConfig.d = {};
   }
@@ -337,7 +337,7 @@ export const recursive = (name: string, fn: (schema: Internal) => Internal): Int
     schema["$defs"] = globalConfig.d;
     schema.decoder = recursiveDecoder;
 
-    globalConfig.d = undefined;
+    globalConfig.d = U;
 
     return schema;
   }
@@ -359,7 +359,7 @@ export const internalRefine = (
   return updateOutput(schema, (mut) => {
     const refiner = makeRefiner(mut);
     const existingRefiner = mut.refiner;
-    if (existingRefiner !== undefined) {
+    if (existingRefiner !== U) {
       mut.refiner = (input) => {
         const arr = existingRefiner(input);
         arr.push(...refiner(input));
@@ -377,14 +377,14 @@ export const refine = (
   error?: string,
   path?: string[]
 ): Internal => {
-  const message = error !== undefined ? error : "Refinement failed";
-  const extraPath = path !== undefined ? pathFromArray(path) : pathEmpty;
+  const message = error !== U ? error : "Refinement failed";
+  const extraPath = path !== U ? pathFromArray(path) : pathEmpty;
   return internalRefine(schema, (_) => (input) => {
     const embeddedCheck = B_embed(input, refineCheck);
     return [
       {
         c: (inputVar) => `${embeddedCheck}(${inputVar})`,
-        f: B_invalidInputBuilder(undefined, extraPath, message),
+        f: B_invalidInputBuilder(U, extraPath, message),
       },
     ];
   });
@@ -415,17 +415,17 @@ export const transform = (
   return updateOutput(schema, (mut) => {
     mut.parser = (input) => {
       const definition = transformer(B_effectCtx(input));
-      if (definition.p !== undefined && definition.a === undefined) {
+      if (definition.p !== U && definition.a === U) {
         return B_embedTransformation(input, definition.p, false);
-      } else if (definition.p === undefined && definition.a !== undefined) {
+      } else if (definition.p === U && definition.a !== U) {
         return B_embedTransformation(input, definition.a, true);
       } else if (
-        definition.p === undefined &&
-        definition.a === undefined &&
-        definition.s === undefined
+        definition.p === U &&
+        definition.a === U &&
+        definition.s === U
       ) {
-        return B_refine(input, undefined, undefined, input.e.to!);
-      } else if (definition.p === undefined && definition.a === undefined) {
+        return B_refine(input, U, U, input.e.to!);
+      } else if (definition.p === U && definition.a === U) {
         return B_invalidOperation(input, `The S.transform parser is missing`);
       } else {
         return B_invalidOperation(
@@ -437,14 +437,14 @@ export const transform = (
     const to = copySchema(unknown);
     to.serializer = (input) => {
       const definition = transformer(B_effectCtx(input));
-      if (definition.s !== undefined) {
+      if (definition.s !== U) {
         return B_embedTransformation(input, definition.s, false);
       } else if (
-        definition.p === undefined &&
-        definition.a === undefined &&
-        definition.s === undefined
+        definition.p === U &&
+        definition.a === U &&
+        definition.s === U
       ) {
-        return B_refine(input, undefined, undefined, input.e.to!);
+        return B_refine(input, U, U, input.e.to!);
       } else {
         return B_invalidOperation(input, `The S.transform serializer is missing`);
       }
@@ -471,7 +471,7 @@ export type OptionDefault =
 export const Option_getWithDefault = (schema: Internal, default_: OptionDefault): Internal => {
   return updateOutput(schema, (mut) => {
     const anyOf = mut.anyOf;
-    if (anyOf !== undefined) {
+    if (anyOf !== U) {
       const outputItems: Internal[] = [];
       // FIXME: drop `originalItems` once unionDecoder can reverse member
       // `.to` chains — then mut.default + the serializer can both run
@@ -538,7 +538,7 @@ export const Option_getWithDefault = (schema: Internal, default_: OptionDefault)
       const originalDecoder = to.decoder;
       to.serializer = (input) => {
         const nextSchema = reverse(originalItem);
-        return B_refine(originalDecoder(input), nextSchema, undefined, nextSchema);
+        return B_refine(originalDecoder(input), nextSchema, U, nextSchema);
       };
 
       // FIXME: This looks wrong, but this is how it was with prev architecture
@@ -574,7 +574,7 @@ export const Object_setAdditionalItems = (
 ): Internal => {
   const currentAdditionalItems = schema.additionalItems;
   if (
-    currentAdditionalItems !== undefined &&
+    currentAdditionalItems !== U &&
     currentAdditionalItems !== additionalItems &&
     typeof currentAdditionalItems !== objectTag
   ) {
@@ -582,12 +582,12 @@ export const Object_setAdditionalItems = (
     mut.additionalItems = additionalItems;
     if (deep) {
       const items = schema.items;
-      if (items !== undefined) {
+      if (items !== U) {
         mut.items = items.map((s) => Object_setAdditionalItems(s, additionalItems, deep));
       }
 
       const properties = schema.properties;
-      if (properties !== undefined) {
+      if (properties !== U) {
         mut.properties = Object.fromEntries(
           Object.keys(properties).map((key) => [
             key,

--- a/packages/sury/src/operations.ts
+++ b/packages/sury/src/operations.ts
@@ -171,6 +171,16 @@ export const getStandardJSONSchema = (
   }
 }
 
+// A lazy prototype getter (not an eager per-schema property — that would put
+// 2 allocations + 4 closures on the baseSchema hot path for a feature most
+// schemas never use), cached on first access: Standard Schema consumers read
+// `schema["~standard"].validate` per validation call, so an uncached getter
+// re-allocates the whole props object per request. The cache is written as a
+// NON-enumerable own property (valueOptions descriptor) on purpose —
+// copySchema's Object.assign copies enumerable own props, and the cached
+// object closes over THIS schema, so an enumerable cache would leak onto
+// derived schemas and validate against the wrong one; non-enumerable means
+// copies lazily re-derive their own.
 Object.defineProperty(schemaPrototype, "~standard", {
   get: function (this: Internal) {
     const schema = this;
@@ -205,6 +215,8 @@ Object.defineProperty(schemaPrototype, "~standard", {
         output: (options) => getStandardJSONSchema(schema, options, true),
       },
     };
+    valueOptions[valKey] = standard;
+    Object.defineProperty(schema, "~standard", valueOptions as PropertyDescriptor);
     return standard;
   },
 });

--- a/packages/sury/src/parse.ts
+++ b/packages/sury/src/parse.ts
@@ -1,17 +1,17 @@
 import { instanceofCond, isArrayCond, nanCond, objectTagCond, setHas, typeofCond } from "./primitives";
 import { baseSchema, cached, copySchema, getOrRethrow, globalConfig, panic, reversedKey, unknown, updateOutput, valKey, valueOptions } from "./schema";
 import { B_scope, B_embedInvalidInput, B_inlineConst, B_markOutput, B_merge, B_next, B_operationArg, B_refine, B_unsupportedDecode, Builder, Encoder, failInvalidType, noopOperation, operationArgVar } from "./builder";
-import { Internal, Val, isLiteral, s } from "./types";
+import { Internal, U, Val, isLiteral, s } from "./types";
 import { Flag, flagAsync, flagDisableNanNumberValidation, flagUnsafeHas, valFlagAsync } from "./flags";
 import { pathConcat, pathDynamic, pathEmpty } from "./path";
 import { instanceTag, neverTag, numberTag, objectTag, tagFlagArray, tagFlagBigint, tagFlagBoolean, tagFlagInstance, tagFlagNaN, tagFlagNull, tagFlagNumber, tagFlagObject, tagFlagString, tagFlagSymbol, tagFlagUndefined, tagFlagUnknown, tagFlags, unknownTag } from "./tags";
 export const parse = (input: Val): Val => {
   let result: Val = input;
-  let appliedEncoderRef: Encoder | undefined = undefined;
+  let appliedEncoderRef: Encoder | undefined = U;
   let loopCount = 0;
   while (!result.io || result.e.to) {
     const appliedEncoder: Encoder | undefined = appliedEncoderRef;
-    appliedEncoderRef = undefined;
+    appliedEncoderRef = U;
     const loopInput = result;
 
     loopCount = loopCount + 1;
@@ -50,17 +50,17 @@ export const parse = (input: Val): Val => {
           operationOutput.e,
         );
       } else {
-        result = B_refine(loopInput, operationOutput.s, undefined, operationOutput.e);
+        result = B_refine(loopInput, operationOutput.s, U, operationOutput.e);
       }
       result.f |= valFlagAsync;
       result.io = true;
     } else if (loopInput.io) {
       // It's guaranteed that to is not undefined, because it's checked in the while condition
       const to = loopInput.e.to!;
-      if (loopInput.e.parser !== undefined) {
+      if (loopInput.e.parser !== U) {
         result = loopInput.e.parser(loopInput);
       } else {
-        result = B_refine(result, undefined, undefined, to);
+        result = B_refine(result, U, U, to);
       }
     } else {
       const maybeEncoder = loopInput.s.encoder;
@@ -98,7 +98,7 @@ export const parseDynamic = (input: Val): Val => {
     const error = getOrRethrow(exn);
     // For the case parent must always be present
     error.path = pathConcat(
-      input.p !== undefined ? input.p.path : pathEmpty,
+      input.p !== U ? input.p.path : pathEmpty,
       pathConcat(pathConcat(input.path, pathDynamic), error.path),
     );
 
@@ -157,7 +157,7 @@ export const compileDecoder = (
   }
 }
 export const getOutputSchema = (schema: Internal): Internal => {
-  if (schema.to !== undefined) {
+  if (schema.to !== U) {
     return getOutputSchema(schema.to);
   } else {
     return schema;
@@ -168,55 +168,55 @@ export const reverse = (schema: Internal): Internal => {
   if (reversedKey in schemaRecord) {
     return schemaRecord[reversedKey]!;
   } else {
-    let reversedHead: Internal | undefined = undefined;
+    let reversedHead: Internal | undefined = U;
     let current: Internal | undefined = schema;
 
     while (current) {
       const mut = copySchema(current!);
       const next = mut.to;
-      if (reversedHead === undefined) {
+      if (reversedHead === U) {
         delete mut.to;
       } else {
         mut.to = reversedHead;
       }
       const parser = mut.parser;
-      if (mut.serializer !== undefined) {
+      if (mut.serializer !== U) {
         mut.parser = mut.serializer;
       } else {
         delete mut.parser;
       }
-      if (parser !== undefined) {
+      if (parser !== U) {
         mut.serializer = parser;
       } else {
         delete mut.serializer;
       }
       // Swap inputRefiner and refiner
       const refiner = mut.refiner;
-      if (mut.inputRefiner !== undefined) {
+      if (mut.inputRefiner !== U) {
         mut.refiner = mut.inputRefiner;
       } else {
         delete mut.refiner;
       }
-      if (refiner !== undefined) {
+      if (refiner !== U) {
         mut.inputRefiner = refiner;
       } else {
         delete mut.inputRefiner;
       }
       const fromDefault = mut.fromDefault;
-      if (mut.default !== undefined) {
+      if (mut.default !== U) {
         mut.fromDefault = mut.default;
       } else {
         delete mut.fromDefault;
       }
-      if (fromDefault !== undefined) {
+      if (fromDefault !== U) {
         mut.default = fromDefault;
       } else {
         delete mut.default;
       }
-      if (mut.items !== undefined) {
+      if (mut.items !== U) {
         mut.items = mut.items.map(reverse);
       }
-      if (mut.properties !== undefined) {
+      if (mut.properties !== U) {
         const properties = mut.properties;
         const newProperties: Record<string, Internal> = {};
         const keys = Object.keys(properties);
@@ -230,7 +230,7 @@ export const reverse = (schema: Internal): Internal => {
       if (typeof mut.additionalItems === objectTag) {
         mut.additionalItems = reverse(mut.additionalItems as Internal);
       }
-      if (mut.anyOf !== undefined) {
+      if (mut.anyOf !== U) {
         const anyOf = mut.anyOf;
         const has: Record<string, boolean> = {};
         const newAnyOf: Internal[] = [];
@@ -243,7 +243,7 @@ export const reverse = (schema: Internal): Internal => {
         mut.has = has;
         mut.anyOf = newAnyOf;
       }
-      if (mut["$defs"] !== undefined) {
+      if (mut["$defs"] !== U) {
         const defs = mut["$defs"];
         const reversedDefs: Record<string, Internal> = {};
         const defsKeys = Object.keys(defs);
@@ -275,12 +275,12 @@ export const reverse = (schema: Internal): Internal => {
 export function getDecoder(..._args: unknown[]): (from: unknown) => unknown {
   const args = arguments as unknown as unknown[];
   let idx = 0;
-  let flag: Flag | undefined = undefined;
+  let flag: Flag | undefined = U;
   let keyRef = "";
   let maxSeq = 0;
-  let cacheTarget: Internal | undefined = undefined;
+  let cacheTarget: Internal | undefined = U;
 
-  while (flag === undefined) {
+  while (flag === U) {
     const arg = args[idx];
     if (!arg) {
       const f = globalConfig.f;
@@ -302,7 +302,7 @@ export function getDecoder(..._args: unknown[]): (from: unknown) => unknown {
     }
   }
 
-  if (cacheTarget === undefined) {
+  if (cacheTarget === U) {
     return panic("No schema provided for decoder.");
   } else {
     const key = keyRef;
@@ -317,7 +317,7 @@ export function getDecoder(..._args: unknown[]): (from: unknown) => unknown {
           mut.to = to;
         });
       }
-      const f = compileDecoder(schema, schema, flag!, undefined);
+      const f = compileDecoder(schema, schema, flag!, U);
       // Reusing the same object makes it a little bit faster
       valueOptions[valKey] = f;
       // Use defineProperty, so the cache keys are not enumerable
@@ -330,7 +330,7 @@ export function getDecoder(..._args: unknown[]): (from: unknown) => unknown {
 export const nestedLoc = "BS_PRIVATE_NESTED_SOME_NONE";
 
 const neverBuilderFn = (input: Val): Val => {
-  const output = B_refine(input, undefined, undefined, never_());
+  const output = B_refine(input, U, U, never_());
   output.cp = B_embedInvalidInput(input) + ";";
   return output;
 }

--- a/packages/sury/src/primitives.ts
+++ b/packages/sury/src/primitives.ts
@@ -10,9 +10,15 @@ export const int32FormatValidation = (inputVar: string) => {
 };
 
 // Atomic type-narrow conditions, shared by the type decoders and the union
-// dispatch (`typeCheckCond`) so the two can't drift.
-export const typeofCond = (tag: Tag) => (inputVar: string): string =>
-  `typeof ${inputVar}==="${tag}"`;
+// dispatch (`typeCheckCond`) so the two can't drift. Memoized per tag: the
+// returned closure depends only on `tag`, and this is called all over the
+// primitive decoders and union dispatch, so caching stops a fresh closure
+// being allocated on every decode (a large share of codegen GC — see the
+// GC-dominated compile profile).
+const typeofCondCache: Record<string, (inputVar: string) => string> = {};
+export const typeofCond = (tag: Tag): ((inputVar: string) => string) =>
+  typeofCondCache[tag] ||
+  (typeofCondCache[tag] = (inputVar) => `typeof ${inputVar}==="${tag}"`);
 export const nanCond = (inputVar: string): string => `Number.isNaN(${inputVar})`;
 export const isArrayCond = (inputVar: string): string => `Array.isArray(${inputVar})`;
 export const objectTagCond = (inputVar: string): string =>
@@ -21,15 +27,22 @@ export const objectTagCond = (inputVar: string): string =>
 export const instanceofCond = (b: Val, class_: unknown) => (inputVar: string): string =>
   `${inputVar} instanceof ${B_embed(b, class_)}`;
 
+// Shared, immutable per-tag type-narrow Check objects. A Check's c/f are only
+// ever called, never reassigned, and callers always wrap it in a fresh array
+// before it becomes a val's `.vc` (which may then be pushed to / cleared), so
+// reusing one object per tag drops a Check allocation on every primitive
+// decode without any aliasing hazard.
+const typeofCheckCache: Record<string, Check> = {};
+const typeofCheck = (tag: Tag): Check =>
+  typeofCheckCache[tag] || (typeofCheckCache[tag] = { c: typeofCond(tag), f: failInvalidType });
+const notNanCheck: Check = { c: (inputVar) => `!${nanCond(inputVar)}`, f: failInvalidType };
+const int32Check: Check = { c: int32FormatValidation, f: failInvalidType };
+const nanCheck: Check = { c: nanCond, f: failInvalidType };
+
 // Reject anything but `tag` when the input is still `unknown` — shared by
 // every primitive decoder's unknown-input branch.
 const B_refineTypeofUnknown = (input: Val, tag: Tag): Val => {
-  return B_refine(input, input.e, [
-    {
-      c: typeofCond(tag),
-      f: failInvalidType,
-    },
-  ]);
+  return B_refine(input, input.e, [typeofCheck(tag)]);
 }
 
 // Allocate a fresh var and start a new Val from it — shared by every
@@ -43,23 +56,12 @@ const B_nextVar = (input: Val, expected: Internal): Val => {
 export const numberDecoder: Builder = (input: Val) => {
   const inputTagFlag = tagFlags[input.s.type]!;
   if (flagUnsafeHas(inputTagFlag, tagFlagUnknown)) {
-    const checks: Check[] = [
-      {
-        c: typeofCond(numberTag),
-        f: failInvalidType,
-      },
-    ];
+    const checks: Check[] = [typeofCheck(numberTag)];
     if (input.e.format === "int32") {
-      checks.push({
-        c: int32FormatValidation,
-        f: failInvalidType,
-      });
+      checks.push(int32Check);
     } else {
       if (!flagUnsafeHas(input.g.o, flagDisableNanNumberValidation)) {
-        checks.push({
-          c: (inputVar) => `!${nanCond(inputVar)}`,
-          f: failInvalidType,
-        });
+        checks.push(notNanCheck);
       }
     }
     return B_refine(input, input.e, checks);
@@ -83,12 +85,7 @@ export const numberDecoder: Builder = (input: Val) => {
   } else if (!flagUnsafeHas(inputTagFlag, tagFlagNumber)) {
     return B_unsupportedDecode(input, input.s, input.e);
   } else if (input.s.format !== input.e.format && input.e.format === "int32") {
-    return B_refine(input, input.e, [
-      {
-        c: int32FormatValidation,
-        f: failInvalidType,
-      },
-    ]);
+    return B_refine(input, input.e, [int32Check]);
   } else {
     return input;
   }
@@ -244,12 +241,7 @@ export const literalDecoder: Builder = (input: Val) => {
 
       return B_nextConst(stringConstVal, expectedSchema, expectedSchema);
     } else if (flagUnsafeHas(schemaTagFlag, tagFlagNaN)) {
-      return B_refine(input, expectedSchema, [
-        {
-          c: nanCond,
-          f: failInvalidType,
-        },
-      ]);
+      return B_refine(input, expectedSchema, [nanCheck]);
     } else {
       return B_refine(input, expectedSchema, [
         {

--- a/packages/sury/src/primitives.ts
+++ b/packages/sury/src/primitives.ts
@@ -1,6 +1,6 @@
 import { baseSchema, cached } from "./schema";
 import { B_embed, B_embedInvalidInput, B_inlineConst, B_next, B_nextConst, B_refine, B_unsupportedDecode, B_varWithoutAllocation, _var, failInvalidType } from "./builder";
-import { Check, Internal, Val, isLiteral } from "./types";
+import { Check, Internal, U, Val, isLiteral } from "./types";
 import { Builder } from "./builder";
 import { flagDisableNanNumberValidation, flagUnsafeHas } from "./flags";
 import { Tag, bigintTag, booleanTag, instanceTag, nanTag, nullTag, numberTag, objectTag, stringTag, symbolTag, tagFlagBigint, tagFlagBoolean, tagFlagNaN, tagFlagNull, tagFlagNumber, tagFlagRef, tagFlagString, tagFlagSymbol, tagFlagUndefined, tagFlagUnion, tagFlagUnknown, tagFlags, undefinedTag, unknownTag } from "./tags";
@@ -255,13 +255,13 @@ export const literalDecoder: Builder = (input: Val) => {
 
 export const unit = () =>
   cached(undefinedTag, undefinedTag, (s) => {
-    s.const = void 0;
+    s.const = U;
     s.decoder = literalDecoder;
   });
 
 export const void_ = () =>
   cached("void", undefinedTag, (s) => {
-    s.const = void 0;
+    s.const = U;
     s.name = "void";
     s.decoder = literalDecoder;
   });

--- a/packages/sury/src/refinements.ts
+++ b/packages/sury/src/refinements.ts
@@ -3,7 +3,7 @@ import { getMutErrorMessage, internalRefine, nullAsUnit, transform } from "./ope
 import { schemaObject, schemaShape, schemaTuple } from "./factory";
 import { parse } from "./parse";
 import { SuryError, copySchema, panic, unknown } from "./schema";
-import { B_scope, B_asyncVal, B_embed, B_failWithErrorMessage, B_inlineLocation, B_markOutput, B_merge, B_next, B_refine, B_varWithoutAllocation, Builder, _notVarBeforeValidation, _var, failInvalidType } from "./builder";
+import { B_scope, B_asyncVal, B_embed, B_failWithErrorMessage, B_markOutput, B_merge, B_next, B_refine, B_varWithoutAllocation, Builder, _notVarBeforeValidation, _var, failInvalidType } from "./builder";
 import { array, dictFactory, optionFactory, unionFactory } from "./composites";
 import { Internal, U, Val, stringify } from "./types";
 import { flagUnsafeHas, valFlagAsync } from "./flags";
@@ -146,7 +146,7 @@ export const compactColumnsDecoder: Builder = (input: Val) => {
         itemInput.io = false;
 
         // Path like ["bar"] so validation errors carry the field location.
-        itemInput.path = pathFromInlinedLocation(B_inlineLocation(input.g, key));
+        itemInput.path = pathFromInlinedLocation(inlinedValueFromString(key));
 
         const itemOutput = parse(itemInput);
         if (flagUnsafeHas(itemOutput.f, valFlagAsync)) {
@@ -233,7 +233,7 @@ export const compactColumnsDecoder: Builder = (input: Val) => {
           itemInput.e = declaredItemSchema;
           itemInput.v = _notVarBeforeValidation;
           itemInput.io = false;
-          itemInput.path = pathFromInlinedLocation(B_inlineLocation(input.g, key));
+          itemInput.path = pathFromInlinedLocation(inlinedValueFromString(key));
 
           const itemOutput = parse(itemInput);
           perFieldCode = perFieldCode + B_merge(itemOutput);

--- a/packages/sury/src/refinements.ts
+++ b/packages/sury/src/refinements.ts
@@ -5,7 +5,7 @@ import { parse } from "./parse";
 import { SuryError, copySchema, panic, unknown } from "./schema";
 import { B_scope, B_asyncVal, B_embed, B_failWithErrorMessage, B_inlineLocation, B_markOutput, B_merge, B_next, B_refine, B_varWithoutAllocation, Builder, _notVarBeforeValidation, _var, failInvalidType } from "./builder";
 import { array, dictFactory, optionFactory, unionFactory } from "./composites";
-import { Internal, Val, stringify } from "./types";
+import { Internal, U, Val, stringify } from "./types";
 import { flagUnsafeHas, valFlagAsync } from "./flags";
 import { inlinedValueFromString, pathEmpty, pathFromInlinedLocation } from "./path";
 import { numberTag, tagFlagUnknown, tagFlags } from "./tags";
@@ -25,29 +25,29 @@ export const compactColumnsDecoder: Builder = (input: Val) => {
   // object schema left over after the preceding parse pipeline step).
   let forwardProps: Record<string, Internal> | undefined;
   if (
-    selfSchema.to !== undefined &&
+    selfSchema.to !== U &&
     typeof selfSchema.to.additionalItems === "object"
   ) {
     forwardProps = (selfSchema.to.additionalItems as Internal).properties;
   } else {
-    forwardProps = undefined;
+    forwardProps = U;
   }
-  const isForwardDirection = forwardProps !== undefined;
+  const isForwardDirection = forwardProps !== U;
   let maybeProperties: Record<string, Internal> | undefined;
   if (isForwardDirection) {
     maybeProperties = forwardProps;
   } else {
     if (
-      input.s.additionalItems !== undefined &&
+      input.s.additionalItems !== U &&
       typeof input.s.additionalItems === "object"
     ) {
       maybeProperties = (input.s.additionalItems as Internal).properties;
     } else {
-      maybeProperties = undefined;
+      maybeProperties = U;
     }
   }
 
-  if (maybeProperties === undefined) {
+  if (maybeProperties === U) {
     return panic(
       "S.compactColumns supports only object schemas. Use S.compactColumns(S.unknown)->S.to(S.array(objectSchema)).",
     );
@@ -72,7 +72,7 @@ export const compactColumnsDecoder: Builder = (input: Val) => {
 
     if (keysLen === 0) {
       if (isUnknownInput) {
-        input = B_refine(input, undefined, [
+        input = B_refine(input, U, [
           {
             c: (inputVar: string) =>
               `Array.isArray(${inputVar})&&${inputVar}.length===0`,
@@ -85,7 +85,7 @@ export const compactColumnsDecoder: Builder = (input: Val) => {
     } else if (isForwardDirection) {
       // Forward direction: columnar → rows
       if (isUnknownInput) {
-        input = B_refine(input, undefined, [
+        input = B_refine(input, U, [
           {
             c: (inputVar: string) => {
               let check = `Array.isArray(${inputVar})&&${inputVar}.length===${keysLen}`;

--- a/packages/sury/src/schema.ts
+++ b/packages/sury/src/schema.ts
@@ -1,4 +1,4 @@
-import { AdditionalItems, AdditionalItemsMode, ErrorDetails, Internal, SuryErrorRecord, Val, s } from "./types";
+import { AdditionalItems, AdditionalItemsMode, ErrorDetails, Internal, SuryErrorRecord, U, Val, s } from "./types";
 import type { Builder } from "./builder";
 import { Flag, valFlagNone } from "./flags";
 import { Tag, unknownTag } from "./tags";
@@ -79,7 +79,7 @@ export const initialOnAdditionalItems: AdditionalItemsMode = "strip";
 export const initialDefaultFlag: Flag = valFlagNone;
 export const globalConfig: GlobalConfig = {
   m: formatErrorMessage,
-  d: undefined,
+  d: U,
   a: initialOnAdditionalItems,
   f: initialDefaultFlag,
 };
@@ -110,7 +110,7 @@ const factoryCache: Record<string, Internal> = {};
 
 export const cached = (key: string, tag: Tag, init: (schema: Internal) => void): Internal => {
   const existing = factoryCache[key];
-  if (existing !== undefined) {
+  if (existing !== U) {
     return existing;
   } else {
     const schema = baseSchema(tag, true);
@@ -132,7 +132,7 @@ export const copySchema = (schema: Internal): Internal => {
 export const updateOutput = <Value>(schema: Internal, fn: (schema: Internal) => void): Value => {
   const root = copySchema(schema);
   let mut = root;
-  while (mut.to !== undefined) {
+  while (mut.to !== U) {
     const next = copySchema(mut.to);
     mut.to = next;
     mut = next;

--- a/packages/sury/src/schema.ts
+++ b/packages/sury/src/schema.ts
@@ -5,10 +5,13 @@ import { Tag, unknownTag } from "./tags";
 
 export function Schema(this: Internal): void {}
 export const schemaPrototype: Record<string, unknown> = Object.create(null);
+// A plain (non-enumerable) method, not a getter returning a closure: the
+// getter form allocated a fresh arrow on every `.with` access, and `.with` is
+// the primary modifier API called all over user construction code. The method
+// binds `this` through the call, so no per-access closure is needed.
 Object.defineProperty(schemaPrototype, "with", {
-  get(this: Internal) {
-    return (fn: (self: Internal, ...args: unknown[]) => unknown, ...args: unknown[]) =>
-      fn(this, ...args);
+  value(this: Internal, fn: (self: Internal, ...args: unknown[]) => unknown, ...args: unknown[]): unknown {
+    return fn(this, ...args);
   },
 });
 // Also has ~standard below

--- a/packages/sury/src/types.ts
+++ b/packages/sury/src/types.ts
@@ -234,6 +234,12 @@ export type Val = {
   o?: boolean;
 }
 
+// Shared `undefined` for every value-position use across the implementation:
+// a bare `undefined` minifies to `void 0` (6 chars), this const to 1. Never
+// interpolate it into generated-code strings — emitted JS text keeps literal
+// `void 0`.
+export const U = undefined;
+
 export const immutableEmptyArray: unknown[] = [];
 // Null-prototype: used as a schema's `properties` placeholder, so an
 // indexed/`in` lookup for a field named after an Object.prototype member
@@ -294,18 +300,18 @@ export const stringify = (unknown: unknown): string => {
 }
 
 export const toExpression = (schema: Internal): string => {
-  if (schema.name !== undefined) {
+  if (schema.name !== U) {
     return schema.name;
-  } else if (schema.const !== undefined) {
+  } else if (schema.const !== U) {
     return stringify(schema.const);
-  } else if (schema.anyOf !== undefined) {
+  } else if (schema.anyOf !== U) {
     return schema.anyOf.map(toExpression).join(" | ");
   } else if (schema.format === "compactColumns") {
     // For compactColumns, show the column types if we have properties from .to
     const to = schema.to;
-    if (to !== undefined) {
+    if (to !== U) {
       const props = to.properties;
-      if (props !== undefined) {
+      if (props !== U) {
         const keys = Object.keys(props);
         return `[${keys
           .map((key) => {
@@ -319,14 +325,14 @@ export const toExpression = (schema: Internal): string => {
     } else {
       // No S.to applied, reuse the array expression logic
       const additionalItems = schema.additionalItems;
-      if (additionalItems !== undefined && typeof additionalItems === "object") {
+      if (additionalItems !== U && typeof additionalItems === "object") {
         const innerArraySchema = additionalItems;
         return `${toExpression(innerArraySchema)}[]`;
       } else {
         return "unknown[][]";
       }
     }
-  } else if (schema.format !== undefined) {
+  } else if (schema.format !== U) {
     return schema.format;
   } else if (schema.type === objectTag) {
     const properties = schema.properties!;

--- a/packages/sury/src/types.ts
+++ b/packages/sury/src/types.ts
@@ -241,9 +241,15 @@ export const immutableEmptyArray: unknown[] = [];
 // something inherited instead of correctly reporting "no such property".
 export const immutableEmptyObject: Record<string, unknown> = Object.create(null);
 
-// This is dirty
+// Probe the Standard Schema marker's *presence* with `in` instead of reading
+// it: the `~standard` prototype getter allocates a fresh StandardProps object
+// (+4 closures) on every access, and this runs per-node while building every
+// `S.schema({...})`. `in` walks the prototype chain without invoking the
+// getter. The `typeof === object` guard keeps primitives (passed by
+// `js_assert`) from throwing on `in` and reproduces the old falsy-on-primitive
+// result.
 export const isSchemaObject = (obj: unknown): boolean => {
-  return !!(obj as { "~standard"?: unknown })["~standard"];
+  return typeof obj === objectTag && obj !== null && "~standard" in (obj as object);
 }
 
 export const constField = "const";

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -186,9 +186,9 @@ test("identity claimed but the operation doesn't actually compile to identity", 
         input: string
         output: string
     -   instantiations: 254
-    -   bundleBytes: 3744
+    -   bundleBytes: 3790
     +   instantiations: 5181
-    +   bundleBytes: 4217
+    +   bundleBytes: 4266
       vs:
         zod: z.string()
       jsonSchema:
@@ -258,11 +258,11 @@ test("eq-to-parse claimed but the operation doesn't actually compile to the same
     -   input: never
     -   output: never
     -   instantiations: 254
-    -   bundleBytes: 3551
+    -   bundleBytes: 3569
     +   input: string
     +   output: string
     +   instantiations: 5181
-    +   bundleBytes: 4217
+    +   bundleBytes: 4266
       vs:
         zod: z.never()
       jsonSchema:


### PR DESCRIPTION
Makes schema construction and operation compilation (codegen + `new Function`) measurably faster, guided by a wall-clock A/B harness (interleaved, drift-cancelled) and CPU profiling. Key insight: operation creation is ~90% Sury's own codegen — `new Function` is only ~2 µs — and ~40% of that codegen was GC from short-lived allocations, so most wins come from allocation elimination. Behaviour is preserved throughout: generated-code goldens, `ts.instantiations`, and inferred types are byte-identical at every commit; 254 tests + 32/32 specs green.

## Measured impact (vs. `main` at fork point)

| metric | change |
|---|---|
| Object schema construction | −30% to −53% |
| Object operation compile | −25% to −30% |
| Union compile | −9% to −16% |
| `~standard.validate` per call | −22% (231 → 180 ns) |
| Codegen GC share | 40% → 8.5% |
| `S.mjs` raw | −3 KB |

## Commits

- **Allocation cuts** (`2bb0dfe`): `isSchemaObject` probes `~standard` with `in` instead of invoking the prototype getter (which allocated an object + 4 closures per node of every `S.schema({...})`); `.with` becomes a plain method instead of a closure-allocating getter; `B_inlineLocation` drops a cache that cost more than it saved (fresh key string + pushed `bGlobal` into dictionary mode); `typeofCond` memoized per tag; shared immutable per-tag `Check` objects.
- **Monomorphic Val** (`a40aedb`): all Val creators emit one canonical field order → one V8 hidden class → monomorphic property reads in the hot `merge`/`parse` loops. Costs ~+60 B gzipped on literal/union bundles (visible in the exact goldens below).
- **`B_val` factory + revert** (`ce6f27d`, `dfdaec7`): a single positional Val factory was tried and reverted — its 15 same-typed positional args can't be type-checked against transposition; named-field literals win on safety/readability.
- **`~standard` cached on first access** (`401a0a0`): Standard Schema consumers read `schema["~standard"].validate` per validation call, and the plain getter re-allocated the whole props object each time. The cache is a non-enumerable own property so `copySchema`'s `Object.assign` can't leak a wrong-schema cache onto derived schemas.
- **Shared `U` const** (`ddc3593`): every value-position `undefined`/`void 0` in the implementation goes through `export const U = undefined` (1 char minified vs 6). Emitted-code strings keep literal `void 0`; type positions keep the `undefined` type. −15 to −28 B gzipped per consumer bundle, −1.9 KB raw.
- **Exact `bundleBytes` goldens** (`b20a30e`): removes the spec harness's ±1% tolerance band — it let consistent sub-1% drift accumulate against stale goldens and misattributed the total to whichever change finally crossed the line. All 32 goldens re-recorded exactly; future diffs show their true size cost.
- Merge of `main` (picks up #312–#314; resolved overlap with the `tuple2` zod fix and #313's `unionIsWiderSchema` guard).

## Net golden ledger (exact, post-band-removal)

Literal/null/nan/union bundles +61–68 B gzipped and merge/object composites +33–52 B (the monomorphic-Val + `~standard`-cache trades); primitives and `object1`/`object10`/`tuple2`/`tuple10`/`union2` end 4–33 B smaller than before. Generated code is unchanged everywhere.

Explored and rejected with measurements: `i.a` member-accessor codegen (+100 B/bundle, no speedup), shared-constructor Val (+185 B on primitives), `unionFactory` Set→array (−15% optional construction but +110 B), typeof-literal and prototype-based schema checks (both measured slower on current V8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jn1tx57nNQX7hwrNH6zNrQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of optional and missing values for more consistent schema parsing, validation, serialization, and code generation.
  * Streamlined repeated primitive validation checks to reduce unnecessary allocations.
  * Preserved existing schema behavior while improving consistency across supported formats and operations.

* **Tests**
  * Updated recorded bundle-size benchmarks to reflect current generated output accurately.
  * Bundle-size changes are now captured precisely rather than being ignored when they fall within a small tolerance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->