### PR TITLE
Preserve YAML comments and enforce spec documentation standards

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -19,8 +19,6 @@ pnpm spec check [id]           # gate; omit [id] for all specs
 Add a case: named entry with just `input` under an op's `examples`, then `check --write`.
 Follow the CLI's error messages. Unassertable ops take `_skip: <reason>`; pass-through ops must be the bare literal `identity`; a decode/encode that compiles to the same code as `parse` must be the bare literal `eq-to-parse` (its expression and examples live on `parse`).
 
-Comments are rejected unless they start with `FIXME:` — the marker for broken behavior the goldens currently snapshot. Anything the format can't express goes under **Spec Harness Suggestions** in `CONTRIBUTING.md`, not into prose the checker can't verify.
-
 Examples must cover every edge case found while investigating the schema — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corners, each generated-check branch. Findings from a bug report/review go into `examples`, not test files or commit messages.
 
 ## Aliases

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -19,6 +19,8 @@ pnpm spec check [id]           # gate; omit [id] for all specs
 Add a case: named entry with just `input` under an op's `examples`, then `check --write`.
 Follow the CLI's error messages. Unassertable ops take `_skip: <reason>`; pass-through ops must be the bare literal `identity`; a decode/encode that compiles to the same code as `parse` must be the bare literal `eq-to-parse` (its expression and examples live on `parse`).
 
+Comments are rejected unless they start with `FIXME:` — the marker for broken behavior the goldens currently snapshot. Anything the format can't express goes under **Spec Harness Suggestions** in `CONTRIBUTING.md`, not into prose the checker can't verify.
+
 Examples must cover every edge case found while investigating the schema — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corners, each generated-check branch. Findings from a bug report/review go into `examples`, not test files or commit messages.
 
 ## Aliases

--- a/packages/spec/cli.ts
+++ b/packages/spec/cli.ts
@@ -13,8 +13,10 @@ import {
   listSpecFiles,
   lintSpecsDir,
   specId,
+  parseSpec,
   readSpec,
   serialize,
+  collectComments,
   recomputeGoldens,
   evalSchema,
   identityViolations,
@@ -90,7 +92,8 @@ const cmdSchema = (): void => {
 
 const cmdFormat = (): void => {
   for (const file of targets()) {
-    writeFileSync(file, serialize(readSpec(file)));
+    const raw = readFileSync(file, "utf8");
+    writeFileSync(file, serialize(parseSpec(raw), collectComments(raw)));
     console.log(`format ${specId(file)}`);
   }
 };
@@ -223,7 +226,7 @@ const cmdCheck = async (): Promise<void> => {
         if (evaluated) {
           try {
             if (identityViolations(schema, obj).length === 0) {
-              knownFresh = serialize(await recomputeGoldens(obj));
+              knownFresh = serialize(await recomputeGoldens(obj), collectComments(raw));
               if (knownFresh !== raw) {
                 writeFileSync(file, knownFresh);
                 raw = knownFresh;

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -65,6 +65,21 @@ export const lintSkips = (obj: unknown, path: string, out: string[]): void => {
     for (const [k, v] of Object.entries(obj)) lintSkips(v, path ? `${path}.${k}` : k, out);
 };
 
+// A full op block is chosen over `identity`/`eq-to-parse` precisely because it
+// has real codegen — and nothing ever runs that codegen until an example does,
+// so an empty map snapshots an expression no test executes.
+export const lintExamples = (spec: Spec, out: string[]): void => {
+  const ops = spec.operations as Record<OpName, Operation>;
+  for (const opName of OP_ORDER) {
+    const op = ops[opName];
+    if (typeof op === "string" || isCreationError(op) || Object.keys(op.examples).length) continue;
+    out.push(
+      `operations.${opName}: no examples — a compiled op block must run at least one input ` +
+        "(add a named entry with just `input`, then `--write` fills the result)",
+    );
+  }
+};
+
 export const specId = (file: string): string =>
   basename(file).replace(/\.yaml$/, "");
 
@@ -755,6 +770,7 @@ export const checkSpec = async (
   const spec = v.ok ? v.value : obj;
 
   lintSkips(spec, "", errs);
+  lintExamples(spec, errs);
 
   // Collected before the canonical form is built (rather than dropped) so a
   // disallowed comment is reported as itself, not as a "not canonical" diff —

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -12,7 +12,7 @@
 import { readFileSync, readdirSync } from "node:fs";
 import { join, basename } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { Document, parse as parseYaml, parseDocument, isMap, isSeq } from "yaml";
 import { diffLinesUnified } from "@vitest/utils/diff";
 import ts from "typescript";
 import * as S from "../sury/src/S.mjs";
@@ -307,8 +307,98 @@ export const canonicalize = (obj: Spec): Spec => {
   return o;
 };
 
-export const serialize = (obj: Spec): string =>
-  HEADER + "\n" + stringifyYaml(canonicalize(obj), { lineWidth: 0 });
+// ---- comments -------------------------------------------------------------
+
+// Rebuilding the YAML from the parsed object would drop every comment, so they
+// are lifted off the on-disk text and re-attached to the canonical document,
+// anchored by the dotted spec path they annotate (`ts.schema`,
+// `ts.aliases[0]`; `""` for a comment trailing the whole file).
+type Anchor = { before?: string; trailing?: string };
+export type SpecComments = ReadonlyMap<string, Anchor>;
+const NO_COMMENTS: SpecComments = new Map();
+
+// `owner` is the collection whose FIRST item this path is: yaml hangs a
+// leading comment on the collection node in that one position and on the item
+// itself everywhere else, though both mean "the lines above this path".
+type AnchorVisitor = (path: string, before: any, trailing: any, owner?: any) => void;
+
+const eachAnchor = (node: unknown, path: string, visit: AnchorVisitor): void => {
+  if (isMap(node)) {
+    node.items.forEach((pair: any, i) => {
+      const p = path ? `${path}.${pair.key.value}` : String(pair.key.value);
+      visit(p, pair.key, pair.value, i === 0 ? node : undefined);
+      eachAnchor(pair.value, p, visit);
+    });
+  } else if (isSeq(node)) {
+    node.items.forEach((item: any, i) => {
+      const p = `${path}[${i}]`;
+      visit(p, item, item, i === 0 ? node : undefined);
+      eachAnchor(item, p, visit);
+    });
+  }
+};
+
+export const collectComments = (raw: string): SpecComments => {
+  // The header is machine-owned (serialize re-emits it); parsing without it
+  // keeps it from being collected as a comment on the first key.
+  const doc = parseDocument(raw.startsWith(HEADER + "\n") ? raw.slice(HEADER.length + 1) : raw);
+  const out = new Map<string, Anchor>();
+  const add = (path: string, side: keyof Anchor, text?: string | null): void => {
+    if (text == null) return;
+    const at = out.get(path) ?? {};
+    at[side] = at[side] === undefined ? text : `${at[side]}\n${text}`;
+    out.set(path, at);
+  };
+  eachAnchor(doc.contents, "", (path, before, trailing, owner) => {
+    add(path, "before", owner?.commentBefore);
+    add(path, "before", before.commentBefore);
+    add(path, "trailing", trailing?.comment);
+  });
+  add("", "trailing", doc.comment);
+  return out;
+};
+
+const applyComments = (doc: Document, comments: SpecComments): void => {
+  eachAnchor(doc.contents, "", (path, before, trailing) => {
+    const at = comments.get(path);
+    if (!at) return;
+    if (at.before !== undefined) before.commentBefore = at.before;
+    if (at.trailing !== undefined && trailing) trailing.comment = at.trailing;
+  });
+  const trailing = comments.get("")?.trailing;
+  if (trailing !== undefined) doc.comment = trailing;
+};
+
+// A spec is machine-checked documentation: every claim about the schema is a
+// dimension the harness executes, so prose the checker can't see is a claim
+// nothing enforces. The one exception is `FIXME:` — a marker for behavior the
+// goldens currently snapshot but shouldn't.
+const FIXME = "FIXME:";
+
+// Consecutive `#` lines arrive as one string; a blank line between them starts
+// a separate comment, and only a comment's first line carries the prefix (the
+// rest is continuation).
+export const lintComments = (comments: SpecComments, out: string[]): void => {
+  for (const [path, anchor] of comments)
+    for (const text of [anchor.before, anchor.trailing]) {
+      if (text === undefined) continue;
+      for (const comment of text.split(/\n\s*\n/)) {
+        const first = comment.split("\n")[0]!.trim();
+        if (first.startsWith(FIXME)) continue;
+        out.push(
+          `${path ? `${path}: ` : ""}comment ${JSON.stringify(first)} is not allowed — prefix it with ` +
+            `\`${FIXME}\` if it flags broken behavior to address, or move it to Spec Harness Suggestions ` +
+            `in CONTRIBUTING.md if the spec format can't express it`,
+        );
+      }
+    }
+};
+
+export const serialize = (obj: Spec, comments: SpecComments = NO_COMMENTS): string => {
+  const doc = new Document(canonicalize(obj));
+  if (comments.size) applyComments(doc, comments);
+  return HEADER + "\n" + doc.toString({ lineWidth: 0 });
+};
 
 // ---- golden recomputation --------------------------------------------------
 
@@ -666,7 +756,13 @@ export const checkSpec = async (
 
   lintSkips(spec, "", errs);
 
-  const canon = serialize(spec);
+  // Collected before the canonical form is built (rather than dropped) so a
+  // disallowed comment is reported as itself, not as a "not canonical" diff —
+  // and so `--write` never silently deletes one.
+  const comments = collectComments(raw);
+  lintComments(comments, errs);
+
+  const canon = serialize(spec, comments);
   if (raw !== canon)
     errs.push(
       `not canonical — run \`pnpm spec format ${id}\` (or \`pnpm spec check ${id} --write\`, which also refreshes goldens):\n${diffText(raw, canon)}`,
@@ -686,7 +782,7 @@ export const checkSpec = async (
     try {
       const violations = identityViolations(schema, spec);
       for (const violation of violations) errs.push(violation);
-      const fresh = knownFresh ?? serialize(await recomputeGoldens(spec));
+      const fresh = knownFresh ?? serialize(await recomputeGoldens(spec), comments);
       if (fresh !== canon)
         errs.push(
           (violations.length

--- a/packages/sury/specs/any.yaml
+++ b/packages/sury/specs/any.yaml
@@ -8,6 +8,9 @@ ts:
 vs:
   zod: z.any()
 jsonSchema:
+  # FIXME: "any value" is the one thing JSON Schema represents trivially ({} or
+  # true), and S.toJSONSchema(S.json) already returns {} — both directions
+  # should too instead of throwing. The message also mislabels S.any as unknown.
   input: Expected JSON, received unknown
   output: Expected JSON, received unknown
 operations:

--- a/packages/sury/specs/codec-json-union2.yaml
+++ b/packages/sury/specs/codec-json-union2.yaml
@@ -13,11 +13,16 @@ jsonSchema:
   output: Expected JSON, received bigint | string
 operations:
   parse:
+    # FIXME: `else if(!(typeof i==="string"))` re-tests the condition it's already
+    # the else of — always true, so it should be a bare `else`.
     expression: i=>{if(typeof i==="string"){let v0;try{v0=BigInt(i)}catch(_){e[0](i)}i=v0}else if(!(typeof i==="string")){e[1](i)}return i}
     examples:
       bigint-string:
         input: '"123"'
         output: 123n
+      # FIXME: the S.string member never gets a chance — a string that isn't a
+      # bigint should fall back to it, not error. codec-string-union2-transformed
+      # falls back in the same shape (its `falls-back-to-string` example).
       catchall-string:
         input: '"abc"'
         error: Expected bigint, received "abc"

--- a/packages/sury/specs/codec-number-union2-int32.yaml
+++ b/packages/sury/specs/codec-number-union2-int32.yaml
@@ -10,9 +10,13 @@ vs:
     _skip: not-applicable
 jsonSchema:
   input: '{ anyOf: [{ type: "integer", minimum: -2147483648, maximum: 2147483647 }, { type: "number" }] }'
+  # FIXME: the same internal crash as operations.parse, surfaced through toJSONSchema.
   output: Cannot read properties of undefined (reading 'v')
 operations:
   parse:
+    # FIXME: a TypeError is an internal fault, not a rejection — parse and decode
+    # both fail to compile while encode compiles fine, so it's the reverse of a
+    # working conversion that crashes.
     creationError: "TypeError: Cannot read properties of undefined (reading 'v')"
   decode: eq-to-parse
   encode:

--- a/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
+++ b/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
@@ -9,6 +9,8 @@ vs:
   zod:
     _skip: not-applicable
 jsonSchema:
+  # FIXME: S.toJSONSchema recurses forever on this conversion — neither side is
+  # unrepresentable ('"x" | undefined' and '"x" | null' both are).
   input: Maximum call stack size exceeded
   output: Maximum call stack size exceeded
 operations:

--- a/packages/sury/specs/codec-optional-nullable-partial.yaml
+++ b/packages/sury/specs/codec-optional-nullable-partial.yaml
@@ -25,6 +25,8 @@ operations:
         output: "null"
   decode: eq-to-parse
   encode:
+    # FIXME: `""+i` on a boolean can't throw, so the first catch (and its
+    # `i===void 0` re-test of a value already known to be a boolean) is dead.
     expression: i=>{if(typeof i==="boolean"){try{i=""+i}catch(e0){if(!(i===void 0)){e[0](i,e0)}}}else if(i===null){try{i=void 0}catch(e1){e[1](i,e1)}}else{e[2](i)}return i}
     examples:
       boolean:

--- a/packages/sury/specs/codec-string-optional-partial.yaml
+++ b/packages/sury/specs/codec-string-optional-partial.yaml
@@ -28,6 +28,9 @@ operations:
       string:
         input: '"abc"'
         output: '"abc"'
+      # FIXME: not injective — this collides with a genuine "undefined" string
+      # (see the parse `ambiguous-undefined-string` example), so an encoded
+      # undefined parses back as the string, never as undefined.
       undefined:
         input: undefined
         output: '"undefined"'

--- a/packages/sury/specs/codec-string-undefined.yaml
+++ b/packages/sury/specs/codec-string-undefined.yaml
@@ -26,7 +26,13 @@ operations:
         error: Expected string, received 123
   decode:
     expression: i=>{i==="undefined"||e[0](i);return void 0}
-    examples: {}
+    examples:
+      valid:
+        input: '"undefined"'
+        output: undefined
+      invalid-string:
+        input: '"abc"'
+        error: Expected "undefined", received "abc"
   encode:
     expression: i=>{i===void 0||e[0](i);return "undefined"}
     examples:

--- a/packages/sury/specs/codec-string-union2-transformed.yaml
+++ b/packages/sury/specs/codec-string-union2-transformed.yaml
@@ -13,6 +13,8 @@ jsonSchema:
   output: '{ anyOf: [{ type: "number" }, { type: "string" }] }'
 operations:
   parse:
+    # FIXME: `catch(e0){}` swallows everything the branch throws, not just the
+    # type miss it means to fall back from (decode's expression too).
     expression: i=>{typeof i==="string"||e[1](i);try{let v0=+i;!Number.isNaN(v0)||e[0](i);i=v0}catch(e0){}return i}
     examples:
       decodes-to-number:
@@ -26,7 +28,27 @@ operations:
         output: "1.5"
   decode:
     expression: i=>{try{let v0=+i;!Number.isNaN(v0)||e[0](i);i=v0}catch(e0){}return i}
-    examples: {}
+    examples:
+      decodes-to-number:
+        input: '"123"'
+        output: "123"
+      falls-back-to-string:
+        input: '"abc"'
+        output: '"abc"'
+      # FIXME: `+i` decodes blank strings to 0 — "" and "   " should fall back to
+      # the S.string member, as "abc" does, not become a number.
+      empty-string:
+        input: '""'
+        output: "0"
+      whitespace-string:
+        input: '"   "'
+        output: "0"
+      hex-string:
+        input: '"0x10"'
+        output: "16"
+      infinity-string:
+        input: '"Infinity"'
+        output: Infinity
   encode:
     expression: i=>{if(typeof i==="number"&&!Number.isNaN(i)){i=""+i}else if(!(typeof i==="string")){e[0](i)}return i}
     examples:

--- a/packages/sury/specs/codec-union2-union2-transformed.yaml
+++ b/packages/sury/specs/codec-union2-union2-transformed.yaml
@@ -26,6 +26,8 @@ operations:
         output: '"1.5"'
   decode: eq-to-parse
   encode:
+    # FIXME: `catch(e0){}` swallows everything the branch throws, not just the
+    # type miss it means to fall back from.
     expression: i=>{if(typeof i==="string"){try{let v0=+i;!Number.isNaN(v0)||e[0](i);i=v0}catch(e0){}}else{e[1](i)}return i}
     examples:
       numeric-string:

--- a/packages/sury/specs/codec-union2-union3-extra-target.yaml
+++ b/packages/sury/specs/codec-union2-union3-extra-target.yaml
@@ -23,6 +23,9 @@ operations:
         output: "123"
   decode: eq-to-parse
   encode:
+    # FIXME: `""+i` on a boolean can't throw, so the catch is unreachable — and
+    # codec-union3-union2-extra-source (the mirror of this shape) passes the same
+    # helper's arguments in a different order, so one of the two is wrong.
     expression: i=>{if(typeof i==="boolean"){try{i=""+i}catch(e0){e[1](i,e0,e[0])}}else if(!(typeof i==="number"&&!Number.isNaN(i)||typeof i==="string")){e[2](i)}return i}
     examples:
       string:

--- a/packages/sury/specs/codec-union3-union2-extra-source.yaml
+++ b/packages/sury/specs/codec-union3-union2-extra-source.yaml
@@ -13,6 +13,8 @@ jsonSchema:
   output: '{ anyOf: [{ type: "string" }, { type: "number" }] }'
 operations:
   parse:
+    # FIXME: unreachable catch, and the argument order differs from
+    # codec-union2-union3-extra-target's mirrored branch — see the FIXME there.
     expression: i=>{if(typeof i==="boolean"){try{i=""+i}catch(e1){e[1](i,e[0],e1)}}else if(!(typeof i==="string"||typeof i==="number"&&!Number.isNaN(i))){e[2](i)}return i}
     examples:
       string:

--- a/packages/sury/specs/object-in-object3.yaml
+++ b/packages/sury/specs/object-in-object3.yaml
@@ -27,12 +27,15 @@ operations:
         input: '{ a: "x", nested: { b: "not a number", inner: { c: true } } }'
         error: 'Failed at ["nested"]["b"]: Expected number, received "not a number"'
   decode:
+    # FIXME: two property reads whose results are discarded, then the input is
+    # returned unchanged — nothing here transforms, so it should be `identity`.
     expression: i=>{let v0=i["nested"];let v1=v0["inner"];return i}
     examples:
       valid:
         input: '{ a: "x", nested: { b: 1, inner: { c: true, d: "y" } } }'
         output: '{ a: "x", nested: { b: 1, inner: { c: true, d: "y" } } }'
   encode:
+    # FIXME: the same discarded reads as decode.
     expression: i=>{let v0=i["nested"];let v1=v0["inner"];return i}
     examples:
       valid:

--- a/packages/sury/specs/object-reserved-names.yaml
+++ b/packages/sury/specs/object-reserved-names.yaml
@@ -22,6 +22,10 @@ operations:
       wrong-type:
         input: "{ constructor: 1, hasOwnProperty: 5 }"
         error: 'Failed at ["constructor"]: Expected string, received 1'
+      # FIXME: fields are read off the prototype chain, so an absent one reports
+      # the inherited value ("received Function") instead of undefined — and an
+      # *optional* field named after a prototype member fails outright:
+      # S.schema({toString: S.optional(S.string)}) rejects {}.
       missing-fields:
         input: "{}"
         error: 'Failed at ["constructor"]: Expected string, received Function'

--- a/packages/sury/specs/unknown.yaml
+++ b/packages/sury/specs/unknown.yaml
@@ -8,6 +8,7 @@ ts:
 vs:
   zod: z.unknown()
 jsonSchema:
+  # FIXME: should be {} (any value), same as S.toJSONSchema(S.json) — see any.yaml.
   input: Expected JSON, received unknown
   output: Expected JSON, received unknown
 operations:

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -202,6 +202,20 @@ test("not canonical (on-disk text doesn't match the canonical form)", async () =
   `);
 });
 
+test("a compiled op block with no examples (codegen nothing ever runs)", async () => {
+  const spec = mutate((s) => {
+    if (s.operations.parse !== "identity" && !isCreationError(s.operations.parse))
+      s.operations.parse.examples = {};
+  });
+  await expect(runCheck("string", serialize(spec))).resolves.toMatchInlineSnapshot(`
+    {
+      "stderr": "✗ string
+        operations.parse: no examples — a compiled op block must run at least one input (add a named entry with just \`input\`, then \`--write\` fills the result)",
+      "stdout": "",
+    }
+  `);
+});
+
 test("a comment that isn't a FIXME (prose the checker can't verify)", async () => {
   const spec = mutate(() => {});
   const commented = serialize(spec).replace("ts:\n", "ts:\n  # the fastest schema there is\n");
@@ -282,6 +296,7 @@ test("full op block claimed but the operation actually compiles to identity", as
   await expect(runCheck("string", serialize(spec))).resolves.toMatchInlineSnapshot(`
     {
       "stderr": "✗ string
+        operations.decode: no examples — a compiled op block must run at least one input (add a named entry with just \`input\`, then \`--write\` fills the result)
         operations.decode: compiles to identity — use \`identity\` instead of an expression + examples
         goldens stale — resolve the identity mismatch above first, then \`pnpm spec check string --write\` can fix it (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
     @@ -27,7 +27,10 @@
@@ -357,6 +372,7 @@ test("full op block claimed but the operation actually compiles to the same code
   await expect(runCheck("never", serialize(spec))).resolves.toMatchInlineSnapshot(`
     {
       "stderr": "✗ never
+        operations.decode: no examples — a compiled op block must run at least one input (add a named entry with just \`input\`, then \`--write\` fills the result)
         operations.decode: compiles to the same code as parse — use \`eq-to-parse\` instead of an expression + examples
         goldens stale — resolve the identity mismatch above first, then \`pnpm spec check never --write\` can fix it (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
     @@ -21,7 +21,7 @@

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -182,19 +182,50 @@ test("vs.zod overwrite form omits a side that actually diverges from ts (must be
 
 test("not canonical (on-disk text doesn't match the canonical form)", async () => {
   const spec = mutate(() => {});
-  const scrambled = serialize(spec).replace("ts:\n", "ts:\n  # a stray comment\n");
+  const scrambled = serialize(spec).replace("vs:\n  zod: z.string()\n", "vs: { zod: z.string() }\n");
   await expect(runCheck("string", scrambled)).resolves.toMatchInlineSnapshot(`
     {
       "stderr": "✗ string
         not canonical — run \`pnpm spec format string\` (or \`pnpm spec check string --write\`, which also refreshes goldens):
-    @@ -1,6 +1,5 @@
-      # yaml-language-server: $schema=./spec.schema.json
-      ts:
-    -   # a stray comment
-        schema: S.string
-        input: string
-        output: string",
+    @@ -5,7 +5,8 @@
+        output: string
+        instantiations: 254
+        bundleBytes: 3744
+    - vs: { zod: z.string() }
+    + vs:
+    +   zod: z.string()
+      jsonSchema:
+        input: '{ type: "string" }'
+        output: '{ type: "string" }'",
       "stdout": "",
+    }
+  `);
+});
+
+test("a comment that isn't a FIXME (prose the checker can't verify)", async () => {
+  const spec = mutate(() => {});
+  const commented = serialize(spec).replace("ts:\n", "ts:\n  # the fastest schema there is\n");
+  await expect(runCheck("string", commented)).resolves.toMatchInlineSnapshot(`
+    {
+      "stderr": "✗ string
+        ts.schema: comment "the fastest schema there is" is not allowed — prefix it with \`FIXME:\` if it flags broken behavior to address, or move it to Spec Harness Suggestions in CONTRIBUTING.md if the spec format can't express it",
+      "stdout": "",
+    }
+  `);
+});
+
+// The canonical form is rebuilt from the parsed object, so a comment survives
+// only if it's re-anchored — otherwise `--write` would silently delete the one
+// marker an author leaves behind.
+test("a FIXME comment is allowed and survives canonicalization", async () => {
+  const spec = mutate(() => {});
+  const commented = serialize(spec)
+    .replace("ts:\n", "ts:\n  # FIXME: coercion is wrong here (#123)\n")
+    .replace("  decode: identity\n", "  decode: identity # FIXME: should not be identity\n");
+  await expect(runCheck("string", commented)).resolves.toMatchInlineSnapshot(`
+    {
+      "stderr": "",
+      "stdout": "✓ string",
     }
   `);
 });

--- a/packages/sury/tests/spec_test.ts
+++ b/packages/sury/tests/spec_test.ts
@@ -15,6 +15,8 @@ import {
   evalSchema,
   identityViolations,
   checkAliases,
+  collectComments,
+  lintComments,
   lintSkips,
   lintSpecsDir,
 } from "../../spec/harness";
@@ -62,7 +64,14 @@ describe.each(specs)("spec: $id", ({ file }) => {
   });
 
   test("is in canonical form (run `pnpm spec format`)", () => {
-    expect(readFileSync(file, "utf8")).toBe(serialize(spec));
+    const raw = readFileSync(file, "utf8");
+    expect(raw).toBe(serialize(spec, collectComments(raw)));
+  });
+
+  test("every comment is a `FIXME:` (run `pnpm spec check`)", () => {
+    const errs: string[] = [];
+    lintComments(collectComments(readFileSync(file, "utf8")), errs);
+    expect(errs, errs.join("\n")).toEqual([]);
   });
 
   // Only checkSpec (the pnpm spec check gate) runs these two — nothing else

--- a/packages/sury/tests/spec_test.ts
+++ b/packages/sury/tests/spec_test.ts
@@ -17,6 +17,7 @@ import {
   checkAliases,
   collectComments,
   lintComments,
+  lintExamples,
   lintSkips,
   lintSpecsDir,
 } from "../../spec/harness";
@@ -87,6 +88,12 @@ describe.each(specs)("spec: $id", ({ file }) => {
   test("every _skip reason is valid (run `pnpm spec check`)", () => {
     const errs: string[] = [];
     lintSkips(spec, "", errs);
+    expect(errs, errs.join("\n")).toEqual([]);
+  });
+
+  test("every compiled op block has examples (run `pnpm spec check`)", () => {
+    const errs: string[] = [];
+    lintExamples(spec, errs);
     expect(errs, errs.join("\n")).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

This change adds infrastructure to preserve YAML comments during spec canonicalization and enforces that all comments in spec files are `FIXME:` markers (prose that documents known broken behavior). It also adds validation that compiled operation blocks must have at least one example, ensuring all generated code paths are tested.

## Key Changes

- **Comment preservation**: Implemented `collectComments()` to extract comments from raw YAML before parsing, and `applyComments()` to re-attach them to the canonical document. Comments are anchored by their dotted spec path (e.g., `ts.schema`, `operations.parse.examples[0]`).

- **Comment linting**: Added `lintComments()` to enforce that all comments are prefixed with `FIXME:` — any other prose is rejected with guidance to move it to CONTRIBUTING.md or mark it as a known issue. This ensures the spec is machine-verifiable documentation where every claim is a dimension the harness executes.

- **Example validation**: Added `lintExamples()` to require that every compiled operation block (not `identity` or `eq-to-parse`) has at least one example. This prevents dead code paths where codegen runs but no test exercises it.

- **Serialization update**: Modified `serialize()` to accept and apply comments, preserving them through `--write` operations. The `cmdFormat` and `cmdCheck` commands now collect comments before canonicalization so they survive the round-trip.

- **Spec updates**: Added `FIXME:` comments to existing specs documenting known issues (unreachable code, incorrect behavior, infinite recursion, etc.). Filled in empty `examples: {}` blocks in `codec-string-undefined.yaml` and `codec-string-union2-transformed.yaml` with test cases.

## Implementation Details

- Comments are collected from the raw YAML text using the `yaml` library's `parseDocument()` and `isMap()`/`isSeq()` helpers to traverse the AST and extract `commentBefore` and `comment` properties.
- The `eachAnchor()` visitor walks the parsed document tree, building a map of spec paths to their associated comments.
- Comments are re-applied by traversing the canonical document's AST in the same order and restoring the comment properties before serialization.
- The header is stripped before parsing to prevent it from being collected as a comment on the first key, then re-prepended after serialization.
- Tests verify that comments survive canonicalization and that disallowed comments are caught with helpful error messages.

https://claude.ai/code/session_01JdpZQX7F3K5FfBUHidZLYx