### PR TITLE
Add CODEC_NEXT_SPEC.md and update union conversion documentation

### DIFF
--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -230,10 +230,15 @@ variant of a union changes nothing about that: if any variant's decoder can't be
 built, the whole operation is rejected, under every rule above.
 
 ```ts
+S.boolean.with(S.to, S.number); // ❌ the reference case, no union involved
 S.boolean.with(S.to, S.union([S.string, S.symbol])); // ❌ boolean -> symbol has no decoder
 S.union([S.boolean, S.symbol]).with(S.to, S.string); // ❌ symbol -> string has no decoder
 S.boolean.with(S.to, S.union([S.number, S.symbol])); // ❌ neither variant is decodable
 ```
+
+Only the first of those four is rejected today
+(`codec-bool-number-unsupported`); the three union shapes each compile into
+something else.
 
 None of the three salvage attempts are available: a variant is never dropped
 from the generated code, never left as a dispatch branch that throws per value,

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -41,10 +41,26 @@ S.string.with(S.to, S.schema(undefined)); // "undefined" <-> undefined
 S.schema(null).with(S.to, S.schema(undefined)); // null <-> undefined
 ```
 
+**Literal → literal is one remap, not a table of pairs.** Whatever their tags,
+one literal decodes into another by validating the source const and returning
+the target const — `null <-> undefined` is an instance of it, not a nullish
+special case:
+
+```ts
+S.schema("a").with(S.to, S.schema(42)); // "a" <-> 42
+S.schema(1).with(S.to, S.schema(true)); // 1 <-> true
+S.schema(1n).with(S.to, S.schema("one")); // 1n <-> "one"
+S.schema(NaN).with(S.to, S.schema(0)); // NaN <-> 0
+S.schema([1, 2]).with(S.to, S.schema("done")); // [1, 2] <-> "done"
+```
+
+The collection-literal line is the one that doesn't hold today — see
+`codec-literal-array-literal-string`.
+
 ## Rule 2: non-union → union
 
 The built-in decoder is applied separately for every target variant, attempted
-in definition order, grouped by tag:
+in definition order:
 
 ```ts
 const schema = S.json.with(S.to, S.union([S.bigint, S.string]));
@@ -57,19 +73,34 @@ S.parser(schema)(true); // throws — no implicit double decoding (true -> "true
 `S.json` is not the exact `string` type, so string inputs still go through
 variant decoding instead of passing through.
 
-**Grouped by tag** means same-tag variants form a single group at the position
-of the first one. The runtime value's tag picks the group; only that group's
-variants are attempted, in definition order:
+**Definition order is not tag order.** Same-tag variants are *not* collapsed
+into one group: a differently-tagged variant sitting between them keeps its
+turn, and the first variant that accepts wins.
+
+```ts
+const schema = S.json.with(S.to, S.union(["123", S.bigint, S.string]));
+
+S.parser(schema)("123"); // "123" — the literal matches first and stays a string
+S.parser(schema)("124"); // 124n — the literal fails, the bigint variant decodes
+S.parser(schema)("abc"); // "abc" — bigint decoding fails, the catch-all string accepts
+```
+
+`"123"` and the catch-all `S.string` share the string tag, but grouping them
+would hide the `S.bigint` between them, and `"124"` would come back a string.
+The same holds with the tags swapped — the `S.number` variant below is reached
+by a string, even though the two literals around it are both strings:
 
 ```ts
 const schema = S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]));
 
-S.parser(schema)("b"); // "b" — tries "a", then "b"; the number variant is never attempted
+S.parser(schema)("b"); // "b" — "a" fails, `+"b"` is NaN, "b" matches
+S.parser(schema)("5"); // 5 — neither literal matches, the number variant decodes
+S.parser(schema)("c"); // throws — no variant accepts
 ```
 
 `S.unknown` is a normal type here — it only matches another `unknown`. An
 `unknown` source matches none of the concrete variants, so it takes the same
-path: every variant is attempted, grouped by tag, in definition order.
+path: every variant is attempted, in definition order.
 
 **Exception — partial type match.** If the source has the same type as *some but
 not all* target variants, the operation is rejected when it's created. Sury
@@ -107,7 +138,7 @@ The `Invalid operation` error suggests these rewrites.
 ## Rule 3: union → non-union
 
 The mirror of rule 2: every source variant gets its own built-in decoder to the
-target, dispatched in definition order, grouped by tag:
+target, dispatched in definition order:
 
 ```ts
 const schema = S.union([S.bigint, S.string]).with(S.to, S.json);
@@ -193,21 +224,24 @@ checked, so transformed unions stay consistent across decode and encode.
 
 Behavior change expected, today's goldens are wrong:
 
-| Spec                                | Rule | Expected                                                          |
-| ----------------------------------- | ---- | ----------------------------------------------------------------- |
-| `codec-json-union2`                 | 2    | non-bigint string falls back to the `S.string` variant            |
-| `codec-number-union2-int32`         | 2    | compiles instead of crashing; int32 first, string next            |
-| `codec-string-optional-partial`     | 2    | rejected — partial type match                                     |
-| `codec-string-union2-partial`       | 2    | rejected — partial type match                                     |
-| `codec-unknown-union2`              | 2    | per-variant decoding, same path as `codec-json-union2`            |
-| `codec-union2-string-partial`       | 3    | rejected — partial type match                                     |
-| `codec-optional-nullable-partial`   | 4    | rejected — `string` has no same-type target variant               |
-| `codec-union2-union3-extra-target`  | 4    | rejected — `boolean` has no source variant                        |
-| `codec-union3-union2-extra-source`  | 4    | rejected — `boolean` has no target variant                        |
-| `codec-union3-union2-json`          | 4    | rejected — `json` is not the exact `string`/`number` type          |
+| Spec                                 | Rule | Expected                                                             |
+| ------------------------------------ | ---- | -------------------------------------------------------------------- |
+| `codec-literal-array-literal-string` | 1    | collection literals remap like every other literal pair              |
+| `codec-json-union2`                  | 2    | non-bigint string falls back to the `S.string` variant               |
+| `codec-json-union3-grouped`          | 2    | the `S.number` variant between the two literals is still attempted   |
+| `codec-json-union3-ungrouped`        | 2    | `"123"` matches the literal, `"124"` reaches the `S.bigint` variant  |
+| `codec-number-union2-int32`          | 2    | compiles instead of crashing; int32 first, string next               |
+| `codec-string-optional-partial`      | 2    | rejected — partial type match                                        |
+| `codec-string-union2-partial`        | 2    | rejected — partial type match                                        |
+| `codec-unknown-union2`               | 2    | per-variant decoding, same path as `codec-json-union2`               |
+| `codec-union2-string-partial`        | 3    | rejected — partial type match                                        |
+| `codec-optional-nullable-partial`    | 4    | rejected — `string` has no same-type target variant                  |
+| `codec-union2-union3-extra-target`   | 4    | rejected — `boolean` has no source variant                           |
+| `codec-union3-union2-extra-source`   | 4    | rejected — `boolean` has no target variant                           |
+| `codec-union3-union2-json`           | 4    | rejected — `json` is not the exact `string`/`number` type             |
 
 Already spec-conformant (their remaining `FIXME`s are codegen bugs, not rule
-changes): `codec-bool-number-unsupported`, `codec-json-union3-grouped`,
+changes): `codec-bool-number-unsupported`, `codec-literal-string-literal-number`,
 `codec-null-undefined`, `codec-optional-literal-nullable-literal`,
 `codec-optional-nullable-transformed`, `codec-optional-nullable`,
 `codec-optional-nullish`, `codec-string-optional-never`, `codec-string-undefined`,

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -1,0 +1,217 @@
+# Codec next
+
+Draft spec for the next codec implementation — how a conversion (`S.to`, or the
+implicit one created by reversing a schema) picks what to decode into what.
+
+Nothing here is implemented yet. `docs/*-usage.md` still describes the shipped
+three-tier algorithm; this file replaces it once the implementation lands. The
+`packages/sury/specs/codec-*.yaml` specs snapshot today's behavior and each
+carries a `FIXME: Codec next expects:` note on its schema saying what this spec
+demands of it.
+
+## Shared definitions
+
+> Two schemas have the **same type** when their type tags match — including the
+> class for instances, the format for formatted primitives, and the reference
+> for recursive schemas, where relevant. `S.int32` and `S.number` are different
+> types, and so are `S.json` and `S.string` — even though every JSON string
+> would validate against `S.string`.
+
+- **Checks run at operation creation time**, against the **derived** types — the
+  actual schema at that point in the pipeline, which may be narrower than the
+  originally defined one (an upstream transformation can refine it). Reversing a
+  schema doesn't re-run the checks: it reverses the already-resolved per-variant
+  pipelines.
+- **Nested unions are flattened** before the rules apply:
+  `S.union([S.string, S.union([S.number, S.boolean])])` acts as a three-variant
+  union. The exception is a union carrying its own format, transformation, or
+  refinement — it's treated as a normal (non-union) schema on its side of the
+  conversion.
+- **`S.never` marks an unreachable path.** `S.never` variants — including
+  transformed ones like `S.never.with(S.to, S.number)`, which match by their
+  `never` input — are ignored by type matching: they never trigger the
+  exceptions below and don't count toward rule 4's coverage.
+
+## Rule 1: non-union → non-union
+
+Built-in decoding (coercion) always applies:
+
+```ts
+S.string.with(S.to, S.schema(undefined)); // "undefined" <-> undefined
+S.schema(null).with(S.to, S.schema(undefined)); // null <-> undefined
+```
+
+## Rule 2: non-union → union
+
+The built-in decoder is applied separately for every target variant, attempted
+in definition order, grouped by tag:
+
+```ts
+const schema = S.json.with(S.to, S.union([S.bigint, S.string]));
+
+S.parser(schema)("123"); // 123n — the bigint variant comes first
+S.parser(schema)("abc"); // "abc" — bigint decoding fails, string accepts
+S.parser(schema)(true); // throws — no implicit double decoding (true -> "true" -> ...)
+```
+
+`S.json` is not the exact `string` type, so string inputs still go through
+variant decoding instead of passing through.
+
+**Grouped by tag** means same-tag variants form a single group at the position
+of the first one. The runtime value's tag picks the group; only that group's
+variants are attempted, in definition order:
+
+```ts
+const schema = S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]));
+
+S.parser(schema)("b"); // "b" — tries "a", then "b"; the number variant is never attempted
+```
+
+`S.unknown` is a normal type here — it only matches another `unknown`. An
+`unknown` source matches none of the concrete variants, so it takes the same
+path: every variant is attempted, grouped by tag, in definition order.
+
+**Exception — partial type match.** If the source has the same type as *some but
+not all* target variants, the operation is rejected when it's created. Sury
+can't tell whether you want a pass-through for the matching variant, decoding
+attempts in definition order, or simply widened the type with no decoding
+intent:
+
+```ts
+S.string.with(S.to, S.union([S.number, S.string]));
+// Invalid operation: for "123" — keep "123" or decode to 123?
+```
+
+Say what you mean with an explicit variant:
+
+```ts
+// Try decoding to number first, keep the string otherwise:
+S.string.with(S.to, S.union([S.string.with(S.to, S.number), S.string]));
+
+// Pass strings through, never producing a number:
+S.string.with(S.to, S.union([S.never.with(S.to, S.number), S.string]));
+```
+
+The same applies to widening into optional or nullable targets:
+
+```ts
+S.string.with(S.to, S.optional(S.string));
+// Invalid operation: for "undefined" — keep the string or decode to undefined?
+
+// Widen without decoding — the undefined variant is unreachable:
+S.string.with(S.to, S.union([S.string, S.never.with(S.to, S.schema(undefined))]));
+```
+
+The `Invalid operation` error suggests these rewrites.
+
+## Rule 3: union → non-union
+
+The mirror of rule 2: every source variant gets its own built-in decoder to the
+target, dispatched in definition order, grouped by tag:
+
+```ts
+const schema = S.union([S.bigint, S.string]).with(S.to, S.json);
+
+S.parser(schema)(123n); // "123"
+S.parser(schema)("123"); // "123"
+S.parser(schema)("abc"); // "abc"
+```
+
+**Exception — partial type match.** If the target has the same type as some but
+not all source variants, the operation is rejected. Sury can't tell whether the
+non-matching variants should decode to the target or be rejected as failed
+cases:
+
+```ts
+S.union([S.number, S.string]).with(S.to, S.string);
+// Invalid operation: for 123 — decode to "123" or fail as a non-matching case?
+```
+
+Say what you mean with an explicit target union:
+
+```ts
+// Decode numbers to strings:
+S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.string), S.string]));
+
+// Reject numbers:
+S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.never), S.string]));
+```
+
+The `Invalid operation` error suggests these rewrites.
+
+## Rule 4: union → union
+
+No coercion — values pass through to the same-type target variant. The two
+unions must cover each other: every source variant needs at least one same-type
+target variant, and every target variant needs at least one same-type source
+variant. Otherwise the operation is rejected:
+
+```ts
+S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string])); // ✅
+S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string, S.boolean])); // ❌ boolean has no source variant
+S.union([S.string, S.number, S.boolean]).with(S.to, S.union([S.number, S.string])); // ❌ boolean has no target variant
+S.union([S.string, S.number, S.bigint]).with(S.to, S.union([S.json, S.bigint])); // ❌ json is not the exact string/number type
+```
+
+A transformed source variant matches by its output type, and a transformed
+target variant by its input type — so per-variant conversion is always available
+explicitly:
+
+```ts
+S.optional(S.string).with(S.to, S.nullable(S.boolean)); // ❌ string doesn't match boolean
+S.optional(S.string).with(S.to, S.nullable(S.string.with(S.to, S.boolean))); // ✅
+```
+
+**Exception — nullish bridge.** A `null` or `undefined` variant left unmatched
+by type may match the opposite nullish variant on the other side — even one that
+already has a same-type match. At runtime the same-type target wins; the bridge
+only kicks in when there is none:
+
+```ts
+S.optional(S.string).with(S.to, S.nullable(S.string)); // ✅ undefined <-> null
+S.optional(S.literal("x")).with(S.to, S.nullable(S.literal("x"))); // ✅ "x" matches by type, undefined <-> null
+S.optional(S.string).with(S.to, S.union([S.string, null, undefined])); // ✅ undefined -> undefined (same type wins); reverse maps null -> undefined
+```
+
+**Worked example** — `S.union([S.bigint, S.number, null]).with(S.to, S.union([S.bigint, S.number, undefined]))`:
+
+Forward:
+
+- `123n` → `123n` (bigint passes through)
+- `123.12` → `123.12` (number passes through)
+- `null` → `undefined` (nullish bridge)
+
+Reverse (via `S.encoder`):
+
+- `undefined` → `null` (nullish bridge)
+- `123n` → `123n`, `123.12` → `123.12` (pass through)
+
+Union conversion always performs exhaustive validation — every variant is
+checked, so transformed unions stay consistent across decode and encode.
+
+## Spec coverage
+
+Behavior change expected, today's goldens are wrong:
+
+| Spec                                | Rule | Expected                                                          |
+| ----------------------------------- | ---- | ----------------------------------------------------------------- |
+| `codec-json-union2`                 | 2    | non-bigint string falls back to the `S.string` variant            |
+| `codec-number-union2-int32`         | 2    | compiles instead of crashing; int32 first, string next            |
+| `codec-string-optional-partial`     | 2    | rejected — partial type match                                     |
+| `codec-string-union2-partial`       | 2    | rejected — partial type match                                     |
+| `codec-unknown-union2`              | 2    | per-variant decoding, same path as `codec-json-union2`            |
+| `codec-union2-string-partial`       | 3    | rejected — partial type match                                     |
+| `codec-optional-nullable-partial`   | 4    | rejected — `string` has no same-type target variant               |
+| `codec-union2-union3-extra-target`  | 4    | rejected — `boolean` has no source variant                        |
+| `codec-union3-union2-extra-source`  | 4    | rejected — `boolean` has no target variant                        |
+| `codec-union3-union2-json`          | 4    | rejected — `json` is not the exact `string`/`number` type          |
+
+Already spec-conformant (their remaining `FIXME`s are codegen bugs, not rule
+changes): `codec-bool-number-unsupported`, `codec-json-union3-grouped`,
+`codec-null-undefined`, `codec-optional-literal-nullable-literal`,
+`codec-optional-nullable-transformed`, `codec-optional-nullable`,
+`codec-optional-nullish`, `codec-string-optional-never`, `codec-string-undefined`,
+`codec-string-union2-never`, `codec-string-union2-transformed`,
+`codec-union-nested-union3-flatten`, `codec-union2-union2-reject`,
+`codec-union2-union2-swap`, `codec-union2-union2-transformed`,
+`codec-union3-union3-bridge`.

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -73,9 +73,8 @@ S.parser(schema)(true); // throws — no implicit double decoding (true -> "true
 `S.json` is not the exact `string` type, so string inputs still go through
 variant decoding instead of passing through.
 
-**Definition order is not tag order.** Same-tag variants are *not* collapsed
-into one group: a differently-tagged variant sitting between them keeps its
-turn, and the first variant that accepts wins.
+**Definition order is not tag order.** The first variant that accepts wins, and
+a differently-tagged variant sitting between two same-tag ones keeps its turn.
 
 ```ts
 const schema = S.json.with(S.to, S.union(["123", S.bigint, S.string]));
@@ -85,7 +84,7 @@ S.parser(schema)("124"); // 124n — the literal fails, the bigint variant decod
 S.parser(schema)("abc"); // "abc" — bigint decoding fails, the catch-all string accepts
 ```
 
-`"123"` and the catch-all `S.string` share the string tag, but grouping them
+`"123"` and the catch-all `S.string` share the string tag, but merging them
 would hide the `S.bigint` between them, and `"124"` would come back a string.
 The same holds with the tags swapped — the `S.number` variant below is reached
 by a string, even though the two literals around it are both strings:
@@ -97,6 +96,13 @@ S.parser(schema)("b"); // "b" — "a" fails, `+"b"` is NaN, "b" matches
 S.parser(schema)("5"); // 5 — neither literal matches, the number variant decodes
 S.parser(schema)("c"); // throws — no variant accepts
 ```
+
+**Grouping is codegen, not semantics.** Emitting same-tag variants under one
+shared type check — `typeof i==="string"&&(i==="a"||i==="b")` — is an
+optimization, allowed exactly while it doesn't change which variant wins. It
+doesn't when nothing else sits between them; it does in both examples above, so
+there each check stays in its own definition slot and the repeated `typeof`
+is reused from a var instead.
 
 `S.unknown` is a normal type here — it only matches another `unknown`. An
 `unknown` source matches none of the concrete variants, so it takes the same

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -12,10 +12,12 @@ demands of it.
 ## Shared definitions
 
 > Two schemas have the **same type** when their type tags match — including the
-> class for instances, the format for formatted primitives, and the reference
-> for recursive schemas, where relevant. `S.int32` and `S.number` are different
-> types, and so are `S.json` and `S.string` — even though every JSON string
-> would validate against `S.string`.
+> class for instances and the format for formatted primitives, where relevant.
+> `S.int32` and `S.number` are different types, and so are `S.json` and
+> `S.string` — even though every JSON string would validate against `S.string`.
+> A schema with no tag of its own to compare — a recursive schema, or a union
+> treated as a normal schema (below) — has the same type as another only when
+> the two are strictly equal, i.e. the same schema reference.
 
 - **Checks run at operation creation time**, against the **derived** types — the
   actual schema at that point in the pipeline, which may be narrower than the
@@ -26,7 +28,8 @@ demands of it.
   `S.union([S.string, S.union([S.number, S.boolean])])` acts as a three-variant
   union. The exception is a union carrying its own format, transformation, or
   refinement — it's treated as a normal (non-union) schema on its side of the
-  conversion.
+  conversion, so it type-matches by strict equality: the same union reference on
+  the other side matches, an identically written one does not.
 - **`S.never` marks an unreachable path.** `S.never` variants — including
   transformed ones like `S.never.with(S.to, S.number)`, which match by their
   `never` input — are ignored by type matching: they never trigger the
@@ -42,19 +45,19 @@ S.schema(null).with(S.to, S.schema(undefined)); // null <-> undefined
 ```
 
 **Literal → literal is one remap, not a table of pairs.** Whatever their tags,
-one literal decodes into another by validating the source const and returning
-the target const — `null <-> undefined` is an instance of it, not a nullish
-special case:
+one primitive literal decodes into another by validating the source const and
+returning the target const — `null <-> undefined` is an instance of it, not a
+nullish special case:
 
 ```ts
 S.schema("a").with(S.to, S.schema(42)); // "a" <-> 42
 S.schema(1).with(S.to, S.schema(true)); // 1 <-> true
 S.schema(1n).with(S.to, S.schema("one")); // 1n <-> "one"
 S.schema(NaN).with(S.to, S.schema(0)); // NaN <-> 0
-S.schema([1, 2]).with(S.to, S.schema("done")); // [1, 2] <-> "done"
 ```
 
-The collection-literal line is the one that doesn't hold today — see
+Collection literals stay out of it — `S.schema([1, 2]).with(S.to,
+S.schema("done"))` keeps today's behavior, snapshot in
 `codec-literal-array-literal-string`.
 
 ## Rule 2: non-union → union
@@ -236,7 +239,7 @@ Behavior change expected, today's goldens are wrong:
 
 | Spec                                 | Rule | Expected                                                             |
 | ------------------------------------ | ---- | -------------------------------------------------------------------- |
-| `codec-literal-array-literal-string` | 1    | collection literals remap like every other literal pair              |
+| `codec-union-nested-refined-union`   | —    | a union with its own refinement isn't flattened, and it still refines |
 | `codec-json-union2`                  | 2    | non-bigint string falls back to the `S.string` variant               |
 | `codec-json-union3-ungrouped`        | 2    | `"123"` matches the literal, `"124"` reaches the `S.bigint` variant  |
 | `codec-number-union2-int32`          | 2    | compiles instead of crashing; int32 first, string next               |
@@ -251,8 +254,8 @@ Behavior change expected, today's goldens are wrong:
 
 Already spec-conformant (their remaining `FIXME`s are codegen bugs, not rule
 changes): `codec-bool-number-unsupported`, `codec-json-union3-grouped`,
-`codec-literal-string-literal-number`, `codec-null-undefined`,
-`codec-optional-literal-nullable-literal`,
+`codec-literal-array-literal-string`, `codec-literal-string-literal-number`,
+`codec-null-undefined`, `codec-optional-literal-nullable-literal`,
 `codec-optional-nullable-transformed`, `codec-optional-nullable`,
 `codec-optional-nullish`, `codec-string-optional-never`, `codec-string-undefined`,
 `codec-string-union2-never`, `codec-string-union2-transformed`,

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -222,6 +222,32 @@ Reverse (via `S.encoder`):
 Union conversion always performs exhaustive validation — every variant is
 checked, so transformed unions stay consistent across decode and encode.
 
+## No built-in decoder for a variant
+
+A pair with no built-in decoder is rejected when the operation is created —
+`Can't decode boolean to number. Use S.to to define a custom decoder`. Being one
+variant of a union changes nothing about that: if any variant's decoder can't be
+built, the whole operation is rejected, under every rule above.
+
+```ts
+S.boolean.with(S.to, S.union([S.string, S.symbol])); // ❌ boolean -> symbol has no decoder
+S.union([S.boolean, S.symbol]).with(S.to, S.string); // ❌ symbol -> string has no decoder
+S.boolean.with(S.to, S.union([S.number, S.symbol])); // ❌ neither variant is decodable
+```
+
+None of the three salvage attempts are available: a variant is never dropped
+from the generated code, never left as a dispatch branch that throws per value,
+and a conversion with no decodable variant at all never compiles into an
+operation that throws for every input. The error belongs to the operation, so it
+is raised once, where the operation is written.
+
+`S.never` remains the way to say a path is deliberately unreachable — it is
+ignored by variant matching, so it never triggers this rejection:
+
+```ts
+S.boolean.with(S.to, S.union([S.string, S.never.with(S.to, S.symbol)])); // ✅ the symbol path is unreachable
+```
+
 ## Spec coverage
 
 Behavior change expected, today's goldens are wrong:
@@ -229,6 +255,9 @@ Behavior change expected, today's goldens are wrong:
 | Spec                                 | Rule | Expected                                                             |
 | ------------------------------------ | ---- | -------------------------------------------------------------------- |
 | `codec-union-nested-refined-union`   | —    | a union with its own refinement isn't flattened, and it still refines |
+| `codec-bool-union2-unsupported`      | —    | rejected — no `boolean -> symbol` decoder; today the variant is dropped |
+| `codec-bool-union2-all-unsupported`  | —    | rejected — today it compiles into an always-throwing operation        |
+| `codec-union2-string-unsupported`    | —    | rejected — no `symbol -> string` decoder; today the branch throws     |
 | `codec-json-union2`                  | 2    | non-bigint string falls back to the `S.string` variant               |
 | `codec-json-union3-ungrouped`        | 2    | `"123"` matches the literal, `"124"` reaches the `S.bigint` variant  |
 | `codec-number-union2-int32`          | 2    | compiles instead of crashing; int32 first, string next               |

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -84,25 +84,29 @@ S.parser(schema)("124"); // 124n — the literal fails, the bigint variant decod
 S.parser(schema)("abc"); // "abc" — bigint decoding fails, the catch-all string accepts
 ```
 
-`"123"` and the catch-all `S.string` share the string tag, but merging them
-would hide the `S.bigint` between them, and `"124"` would come back a string.
-The same holds with the tags swapped — the `S.number` variant below is reached
-by a string, even though the two literals around it are both strings:
+**Built-in decoding fills gaps, it doesn't re-type what the source already
+has.** A variant whose tag the source can produce takes those values as they
+are; the built-in decoder only steps in for a variant whose tag the source has
+no way to produce. `bigint` is not a JSON tag, so a JSON string is offered to
+`BigInt`; `string` and `number` both are, so a JSON boolean never becomes
+`"true"` and a JSON string never becomes a number:
 
 ```ts
 const schema = S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]));
 
-S.parser(schema)("b"); // "b" — "a" fails, `+"b"` is NaN, "b" matches
-S.parser(schema)("5"); // 5 — neither literal matches, the number variant decodes
+S.parser(schema)("b"); // "b" — "a" fails, "b" matches
+S.parser(schema)("5"); // throws — S.number takes JSON numbers as they are, it doesn't decode "5"
 S.parser(schema)("c"); // throws — no variant accepts
 ```
 
 **Grouping is codegen, not semantics.** Emitting same-tag variants under one
 shared type check — `typeof i==="string"&&(i==="a"||i==="b")` — is an
-optimization, allowed exactly while it doesn't change which variant wins. It
-doesn't when nothing else sits between them; it does in both examples above, so
-there each check stays in its own definition slot and the repeated `typeof`
-is reused from a var instead.
+optimization, allowed exactly while it can't change which variant wins. Hoisting
+`"a"` and `"b"` past `S.number` above is legal: neither literal can take a value
+`S.number` would have taken. Hoisting `"123"` and the catch-all `S.string` past
+`S.bigint` is not: the catch-all takes every string, `"124"` among them. Where
+the shortcut isn't available, each check stays in its own definition slot and
+the repeated `typeof` is reused from a var.
 
 `S.unknown` is a normal type here — it only matches another `unknown`. An
 `unknown` source matches none of the concrete variants, so it takes the same
@@ -234,7 +238,6 @@ Behavior change expected, today's goldens are wrong:
 | ------------------------------------ | ---- | -------------------------------------------------------------------- |
 | `codec-literal-array-literal-string` | 1    | collection literals remap like every other literal pair              |
 | `codec-json-union2`                  | 2    | non-bigint string falls back to the `S.string` variant               |
-| `codec-json-union3-grouped`          | 2    | the `S.number` variant between the two literals is still attempted   |
 | `codec-json-union3-ungrouped`        | 2    | `"123"` matches the literal, `"124"` reaches the `S.bigint` variant  |
 | `codec-number-union2-int32`          | 2    | compiles instead of crashing; int32 first, string next               |
 | `codec-string-optional-partial`      | 2    | rejected — partial type match                                        |
@@ -247,8 +250,9 @@ Behavior change expected, today's goldens are wrong:
 | `codec-union3-union2-json`           | 4    | rejected — `json` is not the exact `string`/`number` type             |
 
 Already spec-conformant (their remaining `FIXME`s are codegen bugs, not rule
-changes): `codec-bool-number-unsupported`, `codec-literal-string-literal-number`,
-`codec-null-undefined`, `codec-optional-literal-nullable-literal`,
+changes): `codec-bool-number-unsupported`, `codec-json-union3-grouped`,
+`codec-literal-string-literal-number`, `codec-null-undefined`,
+`codec-optional-literal-nullable-literal`,
 `codec-optional-nullable-transformed`, `codec-optional-nullable`,
 `codec-optional-nullish`, `codec-string-optional-never`, `codec-string-undefined`,
 `codec-string-union2-never`, `codec-string-union2-transformed`,

--- a/CODEC_NEXT_SPEC.md
+++ b/CODEC_NEXT_SPEC.md
@@ -44,21 +44,10 @@ S.string.with(S.to, S.schema(undefined)); // "undefined" <-> undefined
 S.schema(null).with(S.to, S.schema(undefined)); // null <-> undefined
 ```
 
-**Literal → literal is one remap, not a table of pairs.** Whatever their tags,
-one primitive literal decodes into another by validating the source const and
-returning the target const — `null <-> undefined` is an instance of it, not a
-nullish special case:
-
-```ts
-S.schema("a").with(S.to, S.schema(42)); // "a" <-> 42
-S.schema(1).with(S.to, S.schema(true)); // 1 <-> true
-S.schema(1n).with(S.to, S.schema("one")); // 1n <-> "one"
-S.schema(NaN).with(S.to, S.schema(0)); // NaN <-> 0
-```
-
-Collection literals stay out of it — `S.schema([1, 2]).with(S.to,
-S.schema("done"))` keeps today's behavior, snapshot in
-`codec-literal-array-literal-string`.
+Which pairs have a built-in decoder is out of scope here — literal-to-literal
+conversion in particular keeps whatever it does today
+(`codec-literal-string-literal-number`, `codec-literal-array-literal-string`).
+These rules only decide which schemas that decoder is asked about.
 
 ## Rule 2: non-union → union
 
@@ -254,7 +243,6 @@ Behavior change expected, today's goldens are wrong:
 
 Already spec-conformant (their remaining `FIXME`s are codegen bugs, not rule
 changes): `codec-bool-number-unsupported`, `codec-json-union3-grouped`,
-`codec-literal-array-literal-string`, `codec-literal-string-literal-number`,
 `codec-null-undefined`, `codec-optional-literal-nullable-literal`,
 `codec-optional-nullable-transformed`, `codec-optional-nullable`,
 `codec-optional-nullish`, `codec-string-optional-never`, `codec-string-undefined`,

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -872,153 +872,44 @@ type Schema = S.Infer<typeof schema>; // "Win" | "Draw" | "Loss"
 
 ### Decoding into / out of a union
 
-When a conversion (via `S.to`, or implicitly by reversing the schema) has a union on either side, Sury follows four rules. They all build on a few shared definitions:
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant.
 
-> Two schemas have the **same type** when their type tags match — including the class for instances, the format for formatted primitives, and the reference for recursive schemas, where relevant. `S.int32` and `S.number` are different types, and so are `S.json` and `S.string` — even though every JSON string would validate against `S.string`.
+If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 
-- **Checks run at operation creation time**, against the **derived** types — the actual schema at that point in the pipeline, which may be narrower than the originally defined one (an upstream transformation can refine it). Reversing a schema doesn't re-run the checks: it reverses the already-resolved per-variant pipelines.
-- **Nested unions are flattened** before the rules apply: `S.union([S.string, S.union([S.number, S.boolean])])` acts as a three-variant union. The exception is a union carrying its own format, transformation, or refinement — it's treated as a normal (non-union) schema on its side of the conversion.
-- **`S.never` marks an unreachable path.** `S.never` variants — including transformed ones like `S.never.with(S.to, S.number)`, which match by their `never` input — are ignored by type matching: they never trigger the exceptions below and don't count toward rule 4's coverage.
+1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then any remaining catch-all same-tag variants. Variants with a different tag are never tried from here — if every branch in the group fails, the match errors.
+2. **Nullish bridge.** Used only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
+3. **Fallback.** Used only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `number`/`bigint` → `string` via `"" + i`, `string` → `number` via `+i`, `string` → `bigint` via `BigInt(i)`, stringified-const matches like `"null" → null`, and more.
 
-#### Rule 1: non-union → non-union
-
-Built-in decoding (coercion) always applies:
-
-```ts
-S.string.with(S.to, S.schema(undefined)); // "undefined" <-> undefined
-S.schema(null).with(S.to, S.schema(undefined)); // null <-> undefined
-```
-
-#### Rule 2: non-union → union
-
-The built-in decoder is applied separately for every target variant, attempted in definition order, grouped by tag:
-
-```ts
-const schema = S.json.with(S.to, S.union([S.bigint, S.string]));
-
-S.parser(schema)("123"); // 123n — the bigint variant comes first
-S.parser(schema)("abc"); // "abc" — bigint decoding fails, string accepts
-S.parser(schema)(true); // throws — no implicit double decoding (true -> "true" -> ...)
-```
-
-`S.json` is not the exact `string` type, so string inputs still go through variant decoding instead of passing through.
-
-**Grouped by tag** means same-tag variants form a single group at the position of the first one. The runtime value's tag picks the group; only that group's variants are attempted, in definition order:
-
-```ts
-const schema = S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]));
-
-S.parser(schema)("b"); // "b" — tries "a", then "b"; the number variant is never attempted
-```
-
-`S.unknown` is a normal type here — it only matches another `unknown`. An `unknown` source matches none of the concrete variants, so it takes the same path: every variant is attempted, grouped by tag, in definition order.
-
-**Exception — partial type match.** If the source has the same type as *some but not all* target variants, the operation is rejected when it's created. Sury can't tell whether you want a pass-through for the matching variant, decoding attempts in definition order, or simply widened the type with no decoding intent:
-
-```ts
-S.string.with(S.to, S.union([S.number, S.string]));
-// Invalid operation: for "123" — keep "123" or decode to 123?
-```
-
-Say what you mean with an explicit variant:
-
-```ts
-// Try decoding to number first, keep the string otherwise:
-S.string.with(S.to, S.union([S.string.with(S.to, S.number), S.string]));
-
-// Pass strings through, never producing a number:
-S.string.with(S.to, S.union([S.never.with(S.to, S.number), S.string]));
-```
-
-The same applies to widening into optional or nullable targets:
-
-```ts
-S.string.with(S.to, S.optional(S.string));
-// Invalid operation: for "undefined" — keep the string or decode to undefined?
-
-// Widen without decoding — the undefined variant is unreachable:
-S.string.with(S.to, S.union([S.string, S.never.with(S.to, S.schema(undefined))]));
-```
-
-The `Invalid operation` error suggests these rewrites.
-
-#### Rule 3: union → non-union
-
-The mirror of rule 2: every source variant gets its own built-in decoder to the target, dispatched in definition order, grouped by tag:
-
-```ts
-const schema = S.union([S.bigint, S.string]).with(S.to, S.json);
-
-S.parser(schema)(123n); // "123"
-S.parser(schema)("123"); // "123"
-S.parser(schema)("abc"); // "abc"
-```
-
-**Exception — partial type match.** If the target has the same type as some but not all source variants, the operation is rejected. Sury can't tell whether the non-matching variants should decode to the target or be rejected as failed cases:
-
-```ts
-S.union([S.number, S.string]).with(S.to, S.string);
-// Invalid operation: for 123 — decode to "123" or fail as a non-matching case?
-```
-
-Say what you mean with an explicit target union:
-
-```ts
-// Decode numbers to strings:
-S.union([S.number, S.string]).with(
-  S.to,
-  S.union([S.number.with(S.to, S.string), S.string])
-);
-
-// Reject numbers:
-S.union([S.number, S.string]).with(
-  S.to,
-  S.union([S.number.with(S.to, S.never), S.string])
-);
-```
-
-The `Invalid operation` error suggests these rewrites.
-
-#### Rule 4: union → union
-
-No coercion — values pass through to the same-type target variant. The two unions must cover each other: every source variant needs at least one same-type target variant, and every target variant needs at least one same-type source variant. Otherwise the operation is rejected:
-
-```ts
-S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string])); // ✅
-S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string, S.boolean])); // ❌ boolean has no source variant
-S.union([S.string, S.number, S.boolean]).with(S.to, S.union([S.number, S.string])); // ❌ boolean has no target variant
-S.union([S.string, S.number, S.bigint]).with(S.to, S.union([S.json, S.bigint])); // ❌ json is not the exact string/number type
-```
-
-A transformed source variant matches by its output type, and a transformed target variant by its input type — so per-variant conversion is always available explicitly:
-
-```ts
-S.optional(S.string).with(S.to, S.nullable(S.boolean)); // ❌ string doesn't match boolean
-S.optional(S.string).with(S.to, S.nullable(S.string.with(S.to, S.boolean))); // ✅
-```
-
-**Exception — nullish bridge.** A `null` or `undefined` variant left unmatched by type may match the opposite nullish variant on the other side — even one that already has a same-type match. At runtime the same-type target wins; the bridge only kicks in when there is none:
-
-```ts
-S.optional(S.string).with(S.to, S.nullable(S.string)); // ✅ undefined <-> null
-S.optional(S.literal("x")).with(S.to, S.nullable(S.literal("x"))); // ✅ "x" matches by type, undefined <-> null
-S.optional(S.string).with(S.to, S.union([S.string, null, undefined])); // ✅ undefined -> undefined (same type wins); reverse maps null -> undefined
-```
-
-**Worked example** — `S.union([S.bigint, S.number, null]).with(S.to, S.union([S.bigint, S.number, undefined]))`:
+**Worked example** — `S.union([S.bigint, S.number, null]).with(S.to, S.union([S.string, undefined]))`:
 
 Forward:
 
-- `123n` → `123n` (bigint passes through)
-- `123.12` → `123.12` (number passes through)
-- `null` → `undefined` (nullish bridge)
+- `123n` → `"123"` (tier 3: bigint → string)
+- `123.12` → `"123.12"` (tier 3: number → string)
+- `null` → `undefined` (tier 2: nullish bridge)
 
 Reverse (via `S.encoder`):
 
-- `undefined` → `null` (nullish bridge)
-- `123n` → `123n`, `123.12` → `123.12` (pass through)
+- `"null"` → `null` (tier 3: stringified-const literal match)
+- `undefined` → `null` (tier 2: nullish bridge)
+- `"123"` → `123n` (tier 3: bigint attempted first by target order; parse succeeds)
+- `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to number)
+- `"abc"` → error (tier 3: no variant's decoder succeeds)
 
-> 🧠 Union conversion always performs exhaustive validation — every variant is checked, so transformed unions stay consistent across decode and encode.
+**Identity wins over coercion.** For `S.union([S.string, S.bigint]).with(S.to, S.union([S.number, S.string]))`:
+
+- `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `number` even though a `number` target exists)
+- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" + i`)
+
+To opt into `string → number` when a `string` target also exists, write the transform into a variant explicitly:
+
+```ts
+S.union([S.string.with(S.to, S.number), S.string]);
+```
+
+The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+
+> 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 
 ## Records
 

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -923,147 +923,44 @@ let schema = S.enum([Win, Draw, Loss])
 
 #### Decoding into / out of a union
 
-When a conversion (via `S.to`, or implicitly by reversing the schema) has a union on either side, Sury follows four rules. They all build on a few shared definitions:
+When you compile `source -> targetUnion` (via `S.to`, or implicitly by reversing the schema), Sury picks the target variant using a three-tier algorithm based on the source's **derived tag** — the tag known at compile time, which may be narrower than the original type (an upstream transformation can refine it). If the source is itself a union, the algorithm runs independently for each source variant.
 
-> Two schemas have the **same type** when their type tags match — including the class for instances, the format for formatted primitives, and the reference for recursive schemas, where relevant. `S.int` (an `Int32`-formatted number) and `S.float` are different types, and so are `S.json` and `S.string` — even though every JSON string would validate against `S.string`.
+If the source is `unknown` (no derived tag), the tag-based tiers are skipped and target variants are simply attempted in target-union order at runtime.
 
-- **Checks run at operation creation time**, against the **derived** types — the actual schema at that point in the pipeline, which may be narrower than the originally defined one (an upstream transformation can refine it). Reversing a schema doesn't re-run the checks: it reverses the already-resolved per-variant pipelines.
-- **Nested unions are flattened** before the rules apply: `S.union([S.string, S.union([S.float, S.bool])])` acts as a three-variant union. The exception is a union carrying its own format, transformation, or refinement — it's treated as a normal (non-union) schema on its side of the conversion.
-- **`S.never` marks an unreachable path.** `S.never` variants — including transformed ones like `S.never->S.to(S.float)`, which match by their `never` input — are ignored by type matching: they never trigger the exceptions below and don't count toward rule 4's coverage.
+1. **Same-tag group.** Collect target variants sharing the source's tag. If non-empty, match only within this group: variants with a matching `const`/`format` (string literals, `Int32`, etc.) are tried first in target-union order, then any remaining catch-all same-tag variants. Variants with a different tag are never tried from here — if every branch in the group fails, the match errors.
+2. **Nullish bridge.** Used only when tier 1 is empty. If the source tag is `null` or `undefined`, use the opposite nullish target variant (if present), exclusively.
+3. **Fallback.** Used only when tiers 1 and 2 are both empty. Build a decoder for every target variant in target-union order. Cross-type coercions live here: `int`/`bigint` → `string` via `"" ++ i`, `string` → `float` via `Float.fromString`, `string` → `bigint` via `BigInt.fromString`, stringified-const matches like `"null" → null`, and more.
 
-##### Rule 1: non-union → non-union
-
-Built-in decoding (coercion) always applies:
-
-```rescript
-S.string->S.to(S.unit) // "undefined" <-> undefined
-S.literal(Null.null)->S.to(S.unit) // null <-> undefined
-```
-
-##### Rule 2: non-union → union
-
-The built-in decoder is applied separately for every target variant, attempted in definition order, grouped by tag:
-
-```rescript
-let schema = S.json->S.to(S.union([S.bigint, S.string]))
-
-"123"->S.parseOrThrow(~to=schema) // 123n — the bigint variant comes first
-"abc"->S.parseOrThrow(~to=schema) // "abc" — bigint decoding fails, string accepts
-true->S.parseOrThrow(~to=schema) // throws — no implicit double decoding (true -> "true" -> ...)
-```
-
-`S.json` is not the exact `string` type, so string inputs still go through variant decoding instead of passing through.
-
-**Grouped by tag** means same-tag variants form a single group at the position of the first one. The runtime value's tag picks the group; only that group's variants are attempted, in definition order:
-
-```rescript
-let schema = S.json->S.to(S.union([S.literal("a"), S.float, S.literal("b")]))
-
-"b"->S.parseOrThrow(~to=schema) // "b" — tries "a", then "b"; the float variant is never attempted
-```
-
-`S.unknown` is a normal type here — it only matches another `unknown`. An `unknown` source matches none of the concrete variants, so it takes the same path: every variant is attempted, grouped by tag, in definition order.
-
-**Exception — partial type match.** If the source has the same type as *some but not all* target variants, the operation is rejected when it's created. Sury can't tell whether you want a pass-through for the matching variant, decoding attempts in definition order, or simply widened the type with no decoding intent:
-
-```rescript
-S.string->S.to(S.union([S.float, S.string]))
-// Invalid operation: for "123" — keep "123" or decode to 123.?
-```
-
-Say what you mean with an explicit variant:
-
-```rescript
-// Try decoding to float first, keep the string otherwise:
-S.string->S.to(S.union([S.string->S.to(S.float), S.string]))
-
-// Pass strings through, never producing a float:
-S.string->S.to(S.union([S.never->S.to(S.float), S.string]))
-```
-
-The same applies to widening into optional targets:
-
-```rescript
-S.string->S.to(S.option(S.string))
-// Invalid operation: for "undefined" — keep the string or decode to undefined?
-
-// Widen without decoding — the undefined variant is unreachable:
-S.string->S.to(S.union([S.string, S.never->S.to(S.unit)]))
-```
-
-The `Invalid operation` error suggests these rewrites.
-
-##### Rule 3: union → non-union
-
-The mirror of rule 2: every source variant gets its own built-in decoder to the target, dispatched in definition order, grouped by tag:
-
-```rescript
-let schema = S.union([S.bigint, S.string])->S.to(S.json)
-
-123n->S.parseOrThrow(~to=schema) // "123"
-"123"->S.parseOrThrow(~to=schema) // "123"
-"abc"->S.parseOrThrow(~to=schema) // "abc"
-```
-
-**Exception — partial type match.** If the target has the same type as some but not all source variants, the operation is rejected. Sury can't tell whether the non-matching variants should decode to the target or be rejected as failed cases:
-
-```rescript
-S.union([S.float, S.string])->S.to(S.string)
-// Invalid operation: for 123. — decode to "123" or fail as a non-matching case?
-```
-
-Say what you mean with an explicit target union:
-
-```rescript
-// Decode floats to strings:
-S.union([S.float, S.string])->S.to(S.union([S.float->S.to(S.string), S.string]))
-
-// Reject floats:
-S.union([S.float, S.string])->S.to(S.union([S.float->S.to(S.never), S.string]))
-```
-
-The `Invalid operation` error suggests these rewrites.
-
-##### Rule 4: union → union
-
-No coercion — values pass through to the same-type target variant. The two unions must cover each other: every source variant needs at least one same-type target variant, and every target variant needs at least one same-type source variant. Otherwise the operation is rejected:
-
-```rescript
-S.union([S.string, S.float])->S.to(S.union([S.float, S.string])) // ✅
-S.union([S.string, S.float])->S.to(S.union([S.float, S.string, S.bool])) // ❌ bool has no source variant
-S.union([S.string, S.float, S.bool])->S.to(S.union([S.float, S.string])) // ❌ bool has no target variant
-S.union([S.string, S.float, S.bigint])->S.to(S.union([S.json, S.bigint])) // ❌ json is not the exact string/float type
-```
-
-A transformed source variant matches by its output type, and a transformed target variant by its input type — so per-variant conversion is always available explicitly:
-
-```rescript
-S.option(S.string)->S.to(S.null(S.bool)) // ❌ string doesn't match bool
-S.option(S.string)->S.to(S.null(S.string->S.to(S.bool))) // ✅
-```
-
-**Exception — nullish bridge.** A `null` or `undefined` variant left unmatched by type may match the opposite nullish variant on the other side — even one that already has a same-type match. At runtime the same-type target wins; the bridge only kicks in when there is none:
-
-```rescript
-S.option(S.string)->S.to(S.null(S.string)) // ✅ undefined <-> null
-S.option(S.literal("x"))->S.to(S.null(S.literal("x"))) // ✅ "x" matches by type, undefined <-> null
-S.option(S.string)->S.to(S.nullable(S.string)) // ✅ undefined -> undefined (same type wins); reverse maps null -> undefined
-```
-
-**Worked example** — `S.union([S.bigint, S.float, S.literal(Null.null)])->S.to(S.union([S.bigint, S.float, S.unit]))`:
+**Worked example** — `S.union([S.bigint, S.float, S.nullLiteral])->S.to(S.union([S.string, S.unit]))`:
 
 Forward:
 
-- `123n` → `123n` (bigint passes through)
-- `123.12` → `123.12` (float passes through)
-- `null` → `undefined` (nullish bridge)
+- `123n` → `"123"` (tier 3: bigint → string)
+- `123.12` → `"123.12"` (tier 3: float → string)
+- `null` → `undefined` (tier 2: nullish bridge)
 
 Reverse (via `S.decodeOrThrow(~from=schema, ~to=S.unknown)`):
 
-- `undefined` → `null` (nullish bridge)
-- `123n` → `123n`, `123.12` → `123.12` (pass through)
+- `"null"` → `null` (tier 3: stringified-const literal match)
+- `undefined` → `null` (tier 2: nullish bridge)
+- `"123"` → `123n` (tier 3: bigint attempted first by target order; parse succeeds)
+- `"123.12"` → `123.12` (tier 3: bigint parse throws, falls through to float)
+- `"abc"` → error (tier 3: no variant's decoder succeeds)
 
-> 🧠 Union conversion always performs exhaustive validation — every variant is checked, so transformed unions stay consistent across decode and encode.
+**Identity wins over coercion.** For `S.union([S.string, S.bigint])->S.to(S.union([S.float, S.string]))`:
+
+- `"123"` → `"123"` (tier 1: `string` matches `string`, never coerced to `float` even though a `float` target exists)
+- `123n` → `"123"` (tier 3: no `bigint` target, falls through to `string` via `"" ++ i`)
+
+To opt into `string → float` when a `string` target also exists, write the transform into a variant explicitly:
+
+```rescript
+S.union([S.string->S.to(S.float), S.string])
+```
+
+The transformed variant is const/format-refined relative to the catch-all `string` and matches first within tier 1.
+
+> 🧠 Union conversion always performs exhaustive validation now — every variant is checked, so transformed unions stay consistent across decode and encode.
 
 ### **`array`**
 
@@ -1820,7 +1717,7 @@ If you want to handle the error, the best way to use `try/catch` block:
 
 ```rescript
 try true->S.parseOrThrow(~to=schema) catch {
-| S.Error(error) => Console.log(error.message)
+| S.Exn(error) => Console.log(error.message)
 }
 ```
 

--- a/packages/sury/specs/codec-bool-number-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-number-unsupported.yaml
@@ -1,7 +1,9 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: stay the same — rule 1 has no built-in boolean → number
-  # decoding.
+  # FIXME: Codec next expects: stay the same — the reference case for a pair with no
+  # built-in decoder, and the shape the codec-*-unsupported specs have to match:
+  # wrapping either side in a union must not turn this creation error into a dropped
+  # member, a throwing branch, or an always-throwing operation.
   schema: S.boolean.with(S.to, S.number)
   input: boolean
   output: number

--- a/packages/sury/specs/codec-bool-number-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-number-unsupported.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 1 has no built-in boolean → number
+  # decoding.
   schema: S.boolean.with(S.to, S.number)
   input: boolean
   output: number

--- a/packages/sury/specs/codec-bool-union2-all-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-union2-all-unsupported.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: rejected at creation — neither member has a built-in
+  # decoder from boolean, so nothing about this conversion can work. Today it compiles
+  # into a parser that type-checks its input and then throws for every value, carrying
+  # both creation-time messages as nested causes.
+  schema: S.boolean.with(S.to, S.union([S.number, S.symbol]))
+  input: boolean
+  output: number | symbol
+  instantiations: 6080
+  bundleBytes: 9962
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  # FIXME: reported as never on both sides — the schema's own types are boolean and
+  # number | symbol.
+  input: "{ not: {} }"
+  output: "{ not: {} }"
+operations:
+  parse:
+    expression: i=>{typeof i==="boolean"||e[3](i);e[2](i,e[0],e[1]);return i}
+    examples:
+      boolean-always-fails:
+        input: "true"
+        error: |-
+          Expected number | symbol, received true
+          - Can't decode boolean to number. Use S.to to define a custom decoder
+          - Can't decode boolean to symbol. Use S.to to define a custom decoder
+      invalid:
+        input: '"abc"'
+        error: Expected boolean, received "abc"
+  decode:
+    expression: i=>{e[2](i,e[0],e[1]);return i}
+    examples:
+      boolean-always-fails:
+        input: "true"
+        error: |-
+          Expected number | symbol, received true
+          - Can't decode boolean to number. Use S.to to define a custom decoder
+          - Can't decode boolean to symbol. Use S.to to define a custom decoder
+  encode:
+    expression: i=>{if(typeof i==="number"&&!Number.isNaN(i)){e[1](i,e[0])}else if(typeof i==="symbol"){e[3](i,e[2])}else{e[4](i)}return i}
+    examples:
+      number-member:
+        input: "5"
+        error: |-
+          Expected number | symbol, received 5
+          - Can't decode number to boolean. Use S.to to define a custom decoder
+      symbol-member:
+        input: Symbol("s")
+        error: |-
+          Expected number | symbol, received Symbol(s)
+          - Can't decode symbol to boolean. Use S.to to define a custom decoder
+      invalid:
+        input: '"abc"'
+        error: Expected number | symbol, received "abc"

--- a/packages/sury/specs/codec-bool-union2-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-union2-unsupported.yaml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: rejected at creation — S.symbol has no built-in decoder
+  # from boolean, and a member the decoder can't be built for is an error when the
+  # operation is created, not a branch to drop. Today it is dropped from parse and
+  # from the output JSON Schema, so the conversion behaves as if S.symbol weren't in
+  # the union at all.
+  schema: S.boolean.with(S.to, S.union([S.string, S.symbol]))
+  input: boolean
+  output: string | symbol
+  instantiations: 6080
+  bundleBytes: 9882
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "boolean" }'
+  # FIXME: the dropped member is missing here too — the output type is string | symbol.
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="boolean"||e[2](i);try{i=""+i}catch(e0){e[1](i,e0,e[0])}return i}
+    examples:
+      "true":
+        input: "true"
+        output: '"true"'
+      "false":
+        input: "false"
+        output: '"false"'
+      invalid:
+        input: '"abc"'
+        error: Expected boolean, received "abc"
+  decode:
+    expression: i=>{try{i=""+i}catch(e0){e[1](i,e0,e[0])}return i}
+    examples:
+      "true":
+        input: "true"
+        output: '"true"'
+  encode:
+    expression: i=>{if(typeof i==="string"){let v0;(v0=i==="true")||i==="false"||e[0](i);i=v0}else if(typeof i==="symbol"){e[2](i,e[1])}else{e[3](i)}return i}
+    examples:
+      true-string:
+        input: '"true"'
+        output: "true"
+      false-string:
+        input: '"false"'
+        output: "false"
+      other-string:
+        input: '"abc"'
+        error: Expected boolean, received "abc"
+      symbol-member:
+        input: Symbol("s")
+        error: |-
+          Expected string | symbol, received Symbol(s)
+          - Can't decode symbol to boolean. Use S.to to define a custom decoder

--- a/packages/sury/specs/codec-json-union2.yaml
+++ b/packages/sury/specs/codec-json-union2.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rule 2 attempts every target variant, so a string that
+  # isn't a bigint falls back to the S.string member ("abc" → "abc") instead of
+  # erroring; true stays rejected (no double decoding).
   schema: S.json.with(S.to, S.union([S.bigint, S.string]))
   input: JSON
   output: string | bigint

--- a/packages/sury/specs/codec-json-union3-grouped.yaml
+++ b/packages/sury/specs/codec-json-union3-grouped.yaml
@@ -1,10 +1,12 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: rule 2 attempts every variant in definition order, so
-  # the number variant between the two string literals keeps its turn: "a" and "b"
-  # still match their literals, but a numeric string decodes through S.number instead
-  # of being skipped because the two literals share the string tag. The mirror of
-  # codec-json-union3-ungrouped, where the bigint variant sits between the members.
+  # FIXME: Codec next expects: rule 2 attempts every member in definition order, so the
+  # S.number between the two string literals keeps its turn and a numeric string
+  # decodes through it. Sharing one `typeof i==="string"` between "a" and "b" is an
+  # internal optimization, legal only while it doesn't change which member wins —
+  # here it hides S.number, so the two literal checks belong in their definition slots
+  # with the typeof reused from a var. The mirror of codec-json-union3-ungrouped,
+  # where S.bigint sits between the members.
   schema: S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]))
   input: JSON
   output: number | "a" | "b"
@@ -23,19 +25,19 @@ operations:
       first-literal:
         input: '"a"'
         output: '"a"'
-      second-literal-groups-before-number:
+      second-literal-behind-number:
         input: '"b"'
         output: '"b"'
       number:
         input: "5"
         output: "5"
-      # FIXME: the number variant is skipped for string input because the two literals
-      # group ahead of it — "5" should decode to 5 the way "124" should reach the
-      # bigint variant in codec-json-union3-ungrouped.
+      # FIXME: hoisting both literals under one typeof moved S.number behind them, so a
+      # numeric string never reaches it — "5" should decode to 5 the way "124" should
+      # reach S.bigint in codec-json-union3-ungrouped.
       numeric-string-skips-number:
         input: '"5"'
         error: Expected "a" | number | "b", received "5"
-      unmatched-string-skips-number:
+      unmatched-string:
         input: '"c"'
         error: Expected "a" | number | "b", received "c"
       no-double-decoding:

--- a/packages/sury/specs/codec-json-union3-grouped.yaml
+++ b/packages/sury/specs/codec-json-union3-grouped.yaml
@@ -1,12 +1,10 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: rule 2 attempts every member in definition order, so the
-  # S.number between the two string literals keeps its turn and a numeric string
-  # decodes through it. Sharing one `typeof i==="string"` between "a" and "b" is an
-  # internal optimization, legal only while it doesn't change which member wins —
-  # here it hides S.number, so the two literal checks belong in their definition slots
-  # with the typeof reused from a var. The mirror of codec-json-union3-ungrouped,
-  # where S.bigint sits between the members.
+  # FIXME: Codec next expects: stay the same — sharing one `typeof i==="string"`
+  # between "a" and "b" is an internal optimization, and a legal one here: hoisting
+  # them past S.number can't change which member wins, since neither literal can take
+  # a value S.number would take. codec-json-union3-ungrouped is where the same
+  # optimization is illegal — its catch-all S.string would swallow S.bigint's values.
   schema: S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]))
   input: JSON
   output: number | "a" | "b"
@@ -31,10 +29,7 @@ operations:
       number:
         input: "5"
         output: "5"
-      # FIXME: hoisting both literals under one typeof moved S.number behind them, so a
-      # numeric string never reaches it — "5" should decode to 5 the way "124" should
-      # reach S.bigint in codec-json-union3-ungrouped.
-      numeric-string-skips-number:
+      numeric-string-not-coerced:
         input: '"5"'
         error: Expected "a" | number | "b", received "5"
       unmatched-string:

--- a/packages/sury/specs/codec-json-union3-grouped.yaml
+++ b/packages/sury/specs/codec-json-union3-grouped.yaml
@@ -1,7 +1,10 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: stay the same — rule 2 groups same-tag variants, so "b"
-  # matches within the string group and the number variant is never attempted.
+  # FIXME: Codec next expects: rule 2 attempts every variant in definition order, so
+  # the number variant between the two string literals keeps its turn: "a" and "b"
+  # still match their literals, but a numeric string decodes through S.number instead
+  # of being skipped because the two literals share the string tag. The mirror of
+  # codec-json-union3-ungrouped, where the bigint variant sits between the members.
   schema: S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]))
   input: JSON
   output: number | "a" | "b"
@@ -26,6 +29,12 @@ operations:
       number:
         input: "5"
         output: "5"
+      # FIXME: the number variant is skipped for string input because the two literals
+      # group ahead of it — "5" should decode to 5 the way "124" should reach the
+      # bigint variant in codec-json-union3-ungrouped.
+      numeric-string-skips-number:
+        input: '"5"'
+        error: Expected "a" | number | "b", received "5"
       unmatched-string-skips-number:
         input: '"c"'
         error: Expected "a" | number | "b", received "c"

--- a/packages/sury/specs/codec-json-union3-grouped.yaml
+++ b/packages/sury/specs/codec-json-union3-grouped.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 2 groups same-tag variants, so "b"
+  # matches within the string group and the number variant is never attempted.
   schema: S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]))
   input: JSON
   output: number | "a" | "b"

--- a/packages/sury/specs/codec-json-union3-ungrouped.yaml
+++ b/packages/sury/specs/codec-json-union3-ungrouped.yaml
@@ -1,9 +1,10 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: rule 2 attempts every variant in definition order — the
-  # "123" literal and the catch-all S.string are not grouped across the bigint between
-  # them, so "123" matches the literal and stays a string, "124" decodes to 124n
-  # through the bigint variant, and "abc" falls back to S.string.
+  # FIXME: Codec next expects: rule 2 attempts every member in definition order, so
+  # "123" matches the literal and stays a string, "124" decodes to 124n through
+  # S.bigint, and "abc" falls back to S.string. Sharing one `typeof i==="string"`
+  # between the literal and the catch-all is an internal optimization, and not one
+  # available here — it would move S.bigint behind both and swallow "124".
   schema: S.json.with(S.to, S.union(["123", S.bigint, S.string]))
   input: JSON
   output: string | bigint

--- a/packages/sury/specs/codec-json-union3-ungrouped.yaml
+++ b/packages/sury/specs/codec-json-union3-ungrouped.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: rule 2 attempts every variant in definition order — the
+  # "123" literal and the catch-all S.string are not grouped across the bigint between
+  # them, so "123" matches the literal and stays a string, "124" decodes to 124n
+  # through the bigint variant, and "abc" falls back to S.string.
+  schema: S.json.with(S.to, S.union(["123", S.bigint, S.string]))
+  input: JSON
+  output: string | bigint
+  instantiations: 6197
+  bundleBytes: 11062
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ anyOf: [{ type: "string", const: "123" }, { type: "string" }] }'
+  output: Expected JSON, received "123" | bigint | string
+operations:
+  parse:
+    # FIXME: the "123" member is absent from the generated code — every string goes to
+    # BigInt, so the literal that should match first can never win. `else
+    # if(!(typeof i==="string"))` also re-tests the condition it's already the else of.
+    expression: i=>{if(typeof i==="string"){let v0;try{v0=BigInt(i)}catch(_){e[0](i)}i=v0}else if(!(typeof i==="string")){e[1](i)}return i}
+    examples:
+      literal-member:
+        input: '"123"'
+        output: 123n
+      bigint-string:
+        input: '"124"'
+        output: 124n
+      # FIXME: the S.string member never gets a chance — a string that isn't a bigint
+      # should fall back to it, not error (same shape as codec-json-union2's
+      # `catchall-string`).
+      catchall-string:
+        input: '"abc"'
+        error: Expected bigint, received "abc"
+      # FIXME: BigInt("") is 0n and BigInt("   ") is 0n, so blank strings decode to a
+      # bigint instead of falling back to the S.string member.
+      empty-string:
+        input: '""'
+        output: 0n
+      whitespace-string:
+        input: '"   "'
+        output: 0n
+      no-double-decoding:
+        input: "true"
+        error: Expected "123" | bigint | string, received true
+      number:
+        input: "123"
+        error: Expected "123" | bigint | string, received 123
+  decode: eq-to-parse
+  encode:
+    expression: i=>{if(typeof i==="bigint"){i=""+i}else if(!(typeof i==="string")){e[0](i)}return i}
+    examples:
+      bigint:
+        input: 123n
+        output: '"123"'
+      literal-member:
+        input: '"123"'
+        output: '"123"'
+      string:
+        input: '"abc"'
+        output: '"abc"'

--- a/packages/sury/specs/codec-literal-array-literal-string.yaml
+++ b/packages/sury/specs/codec-literal-array-literal-string.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: rule 1's literal remap (see
+  # codec-literal-string-literal-number) to reach collection literals too — [1, 2]
+  # parses to "done" and "done" encodes back to [1, 2]. Today the remap is emitted as
+  # an extra `i==="done"` check on the array that can never hold, so every direction
+  # either throws at runtime or fails to compile.
+  schema: S.schema([1, 2]).with(S.to, S.schema("done"))
+  input: "[1, 2]"
+  output: '"done"'
+  instantiations: 5704
+  bundleBytes: 9652
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "number", const: 1 }, { type: "number", const: 2 }] }'
+  output: '{ type: "string", const: "done" }'
+operations:
+  parse:
+    # FIXME: the tuple is validated and then tested against the target const, so the
+    # only value that clears the array checks fails the one after them.
+    expression: i=>{Array.isArray(i)&&i.length===2||e[3](i);let v0=i["0"],v1=i["1"];v0===1||e[0](v0);v1===2||e[1](v1);i==="done"||e[2](i);return i}
+    examples:
+      const:
+        input: "[1, 2]"
+        error: Expected "done", received [1, 2]
+      other-array:
+        input: "[1, 3]"
+        error: 'Failed at ["1"]: Expected 2, received 3'
+      target-const:
+        input: '"done"'
+        error: Expected [1, 2], received "done"
+  decode:
+    # FIXME: the array checks are dropped and only the target-const test survives, so
+    # decode rejects the very value its input type describes.
+    expression: i=>{i==="done"||e[0](i);return i}
+    examples:
+      const:
+        input: "[1, 2]"
+        error: Expected "done", received [1, 2]
+  encode:
+    creationError: "SuryError: Can't decode \"done\" to [1, 2]. Use S.to to define a custom decoder"

--- a/packages/sury/specs/codec-literal-array-literal-string.yaml
+++ b/packages/sury/specs/codec-literal-array-literal-string.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: stay the same — rule 1's literal remap (see
-  # codec-literal-string-literal-number) stops at primitive literals, so a collection
-  # literal keeps the behavior below: the remap lands as an extra `i==="done"` check
-  # the array can never satisfy, and encode refuses to compile at all.
+  # FIXME: Codec next expects: stay the same — literal-to-literal decoding is out of
+  # CODEC_NEXT_SPEC.md's scope, this collection-literal shape included.
   schema: S.schema([1, 2]).with(S.to, S.schema("done"))
   input: "[1, 2]"
   output: '"done"'

--- a/packages/sury/specs/codec-literal-array-literal-string.yaml
+++ b/packages/sury/specs/codec-literal-array-literal-string.yaml
@@ -1,10 +1,9 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: rule 1's literal remap (see
-  # codec-literal-string-literal-number) to reach collection literals too — [1, 2]
-  # parses to "done" and "done" encodes back to [1, 2]. Today the remap is emitted as
-  # an extra `i==="done"` check on the array that can never hold, so every direction
-  # either throws at runtime or fails to compile.
+  # FIXME: Codec next expects: stay the same — rule 1's literal remap (see
+  # codec-literal-string-literal-number) stops at primitive literals, so a collection
+  # literal keeps the behavior below: the remap lands as an extra `i==="done"` check
+  # the array can never satisfy, and encode refuses to compile at all.
   schema: S.schema([1, 2]).with(S.to, S.schema("done"))
   input: "[1, 2]"
   output: '"done"'
@@ -18,8 +17,6 @@ jsonSchema:
   output: '{ type: "string", const: "done" }'
 operations:
   parse:
-    # FIXME: the tuple is validated and then tested against the target const, so the
-    # only value that clears the array checks fails the one after them.
     expression: i=>{Array.isArray(i)&&i.length===2||e[3](i);let v0=i["0"],v1=i["1"];v0===1||e[0](v0);v1===2||e[1](v1);i==="done"||e[2](i);return i}
     examples:
       const:
@@ -32,8 +29,6 @@ operations:
         input: '"done"'
         error: Expected [1, 2], received "done"
   decode:
-    # FIXME: the array checks are dropped and only the target-const test survives, so
-    # decode rejects the very value its input type describes.
     expression: i=>{i==="done"||e[0](i);return i}
     examples:
       const:

--- a/packages/sury/specs/codec-literal-string-literal-number.yaml
+++ b/packages/sury/specs/codec-literal-string-literal-number.yaml
@@ -1,8 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: stay the same — rule 1's built-in decoding covers any
-  # literal pair, whatever their tags: validate the source const, return the target
-  # const. codec-null-undefined is this same remap, not a nullish special case.
+  # FIXME: Codec next expects: stay the same — which pairs have a built-in decoder is
+  # out of CODEC_NEXT_SPEC.md's scope, literal-to-literal included.
   schema: S.schema("a").with(S.to, S.schema(42))
   aliases:
     - S.literal("a").with(S.to, S.literal(42))

--- a/packages/sury/specs/codec-literal-string-literal-number.yaml
+++ b/packages/sury/specs/codec-literal-string-literal-number.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: stay the same — rule 1's built-in decoding covers any
+  # literal pair, whatever their tags: validate the source const, return the target
+  # const. codec-null-undefined is this same remap, not a nullish special case.
+  schema: S.schema("a").with(S.to, S.schema(42))
+  aliases:
+    - S.literal("a").with(S.to, S.literal(42))
+  input: '"a"'
+  output: "42"
+  instantiations: 5590
+  bundleBytes: 9648
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string", const: "a" }'
+  output: '{ type: "number", const: 42 }'
+operations:
+  parse:
+    expression: i=>{i==="a"||e[0](i);return 42}
+    examples:
+      const:
+        input: '"a"'
+        output: "42"
+      other-string:
+        input: '"b"'
+        error: Expected "a", received "b"
+      target-const:
+        input: "42"
+        error: Expected "a", received 42
+      stringified-target-const:
+        input: '"42"'
+        error: Expected "a", received "42"
+  decode: eq-to-parse
+  encode:
+    expression: i=>{i===42||e[0](i);return "a"}
+    examples:
+      const:
+        input: "42"
+        output: '"a"'
+      source-const:
+        input: '"a"'
+        error: Expected 42, received "a"
+      other-number:
+        input: "43"
+        error: Expected 42, received 43

--- a/packages/sury/specs/codec-null-undefined.yaml
+++ b/packages/sury/specs/codec-null-undefined.yaml
@@ -1,7 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: stay the same — rule 1 always applies the built-in null
-  # <-> undefined decoding.
+  # FIXME: Codec next expects: stay the same — this is rule 1's literal remap (see
+  # codec-literal-string-literal-number), which covers any literal pair, not a nullish
+  # special case.
   schema: S.schema(null).with(S.to, S.schema(undefined))
   input: "null"
   output: undefined

--- a/packages/sury/specs/codec-null-undefined.yaml
+++ b/packages/sury/specs/codec-null-undefined.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 1 always applies the built-in null
+  # <-> undefined decoding.
   schema: S.schema(null).with(S.to, S.schema(undefined))
   input: "null"
   output: undefined

--- a/packages/sury/specs/codec-null-undefined.yaml
+++ b/packages/sury/specs/codec-null-undefined.yaml
@@ -1,8 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  # FIXME: Codec next expects: stay the same — this is rule 1's literal remap (see
-  # codec-literal-string-literal-number), which covers any literal pair, not a nullish
-  # special case.
+  # FIXME: Codec next expects: stay the same — rule 1 asks the built-in decoder, which
+  # covers this pair.
   schema: S.schema(null).with(S.to, S.schema(undefined))
   input: "null"
   output: undefined

--- a/packages/sury/specs/codec-number-union2-int32.yaml
+++ b/packages/sury/specs/codec-number-union2-int32.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rule 2 — S.number is neither the int32 nor the string
+  # type, so parse/decode must compile (int32 attempted first, string next) instead of
+  # throwing at creation.
   schema: S.number.with(S.to, S.union([S.int32, S.string]))
   input: number
   output: string | number

--- a/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
+++ b/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 matches "x" by type and bridges
+  # undefined <-> null.
   schema: S.optional(S.literal("x")).with(S.to, S.nullable(S.literal("x")))
   input: '"x" | undefined'
   output: '"x" | null'

--- a/packages/sury/specs/codec-optional-nullable-partial.yaml
+++ b/packages/sury/specs/codec-optional-nullable-partial.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 4 coerces nothing and
+  # string has no same-type target variant. S.optional(S.string).with(S.to,
+  # S.nullable(S.string.with(S.to, S.boolean))) converts per variant.
   schema: S.optional(S.string).with(S.to, S.nullable(S.boolean))
   input: string | undefined
   output: boolean | null

--- a/packages/sury/specs/codec-optional-nullable-transformed.yaml
+++ b/packages/sury/specs/codec-optional-nullable-transformed.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 matches the transformed target
+  # variant by its string input and bridges undefined <-> null.
   schema: S.optional(S.string).with(S.to, S.nullable(S.string.with(S.to, S.boolean)))
   input: string | undefined
   output: boolean | null

--- a/packages/sury/specs/codec-optional-nullable.yaml
+++ b/packages/sury/specs/codec-optional-nullable.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 passes string through and
+  # bridges undefined <-> null.
   schema: S.optional(S.string).with(S.to, S.nullable(S.string))
   input: string | undefined
   output: string | null

--- a/packages/sury/specs/codec-optional-nullish.yaml
+++ b/packages/sury/specs/codec-optional-nullish.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 lets the same-type undefined
+  # target win, and the reverse bridges null → undefined.
   schema: S.optional(S.string).with(S.to, S.union([S.string, null, undefined]))
   input: string | undefined
   output: string | null | undefined

--- a/packages/sury/specs/codec-string-optional-never.yaml
+++ b/packages/sury/specs/codec-string-optional-never.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — the S.never variant is ignored by type
+  # matching, so the source fully matches the S.string variant and passes through.
   schema: S.string.with(S.to, S.union([S.string, S.never.with(S.to, S.schema(undefined))]))
   input: string
   output: string | undefined

--- a/packages/sury/specs/codec-string-optional-partial.yaml
+++ b/packages/sury/specs/codec-string-optional-partial.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 2 partial type match
+  # (string matches the string variant but not the undefined one). S.union([S.string,
+  # S.never.with(S.to, S.schema(undefined))]) widens without decoding.
   schema: S.string.with(S.to, S.optional(S.string))
   input: string
   output: string | undefined

--- a/packages/sury/specs/codec-string-undefined.yaml
+++ b/packages/sury/specs/codec-string-undefined.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 1 always applies the built-in
+  # "undefined" <-> undefined decoding.
   schema: S.string.with(S.to, S.schema(undefined))
   input: string
   output: undefined

--- a/packages/sury/specs/codec-string-union2-never.yaml
+++ b/packages/sury/specs/codec-string-union2-never.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — the S.never variant is ignored by type
+  # matching, so strings pass through and never become numbers.
   schema: S.string.with(S.to, S.union([S.never.with(S.to, S.number), S.string]))
   input: string
   output: string | number

--- a/packages/sury/specs/codec-string-union2-partial.yaml
+++ b/packages/sury/specs/codec-string-union2-partial.yaml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 2 partial type match ("123"
+  # could stay a string or decode to 123). S.union([S.string.with(S.to, S.number),
+  # S.string]) and S.union([S.never.with(S.to, S.number), S.string]) are the two
+  # explicit spellings.
   schema: S.string.with(S.to, S.union([S.number, S.string]))
   input: string
   output: string | number

--- a/packages/sury/specs/codec-string-union2-transformed.yaml
+++ b/packages/sury/specs/codec-string-union2-transformed.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — every target variant matches by its
+  # string input, so the transformed variant is tried first and the catch-all keeps
+  # the rest.
   schema: S.string.with(S.to, S.union([S.string.with(S.to, S.number), S.string]))
   input: string
   output: string | number

--- a/packages/sury/specs/codec-union-nested-refined-union.yaml
+++ b/packages/sury/specs/codec-union-nested-refined-union.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: a union carrying its own refinement is not flattened —
+  # it stays one normal (non-union) member of the outer union, type-matched by strict
+  # equality, and its refinement runs. Today it flattens into string | number |
+  # boolean and the refinement is dropped from every operation, so "" is accepted.
+  schema: 'S.union([S.union([S.string, S.number]).with(S.refine, (value) => value !== "", { error: "Expected a non-empty value" }), S.boolean])'
+  input: string | number | boolean
+  output: string | number | boolean
+  instantiations: 6519
+  bundleBytes: 9975
+vs:
+  zod: z.union([z.union([z.string(), z.number()]).refine((value) => value !== ""), z.boolean()])
+jsonSchema:
+  input: '{ anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] }'
+  output: '{ anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] }'
+operations:
+  parse:
+    # FIXME: no refinement call survives — the inner union's members are inlined into
+    # the outer type check and its refiner is lost with it.
+    expression: i=>{if(!(typeof i==="string"||typeof i==="number"&&!Number.isNaN(i)||typeof i==="boolean")){e[0](i)}return i}
+    examples:
+      string:
+        input: '"abc"'
+        output: '"abc"'
+      # FIXME: the refinement should reject this — it's the value it exists to catch.
+      refined-away-empty-string:
+        input: '""'
+        output: '""'
+      number:
+        input: "5"
+        output: "5"
+      boolean-outer-member:
+        input: "true"
+        output: "true"
+      invalid:
+        input: "null"
+        error: Expected string | number | boolean, received null
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/codec-union-nested-union3-flatten.yaml
+++ b/packages/sury/specs/codec-union-nested-union3-flatten.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — the nested union flattens first, and
+  # rule 4 has the two three-variant unions covering each other.
   schema: S.union([S.string, S.union([S.number, S.boolean])]).with(S.to, S.union([S.boolean, S.number, S.string]))
   input: string | number | boolean
   output: string | number | boolean

--- a/packages/sury/specs/codec-union2-string-partial.yaml
+++ b/packages/sury/specs/codec-union2-string-partial.yaml
@@ -1,5 +1,9 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 3 partial type match (123
+  # could decode to "123" or fail as a non-matching case).
+  # S.union([S.number.with(S.to, S.string), S.string]) and
+  # S.union([S.number.with(S.to, S.never), S.string]) are the two explicit targets.
   schema: S.union([S.number, S.string]).with(S.to, S.string)
   input: string | number
   output: string

--- a/packages/sury/specs/codec-union2-string-unsupported.yaml
+++ b/packages/sury/specs/codec-union2-string-unsupported.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  # FIXME: Codec next expects: rejected at creation — S.symbol has no built-in decoder
+  # to string. Today the member survives as a dispatch branch that throws for every
+  # symbol, so the creation-time message resurfaces as a nested cause under a runtime
+  # union error.
+  schema: S.union([S.boolean, S.symbol]).with(S.to, S.string)
+  input: boolean | symbol
+  output: string
+  instantiations: 5824
+  bundleBytes: 9882
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  # FIXME: the symbol member is missing here — the input type is boolean | symbol.
+  input: '{ type: "boolean" }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{if(typeof i==="boolean"){i=""+i}else if(typeof i==="symbol"){e[1](i,e[0])}else{e[2](i)}return i}
+    examples:
+      boolean-member:
+        input: "true"
+        output: '"true"'
+      symbol-member:
+        input: Symbol("s")
+        error: |-
+          Expected boolean | symbol, received Symbol(s)
+          - Can't decode symbol to string. Use S.to to define a custom decoder
+      invalid:
+        input: "5"
+        error: Expected boolean | symbol, received 5
+  decode: eq-to-parse
+  encode:
+    expression: i=>{try{let v0;(v0=i==="true")||i==="false"||e[0](i);i=v0}catch(e0){e[2](i,e0,e[1])}return i}
+    examples:
+      true-string:
+        input: '"true"'
+        output: "true"
+      false-string:
+        input: '"false"'
+        output: "false"
+      other-string:
+        input: '"abc"'
+        error: |-
+          Expected boolean | symbol, received "abc"
+          - Expected boolean, received "abc"
+          - Can't decode string to symbol. Use S.to to define a custom decoder

--- a/packages/sury/specs/codec-union2-union2-reject.yaml
+++ b/packages/sury/specs/codec-union2-union2-reject.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — the explicit S.never target variant is
+  # how rule 3's partial match is resolved into rejecting numbers.
   schema: S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.never), S.string]))
   input: string | number
   output: string

--- a/packages/sury/specs/codec-union2-union2-swap.yaml
+++ b/packages/sury/specs/codec-union2-union2-swap.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 passes both variants through,
+  # never coercing "123" to a number.
   schema: S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string]))
   input: string | number
   output: string | number

--- a/packages/sury/specs/codec-union2-union2-transformed.yaml
+++ b/packages/sury/specs/codec-union2-union2-transformed.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 matches number to the
+  # transformed variant by its number input and string to the catch-all.
   schema: S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.string), S.string]))
   input: string | number
   output: string

--- a/packages/sury/specs/codec-union2-union3-extra-target.yaml
+++ b/packages/sury/specs/codec-union2-union3-extra-target.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 4 requires mutual coverage
+  # and the boolean target variant has no same-type source variant.
   schema: S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string, S.boolean]))
   input: string | number
   output: string | number | boolean

--- a/packages/sury/specs/codec-union3-union2-extra-source.yaml
+++ b/packages/sury/specs/codec-union3-union2-extra-source.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 4 requires mutual coverage
+  # and the boolean source variant has no same-type target variant.
   schema: S.union([S.string, S.number, S.boolean]).with(S.to, S.union([S.number, S.string]))
   input: string | number | boolean
   output: string | number

--- a/packages/sury/specs/codec-union3-union2-json.yaml
+++ b/packages/sury/specs/codec-union3-union2-json.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rejected at creation — rule 4 matches by exact type and
+  # S.json is neither the string nor the number type.
   schema: S.union([S.string, S.number, S.bigint]).with(S.to, S.union([S.json, S.bigint]))
   input: string | number | bigint
   output: bigint | JSON

--- a/packages/sury/specs/codec-union3-union3-bridge.yaml
+++ b/packages/sury/specs/codec-union3-union3-bridge.yaml
@@ -1,5 +1,7 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: stay the same — rule 4 passes bigint/number through and
+  # bridges null <-> undefined.
   schema: S.union([S.bigint, S.number, null]).with(S.to, S.union([S.bigint, S.number, undefined]))
   input: number | bigint | null
   output: number | bigint | undefined

--- a/packages/sury/specs/codec-unknown-union2.yaml
+++ b/packages/sury/specs/codec-unknown-union2.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
+  # FIXME: Codec next expects: rule 2 — S.unknown matches no concrete variant, so every
+  # variant is attempted with decoding: "123" decodes to 123n as in
+  # codec-json-union2, instead of passing through as a string.
   schema: S.unknown.with(S.to, S.union([S.bigint, S.string]))
   input: unknown
   output: string | bigint


### PR DESCRIPTION
## Summary

This PR introduces a formal specification for the next-generation codec algorithm that will replace the current three-tier union conversion system. It documents the new four-rule approach for handling conversions between schemas with unions, along with comprehensive spec coverage expectations and updated user-facing documentation.

## Key Changes

- **New specification document** (`CODEC_NEXT_SPEC.md`): Defines the complete codec-next algorithm with four rules covering non-union→non-union, non-union→union, union→non-union, and union→union conversions. Includes shared definitions around type matching, nested union flattening, and `S.never` handling.

- **Updated user documentation**: Simplified the union conversion explanation in `docs/js-usage.md` and `docs/rescript-usage.md` from the four-rule format to a three-tier algorithm description (same-tag group, nullish bridge, fallback), with worked examples showing how the algorithm picks target variants at runtime.

- **New test specs**: Added 7 new YAML spec files documenting expected behavior changes:
  - `codec-json-union3-ungrouped.yaml`: Literal-first matching with fallback
  - `codec-bool-union2-unsupported.yaml`: Rejection of unsupported variant decoders
  - `codec-bool-union2-all-unsupported.yaml`: Rejection when no variant is decodable
  - `codec-union2-string-unsupported.yaml`: Rejection of unsupported cross-type decoding
  - `codec-literal-string-literal-number.yaml`: Literal-to-literal conversion reference
  - `codec-union-nested-refined-union.yaml`: Refined unions not flattened
  - `codec-literal-array-literal-string.yaml`: Array-to-literal conversion reference

- **Updated existing specs**: Added `FIXME: Codec next expects:` annotations to 20+ existing spec files documenting the expected behavior changes when the new algorithm is implemented.

## Notable Details

- The specification clarifies that nested unions are flattened before rules apply, except unions carrying their own format, transformation, or refinement (treated as normal schemas).
- `S.never` variants are ignored by type matching and never trigger exceptions.
- Partial type matches (where source/target type matches some but not all variants) are rejected at operation creation time with helpful error messages.
- The nullish bridge exception allows `null` ↔ `undefined` matching in union-to-union conversions even when types don't match exactly.
- Spec coverage table documents which existing tests expect behavior changes and under which rules.

https://claude.ai/code/session_012ib4oUnSCTVrhN2kcSUNgT