### PR TITLE
Standardize generic type parameter naming with T prefix

### DIFF
--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -113,11 +113,7 @@ const playerSchema = S.schema({
 type Player = S.Infer<typeof playerSchema>;
 ```
 
-The two type parameters are `S.Schema<Input, Output>` — the encoded type the schema accepts first, the decoded type it produces second, matching the direction data flows through the schema. `Output` defaults to `Input`, so a schema that doesn't transform can be annotated with one parameter:
-
-```ts
-const schema: S.Schema<string> = S.string; // same as S.Schema<string, string>
-```
+The type parameters read in the direction data flows: `S.Schema<TInput, TOutput>` — the encoded type the schema accepts, then the decoded type it produces. `TOutput` defaults to `TInput`, so an identity schema is just `S.Schema<string>`.
 
 To annotate "any schema producing `T`, whatever it accepts", leave the input as `unknown`:
 
@@ -391,10 +387,10 @@ S.parser(schema)("2020-01-01T00:00:00.123456Z"); // pass (arbitrary precision)
 S.parser(schema)("2020-01-01T00:00:00+02:00"); // fail (no offsets allowed)
 ```
 
-To decode an ISO datetime string into a `Date`, combine it with `S.to(S.date)`:
+To decode an ISO datetime string into a `Date`, chain it with `.with(S.to, S.date)`:
 
 ```ts
-const schema = S.to(S.string, S.date);
+const schema = S.string.with(S.to, S.date);
 // schema has the type S.Schema<string, Date>
 ```
 
@@ -876,7 +872,7 @@ S.parser(S.date)(new Date("invalid")); // throws
 S.parser(S.date)("2024-01-01"); // throws - not a Date instance
 ```
 
-> Unlike `S.isoDateTime` (which validates ISO datetime strings) and `S.to(S.string, S.date)` (which decodes ISO strings into Date objects), `S.date` validates existing Date instances directly.
+> Unlike `S.isoDateTime` (which validates ISO datetime strings) and `S.string.with(S.to, S.date)` (which decodes ISO strings into Date objects), `S.date` validates existing Date instances directly.
 
 You can use `S.decoder` with multiple arguments to decode between strings and dates:
 
@@ -1011,6 +1007,15 @@ S.parser(numberSetSchema)(new Set([1, 2, "3"])); // throws S.Error: At item 3 - 
 S.parser(numberSetSchema)([1, 2, 3]); // throws S.Error: Expected Set<number>, received [1, 2, 3]
 ```
 
+`S.to` is what makes the items *decode*, so an item codec keeps working: `mySet(S.string.with(S.to, S.date))` yields a `Set<Date>`. When you only need to validate — the items never change type — reach for [`S.refine`](#refinements) instead, which checks in place instead of rebuilding the collection:
+
+```ts
+const numberSet = S.instance(Set<number>).with(S.refine, (set) => {
+  for (const item of set) S.assert(S.number, item);
+  return true;
+});
+```
+
 ## Recursive schemas
 
 You can define a recursive schema in **Sury**. Unfortunately, TypeScript derives the Schema type as `unknown` so you need to explicitly specify the type and it'll start correctly typechecking.
@@ -1029,7 +1034,7 @@ const nodeSchema = S.recursive<Node>("Node", (nodeSchema) =>
 );
 ```
 
-One type parameter is enough when the schema doesn't transform — `S.recursive<Node>` is `S.Schema<Node, Node>`. When the recursive schema transforms its input, pass both sides in `S.Schema<Input, Output>` order:
+One type parameter is enough when the schema doesn't transform — `S.recursive<Node>` is `S.Schema<Node, Node>`. When the recursive schema transforms its input, pass both sides in `S.Schema<TInput, TOutput>` order:
 
 ```ts
 type Row = { title: string; children: Row[] };

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -1007,15 +1007,6 @@ S.parser(numberSetSchema)(new Set([1, 2, "3"])); // throws S.Error: At item 3 - 
 S.parser(numberSetSchema)([1, 2, 3]); // throws S.Error: Expected Set<number>, received [1, 2, 3]
 ```
 
-`S.to` is what makes the items *decode*, so an item codec keeps working: `mySet(S.string.with(S.to, S.date))` yields a `Set<Date>`. When you only need to validate — the items never change type — reach for [`S.refine`](#refinements) instead, which checks in place instead of rebuilding the collection:
-
-```ts
-const numberSet = S.instance(Set<number>).with(S.refine, (set) => {
-  for (const item of set) S.assert(S.number, item);
-  return true;
-});
-```
-
 ## Recursive schemas
 
 You can define a recursive schema in **Sury**. Unfortunately, TypeScript derives the Schema type as `unknown` so you need to explicitly specify the type and it'll start correctly typechecking.
@@ -1190,15 +1181,15 @@ Parsing means that the input value is validated against the schema and transform
 
 | Operation      | Interface                                                       | Description                                                   |
 | -------------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
-| S.parser       | `(Schema<Input, Output>) => (data: unknown) => Output`          | Parses any value with the schema                              |
-| S.asyncParser  | `(Schema<Input, Output>) => (data: unknown) => Promise<Output>` | Parses any value with the schema having async transformations |
+| S.parser       | `(Schema<TInput, TOutput>) => (data: unknown) => TOutput`          | Parses any value with the schema                              |
+| S.asyncParser  | `(Schema<TInput, TOutput>) => (data: unknown) => Promise<TOutput>` | Parses any value with the schema having async transformations |
 
 For advanced users you can only transform to the output type without type validations. But be careful, since the input type is not checked:
 
 | Operation       | Interface                                                | Description                                                      |
 | --------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
-| S.decoder       | `(Schema<Input, Output>) => (Input) => Output`           | Converts input value to the output type                          |
-| S.asyncDecoder  | `(Schema<Input, Output>) => (Input) => Promise<Output>`  | Converts input value to the output type with async transforms    |
+| S.decoder       | `(Schema<TInput, TOutput>) => (TInput) => TOutput`           | Converts input value to the output type                          |
+| S.asyncDecoder  | `(Schema<TInput, TOutput>) => (TInput) => Promise<TOutput>`  | Converts input value to the output type with async transforms    |
 
 Note, that in this case only type validations are skipped. If your schema has refinements or transforms, they will be applied.
 
@@ -1208,8 +1199,8 @@ More often than converting input to output, you'll need to perform the reversed 
 
 | Operation       | Interface                                              | Description                                                           |
 | --------------- | ------------------------------------------------------ | --------------------------------------------------------------------- |
-| S.encoder       | `(Schema<Input, Output>) => (Output) => Input`         | Converts schema value to the input type                               |
-| S.asyncEncoder  | `(Schema<Input, Output>) => (Output) => Promise<Input>`| Converts schema value to the input type with async transformations    |
+| S.encoder       | `(Schema<TInput, TOutput>) => (TOutput) => TInput`         | Converts schema value to the input type                               |
+| S.asyncEncoder  | `(Schema<TInput, TOutput>) => (TOutput) => Promise<TInput>`| Converts schema value to the input type with async transformations    |
 
 This is literally the same as convert operations applied to the reversed schema.
 
@@ -1217,8 +1208,8 @@ For some cases you might want to simply check whether the input value is valid, 
 
 | Operation | Interface                                                      | Description                                                                                                                                    |
 | --------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| S.assert  | `(Schema<Input, Output>, data: unknown) asserts data is Input` or `(data: unknown, Schema<Input, Output>) asserts data is Input` | Asserts that the input value is valid. Since the operation doesn't return a value, it's 2-3 times faster than `parser` depending on the schema |
-| S.is      | `(Schema<Input, Output>, data: unknown) => data is Input` or `(data: unknown, Schema<Input, Output>) => data is Input`      | Returns `true`/`false` whether the input value is valid. Acts as a TypeScript type guard and shares the fast validate-only path with `assert`  |
+| S.assert  | `(Schema<TInput, TOutput>, data: unknown) asserts data is TInput` or `(data: unknown, Schema<TInput, TOutput>) asserts data is TInput` | Asserts that the input value is valid. Since the operation doesn't return a value, it's 2-3 times faster than `parser` depending on the schema |
+| S.is      | `(Schema<TInput, TOutput>, data: unknown) => data is TInput` or `(data: unknown, Schema<TInput, TOutput>) => data is TInput`      | Returns `true`/`false` whether the input value is valid. Acts as a TypeScript type guard and shares the fast validate-only path with `assert`  |
 
 Both `S.assert` and `S.is` accept their arguments in either order, so `(schema, data)` and `(data, schema)` are equivalent and both narrow the type. There's no "correct" order to memorize — pass the schema and the data in whatever order feels natural, and it just works. This is especially handy for AI assistants, which no longer have to guess the right argument position:
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -1021,11 +1021,27 @@ type Node = {
   children: Node[];
 };
 
-const nodeSchema = S.recursive<Node, Node>("Node", (nodeSchema) =>
+const nodeSchema = S.recursive<Node>("Node", (nodeSchema) =>
   S.schema({
     id: S.string,
     children: S.array(nodeSchema),
   })
+);
+```
+
+One type parameter is enough when the schema doesn't transform — `S.recursive<Node>` is `S.Schema<Node, Node>`. When the recursive schema transforms its input, pass both sides in `S.Schema<Input, Output>` order:
+
+```ts
+type Row = { title: string; children: Row[] };
+
+const rowSchema = S.recursive<unknown, Row>("Row", (rowSchema) =>
+  S.schema({
+    TITLE: S.string,
+    CHILDREN: S.array(rowSchema),
+  }).with(S.shape, (input) => ({
+    title: input.TITLE,
+    children: input.CHILDREN,
+  }))
 );
 ```
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -113,6 +113,19 @@ const playerSchema = S.schema({
 type Player = S.Infer<typeof playerSchema>;
 ```
 
+The two type parameters are `S.Schema<Input, Output>` — the encoded type the schema accepts first, the decoded type it produces second, matching the direction data flows through the schema. `Output` defaults to `Input`, so a schema that doesn't transform can be annotated with one parameter:
+
+```ts
+const schema: S.Schema<string> = S.string; // same as S.Schema<string, string>
+```
+
+To annotate "any schema producing `T`, whatever it accepts", leave the input as `unknown`:
+
+```ts
+const parseT = <T>(schema: S.Schema<unknown, T>, data: unknown): T =>
+  S.parser(schema)(data);
+```
+
 ### Serializing data
 
 Every schema has an `Input` type as well as an `Output` type, so the same definition serializes back to the input format:
@@ -132,7 +145,7 @@ const userSchema = S.schema({
   id: input.USER_ID,
   name: input.USER_NAME,
 }));
-//? S.Schema<{ id: bigint; name: string }, { USER_ID: string; USER_NAME: string }>
+//? S.Schema<{ USER_ID: string; USER_NAME: string }, { id: bigint; name: string }>
 
 S.parser(userSchema)({ USER_ID: "0", USER_NAME: "Dmitry" });
 // { id: 0n, name: "Dmitry" }
@@ -382,7 +395,7 @@ To decode an ISO datetime string into a `Date`, combine it with `S.to(S.date)`:
 
 ```ts
 const schema = S.to(S.string, S.date);
-// schema has the type S.Schema<Date, string>
+// schema has the type S.Schema<string, Date>
 ```
 
 ## Numbers
@@ -970,7 +983,7 @@ For more information on branding in general, check out [this excellent article](
 3. Optionally, use `S.meta` to add customize the name of the schema and additional metadata.
 
 ```ts
-const mySet = <T>(itemSchema: S.Schema<T>): S.Schema<Set<T>> =>
+const mySet = <T>(itemSchema: S.Schema<unknown, T>): S.Schema<unknown, Set<T>> =>
   S.instance(Set<unknown>)
     .with(S.to, S.instance(Set<T>), (input) => {
       const output = new Set<T>();
@@ -1156,15 +1169,15 @@ Parsing means that the input value is validated against the schema and transform
 
 | Operation      | Interface                                                       | Description                                                   |
 | -------------- | --------------------------------------------------------------- | ------------------------------------------------------------- |
-| S.parser       | `(Schema<Output, Input>) => (data: unknown) => Output`          | Parses any value with the schema                              |
-| S.asyncParser  | `(Schema<Output, Input>) => (data: unknown) => Promise<Output>` | Parses any value with the schema having async transformations |
+| S.parser       | `(Schema<Input, Output>) => (data: unknown) => Output`          | Parses any value with the schema                              |
+| S.asyncParser  | `(Schema<Input, Output>) => (data: unknown) => Promise<Output>` | Parses any value with the schema having async transformations |
 
 For advanced users you can only transform to the output type without type validations. But be careful, since the input type is not checked:
 
 | Operation       | Interface                                                | Description                                                      |
 | --------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
-| S.decoder       | `(Schema<Output, Input>) => (Input) => Output`           | Converts input value to the output type                          |
-| S.asyncDecoder  | `(Schema<Output, Input>) => (Input) => Promise<Output>`  | Converts input value to the output type with async transforms    |
+| S.decoder       | `(Schema<Input, Output>) => (Input) => Output`           | Converts input value to the output type                          |
+| S.asyncDecoder  | `(Schema<Input, Output>) => (Input) => Promise<Output>`  | Converts input value to the output type with async transforms    |
 
 Note, that in this case only type validations are skipped. If your schema has refinements or transforms, they will be applied.
 
@@ -1174,8 +1187,8 @@ More often than converting input to output, you'll need to perform the reversed 
 
 | Operation       | Interface                                              | Description                                                           |
 | --------------- | ------------------------------------------------------ | --------------------------------------------------------------------- |
-| S.encoder       | `(Schema<Output, Input>) => (Output) => Input`         | Converts schema value to the input type                               |
-| S.asyncEncoder  | `(Schema<Output, Input>) => (Output) => Promise<Input>`| Converts schema value to the input type with async transformations    |
+| S.encoder       | `(Schema<Input, Output>) => (Output) => Input`         | Converts schema value to the input type                               |
+| S.asyncEncoder  | `(Schema<Input, Output>) => (Output) => Promise<Input>`| Converts schema value to the input type with async transformations    |
 
 This is literally the same as convert operations applied to the reversed schema.
 
@@ -1183,8 +1196,8 @@ For some cases you might want to simply check whether the input value is valid, 
 
 | Operation | Interface                                                      | Description                                                                                                                                    |
 | --------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| S.assert  | `(Schema<Output, Input>, data: unknown) asserts data is Input` or `(data: unknown, Schema<Output, Input>) asserts data is Input` | Asserts that the input value is valid. Since the operation doesn't return a value, it's 2-3 times faster than `parser` depending on the schema |
-| S.is      | `(Schema<Output, Input>, data: unknown) => data is Input` or `(data: unknown, Schema<Output, Input>) => data is Input`      | Returns `true`/`false` whether the input value is valid. Acts as a TypeScript type guard and shares the fast validate-only path with `assert`  |
+| S.assert  | `(Schema<Input, Output>, data: unknown) asserts data is Input` or `(data: unknown, Schema<Input, Output>) asserts data is Input` | Asserts that the input value is valid. Since the operation doesn't return a value, it's 2-3 times faster than `parser` depending on the schema |
+| S.is      | `(Schema<Input, Output>, data: unknown) => data is Input` or `(data: unknown, Schema<Input, Output>) => data is Input`      | Returns `true`/`false` whether the input value is valid. Acts as a TypeScript type guard and shares the fast validate-only path with `assert`  |
 
 Both `S.assert` and `S.is` accept their arguments in either order, so `(schema, data)` and `(data, schema)` are equivalent and both narrow the type. There's no "correct" order to memorize — pass the schema and the data in whatever order feels natural, and it just works. This is especially handy for AI assistants, which no longer have to guess the right argument position:
 

--- a/packages/e2e/src/genType/GenType_test_type.ts
+++ b/packages/e2e/src/genType/GenType_test_type.ts
@@ -3,6 +3,6 @@ import { expectType, TypeEqual } from "ts-expect";
 import * as S from "../../../../src/S.js";
 import * as GenType from "./GenType.gen";
 
-expectType<TypeEqual<typeof GenType.stringSchema, S.Schema<string, unknown>>>(
+expectType<TypeEqual<typeof GenType.stringSchema, S.Schema<unknown, string>>>(
   true
 );

--- a/packages/sury/README.md
+++ b/packages/sury/README.md
@@ -127,7 +127,7 @@ const userSchema = S.schema({
   id: input.USER_ID,
   name: input.USER_NAME,
 }));
-//? S.Schema<{ id: bigint; name: string }, { USER_ID: string; USER_NAME: string }>
+//? S.Schema<{ USER_ID: string; USER_NAME: string }, { id: bigint; name: string }>
 
 S.parser(userSchema)({ USER_ID: "0", USER_NAME: "Dmitry" });
 // => { id: 0n, name: "Dmitry" }
@@ -222,7 +222,7 @@ S.schema({ foo: S.string });
 //? S.Schema<{ foo: string }, { foo: string }>
 ```
 
-Compare that with `v.ObjectSchema<{readonly foo: v.StringSchema<undefined>}, undefined>`. Both `Input` and `Output` are right there, which is what makes a transformation's two sides obvious at a glance rather than something you reconstruct in your head.
+Compare that with `v.ObjectSchema<{readonly foo: v.StringSchema<undefined>}, undefined>`. Both sides are right there, and they read in the direction the data flows — `S.Schema<Input, Output>` — which is what makes a transformation's two sides obvious at a glance rather than something you reconstruct in your head.
 
 ### Errors that tell you where to look
 

--- a/packages/sury/README.md
+++ b/packages/sury/README.md
@@ -222,7 +222,7 @@ S.schema({ foo: S.string });
 //? S.Schema<{ foo: string }, { foo: string }>
 ```
 
-Compare that with `v.ObjectSchema<{readonly foo: v.StringSchema<undefined>}, undefined>`. Both sides are right there, and they read in the direction the data flows — `S.Schema<Input, Output>` — which is what makes a transformation's two sides obvious at a glance rather than something you reconstruct in your head.
+Compare that with `v.ObjectSchema<{readonly foo: v.StringSchema<undefined>}, undefined>`. Both sides are right there, and they read in the direction the data flows — `S.Schema<TInput, TOutput>` — which is what makes a transformation's two sides obvious at a glance rather than something you reconstruct in your head.
 
 ### Errors that tell you where to look
 

--- a/packages/sury/specs/codec-bool-number-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-number-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.boolean.with(S.to, S.number)
   input: boolean
   output: number
-  instantiations: 5106
+  instantiations: 5085
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-bool-union2-all-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-union2-all-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.boolean.with(S.to, S.union([S.number, S.symbol]))
   input: boolean
   output: number | symbol
-  instantiations: 6080
+  instantiations: 6059
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-bool-union2-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-union2-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.boolean.with(S.to, S.union([S.string, S.symbol]))
   input: boolean
   output: string | symbol
-  instantiations: 6080
+  instantiations: 6059
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-json-optional-union-literal-first.yaml
+++ b/packages/sury/specs/codec-json-optional-union-literal-first.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object({ selector: S.optional(S.union([S.literal("*"), S.string, S.array(S.string)])) }).with(S.to, S.json)'
   input: "{ selector?: string | string[] | undefined; }"
   output: JSON
-  instantiations: 8089
+  instantiations: 8068
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-json-union2.yaml
+++ b/packages/sury/specs/codec-json-union2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.union([S.bigint, S.string]))
   input: JSON
   output: string | bigint
-  instantiations: 6083
+  instantiations: 6062
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-json-union3-grouped.yaml
+++ b/packages/sury/specs/codec-json-union3-grouped.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]))
   input: JSON
   output: number | "a" | "b"
-  instantiations: 6578
+  instantiations: 6557
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-json-union3-ungrouped.yaml
+++ b/packages/sury/specs/codec-json-union3-ungrouped.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.union(["123", S.bigint, S.string]))
   input: JSON
   output: string | bigint
-  instantiations: 6197
+  instantiations: 6176
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-literal-array-literal-string.yaml
+++ b/packages/sury/specs/codec-literal-array-literal-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([1, 2]).with(S.to, S.schema("done"))
   input: "[1, 2]"
   output: '"done"'
-  instantiations: 5704
+  instantiations: 5683
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-literal-string-literal-number.yaml
+++ b/packages/sury/specs/codec-literal-string-literal-number.yaml
@@ -5,7 +5,7 @@ ts:
     - S.literal("a").with(S.to, S.literal(42))
   input: '"a"'
   output: "42"
-  instantiations: 5590
+  instantiations: 5569
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-nan-union2-exact.yaml
+++ b/packages/sury/specs/codec-nan-union2-exact.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema(NaN).with(S.to, S.union([S.schema(NaN), S.string]))
   input: number
   output: string | number
-  instantiations: 6198
+  instantiations: 6177
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-null-undefined.yaml
+++ b/packages/sury/specs/codec-null-undefined.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema(null).with(S.to, S.schema(undefined))
   input: "null"
   output: undefined
-  instantiations: 5522
+  instantiations: 5501
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-number-union2-int32.yaml
+++ b/packages/sury/specs/codec-number-union2-int32.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.to, S.union([S.int32, S.string]))
   input: number
   output: string | number
-  instantiations: 6059
+  instantiations: 6038
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
+++ b/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.literal("x")).with(S.to, S.nullable(S.literal("x")))
   input: '"x" | undefined'
   output: '"x" | null'
-  instantiations: 5690
+  instantiations: 5669
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-optional-nullable-partial.yaml
+++ b/packages/sury/specs/codec-optional-nullable-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.nullable(S.boolean))
   input: string | undefined
   output: boolean | null
-  instantiations: 5390
+  instantiations: 5369
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-optional-nullable-transformed.yaml
+++ b/packages/sury/specs/codec-optional-nullable-transformed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.nullable(S.string.with(S.to, S.boolean)))
   input: string | undefined
   output: boolean | null
-  instantiations: 5756
+  instantiations: 5735
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-optional-nullable.yaml
+++ b/packages/sury/specs/codec-optional-nullable.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.nullable(S.string))
   input: string | undefined
   output: string | null
-  instantiations: 5327
+  instantiations: 5306
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-optional-nullish.yaml
+++ b/packages/sury/specs/codec-optional-nullish.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.union([S.string, null, undefined]))
   input: string | undefined
   output: string | null | undefined
-  instantiations: 5956
+  instantiations: 5935
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-string-optional-never.yaml
+++ b/packages/sury/specs/codec-string-optional-never.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.string, S.never.with(S.to, S.schema(undefined))]))
   input: string
   output: string | undefined
-  instantiations: 6704
+  instantiations: 6683
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-string-optional-partial.yaml
+++ b/packages/sury/specs/codec-string-optional-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.optional(S.string))
   input: string
   output: string | undefined
-  instantiations: 5243
+  instantiations: 5222
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-string-undefined.yaml
+++ b/packages/sury/specs/codec-string-undefined.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.schema(undefined))
   input: string
   output: undefined
-  instantiations: 5475
+  instantiations: 5454
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-string-union2-never.yaml
+++ b/packages/sury/specs/codec-string-union2-never.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.never.with(S.to, S.number), S.string]))
   input: string
   output: string | number
-  instantiations: 6379
+  instantiations: 6358
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-string-union2-partial.yaml
+++ b/packages/sury/specs/codec-string-union2-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.number, S.string]))
   input: string
   output: string | number
-  instantiations: 6059
+  instantiations: 6038
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-string-union2-transformed.yaml
+++ b/packages/sury/specs/codec-string-union2-transformed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.string.with(S.to, S.number), S.string]))
   input: string
   output: string | number
-  instantiations: 6261
+  instantiations: 6240
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union-nested-refined-union.yaml
+++ b/packages/sury/specs/codec-union-nested-refined-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.union([S.string, S.number]).with(S.refine, (value) => value !== "", { error: "Expected a non-empty value" }), S.boolean])'
   input: string | number | boolean
   output: string | number | boolean
-  instantiations: 6519
+  instantiations: 6498
 vs:
   zod: z.union([z.union([z.string(), z.number()]).refine((value) => value !== ""), z.boolean()])
 jsonSchema:

--- a/packages/sury/specs/codec-union-nested-union3-flatten.yaml
+++ b/packages/sury/specs/codec-union-nested-union3-flatten.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.union([S.number, S.boolean])]).with(S.to, S.union([S.boolean, S.number, S.string]))
   input: string | number | boolean
   output: string | number | boolean
-  instantiations: 6907
+  instantiations: 6886
 vs:
   zod: z.union([z.string(), z.union([z.number(), z.boolean()])])
 jsonSchema:

--- a/packages/sury/specs/codec-union-refined-fallback.yaml
+++ b/packages/sury/specs/codec-union-refined-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.min, 3), S.number, S.string])
   input: string | number
   output: string | number
-  instantiations: 6098
+  instantiations: 6077
 vs:
   zod: z.union([z.string().min(3), z.number(), z.string()])
 jsonSchema:

--- a/packages/sury/specs/codec-union-unreachable-nullish-bridge.yaml
+++ b/packages/sury/specs/codec-union-unreachable-nullish-bridge.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.never.with(S.to, S.schema(null)), S.string]).with(S.to, S.union([S.schema(undefined), S.string]))
   input: string
   output: string | undefined
-  instantiations: 7172
+  instantiations: 7151
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union2-string-partial.yaml
+++ b/packages/sury/specs/codec-union2-string-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.number, S.string]).with(S.to, S.string)
   input: string | number
   output: string
-  instantiations: 5766
+  instantiations: 5745
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union2-string-unsupported.yaml
+++ b/packages/sury/specs/codec-union2-string-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.boolean, S.symbol]).with(S.to, S.string)
   input: boolean | symbol
   output: string
-  instantiations: 5824
+  instantiations: 5803
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union2-union2-reject.yaml
+++ b/packages/sury/specs/codec-union2-union2-reject.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.never), S.string]))
   input: string | number
   output: string
-  instantiations: 6742
+  instantiations: 6721
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union2-union2-swap.yaml
+++ b/packages/sury/specs/codec-union2-union2-swap.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string]))
   input: string | number
   output: string | number
-  instantiations: 6196
+  instantiations: 6175
 vs:
   zod: z.union([z.string(), z.number()])
 jsonSchema:

--- a/packages/sury/specs/codec-union2-union2-transformed.yaml
+++ b/packages/sury/specs/codec-union2-union2-transformed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.string), S.string]))
   input: string | number
   output: string
-  instantiations: 6680
+  instantiations: 6659
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union2-union3-extra-target.yaml
+++ b/packages/sury/specs/codec-union2-union3-extra-target.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string, S.boolean]))
   input: string | number
   output: string | number | boolean
-  instantiations: 6536
+  instantiations: 6515
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union3-union2-extra-source.yaml
+++ b/packages/sury/specs/codec-union3-union2-extra-source.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number, S.boolean]).with(S.to, S.union([S.number, S.string]))
   input: string | number | boolean
   output: string | number
-  instantiations: 6536
+  instantiations: 6515
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union3-union2-json.yaml
+++ b/packages/sury/specs/codec-union3-union2-json.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number, S.bigint]).with(S.to, S.union([S.json, S.bigint]))
   input: string | number | bigint
   output: bigint | JSON
-  instantiations: 6901
+  instantiations: 6880
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-union3-union3-bridge.yaml
+++ b/packages/sury/specs/codec-union3-union3-bridge.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.bigint, S.number, null]).with(S.to, S.union([S.bigint, S.number, undefined]))
   input: number | bigint | null
   output: number | bigint | undefined
-  instantiations: 6352
+  instantiations: 6331
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/codec-unknown-union2.yaml
+++ b/packages/sury/specs/codec-unknown-union2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.unknown.with(S.to, S.union([S.bigint, S.string]))
   input: unknown
   output: string | bigint
-  instantiations: 6059
+  instantiations: 6038
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/union-large-planner.yaml
+++ b/packages/sury/specs/union-large-planner.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union(["literal-0", "literal-1", "literal-2", "literal-3", "literal-4", "literal-5", "literal-6", "literal-7", { kind: "number", value: S.number }, { kind: "string", value: S.string }, { kind: "boolean", value: S.boolean }, { kind: "bigint", value: S.bigint }, S.instance(Date).with(S.to, S.string, () => "date"), S.instance(Error).with(S.to, S.string, () => "error"), S.instance(TypeError).with(S.to, S.string, () => "type-error"), S.union([S.string.with(S.min, 12), S.number]).with(S.refine, () => false, { error: "opaque member rejected" }), S.string, S.number, S.boolean, S.bigint, S.symbol, null, undefined])'
   input: 'string | number | bigint | boolean | symbol | Date | Error | { kind: "number"; value: number; } | { kind: "string"; value: string; } | { kind: "boolean"; value: boolean; } | { kind: "bigint"; value: bigint; } | null | undefined'
   output: 'string | number | bigint | boolean | symbol | { kind: "number"; value: number; } | { kind: "string"; value: string; } | { kind: "boolean"; value: boolean; } | { kind: "bigint"; value: bigint; } | null | undefined'
-  instantiations: 12413
+  instantiations: 12392
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/union2-broad-covers-blocked-by-refine.yaml
+++ b/packages/sury/specs/union2-broad-covers-blocked-by-refine.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.min, 3), S.string])
   input: string
   output: string
-  instantiations: 5702
+  instantiations: 5681
 vs:
   zod: z.union([z.string().min(3), z.string()])
 jsonSchema:

--- a/packages/sury/specs/union2-opaque-literal-effect-boundary.yaml
+++ b/packages/sury/specs/union2-opaque-literal-effect-boundary.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.literal("a"), S.literal("b").with(S.to, S.json)])
   input: '"a" | "b"'
   output: JSON
-  instantiations: 6190
+  instantiations: 6169
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/union2-refine-throws.yaml
+++ b/packages/sury/specs/union2-refine-throws.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.refine, (v) => { throw new TypeError("predicate blew up") }), S.string])
   input: string
   output: string
-  instantiations: 5518
+  instantiations: 5497
 vs:
   zod: z.union([z.string().refine((v) => { throw new TypeError("predicate blew up") }), z.string()])
 jsonSchema:

--- a/packages/sury/specs/union2-refined-literal-fallback.yaml
+++ b/packages/sury/specs/union2-refined-literal-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.min, 3), S.schema("x")])
   input: string
   output: string
-  instantiations: 6159
+  instantiations: 6138
 vs:
   zod: z.union([z.string().min(3), z.literal("x")])
 jsonSchema:

--- a/packages/sury/specs/union2-shared-discriminator-fallback.yaml
+++ b/packages/sury/specs/union2-shared-discriminator-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({ kind: S.schema("a"), value: S.number.with(S.min, 2) }), S.schema({ kind: S.schema("a"), value: S.schema(1) })])'
   input: '{ kind: "a"; value: number; } | { kind: "a"; value: 1; }'
   output: '{ kind: "a"; value: number; } | { kind: "a"; value: 1; }'
-  instantiations: 9451
+  instantiations: 9430
 vs:
   zod: 'z.union([z.object({ kind: z.literal("a"), value: z.number().min(2) }), z.object({ kind: z.literal("a"), value: z.literal(1) })])'
 jsonSchema:

--- a/packages/sury/specs/union2-symbol-literal-fallback.yaml
+++ b/packages/sury/specs/union2-symbol-literal-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.schema(Symbol.for("union-fallback")).with(S.refine, () => false, "first rejected"), S.schema(Symbol.for("union-fallback"))])
   input: symbol
   output: unknown
-  instantiations: 6665
+  instantiations: 6644
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/union3-broad-covers-blocked-by-codec.yaml
+++ b/packages/sury/specs/union3-broad-covers-blocked-by-codec.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.schema("apple"), S.string.with(S.to, S.number, Number, String), S.string])
   input: string
   output: string | number
-  instantiations: 6492
+  instantiations: 6471
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/union3-instance-priority-order.yaml
+++ b/packages/sury/specs/union3-instance-priority-order.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.instance(Error).with(S.to, S.string, () => "error"), S.schema({ x: S.string }), S.instance(TypeError).with(S.to, S.string, () => "type-error")])'
   input: "Error | { x: string; }"
   output: "string | { x: string; }"
-  instantiations: 7699
+  instantiations: 7678
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/union3-overlap-group-barrier.yaml
+++ b/packages/sury/specs/union3-overlap-group-barrier.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({ kind: "left", value: S.string }).with(S.refine, () => false, { error: "left member rejected" }), S.schema({ kind: S.string, value: S.string.with(S.pattern, /^broad-/, "broad member rejected") }), S.schema({ kind: "right", value: S.string.with(S.pattern, /^right-/, "right member rejected") })])'
   input: '{ kind: "left"; value: string; } | { kind: string; value: string; } | { kind: "right"; value: string; }'
   output: '{ kind: "left"; value: string; } | { kind: string; value: string; } | { kind: "right"; value: string; }'
-  instantiations: 10626
+  instantiations: 10605
 vs:
   zod: 'z.union([z.object({ kind: z.literal("left"), value: z.string() }).refine(() => false, { message: "left member rejected" }), z.object({ kind: z.string(), value: z.string().regex(/^broad-/, { message: "broad member rejected" }) }), z.object({ kind: z.literal("right"), value: z.string().regex(/^right-/, { message: "right member rejected" }) })])'
 jsonSchema:

--- a/packages/sury/specs/union3-same-tag-effect-boundary.yaml
+++ b/packages/sury/specs/union3-same-tag-effect-boundary.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.min, 5), S.string.with(S.to, S.number), S.string.with(S.max, 1)])
   input: string
   output: string | number
-  instantiations: 6410
+  instantiations: 6389
 vs:
   zod: z.union([z.string().min(5), z.string().pipe(z.coerce.number()), z.string().max(1)])
 jsonSchema:

--- a/packages/sury/specs/union3-same-tag-validation-group.yaml
+++ b/packages/sury/specs/union3-same-tag-validation-group.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.min, 4), S.string.with(S.max, 1), S.string.with(S.length, 2)])
   input: string
   output: string
-  instantiations: 6001
+  instantiations: 5980
 vs:
   zod: z.union([z.string().min(4), z.string().max(1), z.string().length(2)])
 jsonSchema:

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -1,12 +1,12 @@
 /** The Standard Schema interface. */
-export interface StandardSchemaV1<Input = unknown, Output = Input> {
+export interface StandardSchemaV1<TInput = unknown, TOutput = TInput> {
   /** The Standard Schema properties. */
-  readonly "~standard": StandardSchemaV1.Props<Input, Output>;
+  readonly "~standard": StandardSchemaV1.Props<TInput, TOutput>;
 }
 
 export declare namespace StandardSchemaV1 {
   /** The Standard Schema properties interface. */
-  export interface Props<Input = unknown, Output = Input> {
+  export interface Props<TInput = unknown, TOutput = TInput> {
     /** The version number of the standard. */
     readonly version: 1;
     /** The vendor name of the schema library. */
@@ -14,18 +14,18 @@ export declare namespace StandardSchemaV1 {
     /** Validates unknown input values. */
     readonly validate: (
       value: unknown
-    ) => Result<Output> | Promise<Result<Output>>;
+    ) => Result<TOutput> | Promise<Result<TOutput>>;
     /** Inferred types associated with the schema. */
-    readonly types?: Types<Input, Output> | undefined;
+    readonly types?: Types<TInput, TOutput> | undefined;
   }
 
   /** The result interface of the validate function. */
-  export type Result<Output> = SuccessResult<Output> | FailureResult;
+  export type Result<TOutput> = SuccessResult<TOutput> | FailureResult;
 
   /** The result interface if validation succeeds. */
-  export interface SuccessResult<Output> {
+  export interface SuccessResult<TOutput> {
     /** The typed output value. */
-    readonly value: Output;
+    readonly value: TOutput;
     /** The non-existent issues. */
     readonly issues?: undefined;
   }
@@ -51,21 +51,21 @@ export declare namespace StandardSchemaV1 {
   }
 
   /** The Standard Schema types interface. */
-  export interface Types<Input = unknown, Output = Input> {
+  export interface Types<TInput = unknown, TOutput = TInput> {
     /** The input type of the schema. */
-    readonly input: Input;
+    readonly input: TInput;
     /** The output type of the schema. */
-    readonly output: Output;
+    readonly output: TOutput;
   }
 
   /** Infers the input type of a Standard Schema. */
-  export type InferInput<Schema extends StandardSchemaV1> = NonNullable<
-    Schema["~standard"]["types"]
+  export type InferInput<TSchema extends StandardSchemaV1> = NonNullable<
+    TSchema["~standard"]["types"]
   >["input"];
 
   /** Infers the output type of a Standard Schema. */
-  export type InferOutput<Schema extends StandardSchemaV1> = NonNullable<
-    Schema["~standard"]["types"]
+  export type InferOutput<TSchema extends StandardSchemaV1> = NonNullable<
+    TSchema["~standard"]["types"]
   >["output"];
 }
 
@@ -73,36 +73,36 @@ export declare namespace StandardSchemaV1 {
  * The Standard Typed interface.
  * This is a base type extended by other specs.
  */
-export interface StandardTypedV1<Input = unknown, Output = Input> {
-  readonly "~standard": StandardTypedV1.Props<Input, Output>;
+export interface StandardTypedV1<TInput = unknown, TOutput = TInput> {
+  readonly "~standard": StandardTypedV1.Props<TInput, TOutput>;
 }
 
 export declare namespace StandardTypedV1 {
-  export interface Props<Input = unknown, Output = Input> {
+  export interface Props<TInput = unknown, TOutput = TInput> {
     readonly version: 1;
     readonly vendor: string;
-    readonly types?: Types<Input, Output> | undefined;
+    readonly types?: Types<TInput, TOutput> | undefined;
   }
-  export interface Types<Input = unknown, Output = Input> {
-    readonly input: Input;
-    readonly output: Output;
+  export interface Types<TInput = unknown, TOutput = TInput> {
+    readonly input: TInput;
+    readonly output: TOutput;
   }
-  export type InferInput<Schema extends StandardTypedV1> = NonNullable<
-    Schema["~standard"]["types"]
+  export type InferInput<TSchema extends StandardTypedV1> = NonNullable<
+    TSchema["~standard"]["types"]
   >["input"];
-  export type InferOutput<Schema extends StandardTypedV1> = NonNullable<
-    Schema["~standard"]["types"]
+  export type InferOutput<TSchema extends StandardTypedV1> = NonNullable<
+    TSchema["~standard"]["types"]
   >["output"];
 }
 
 /** The Standard JSON Schema interface. https://standardschema.dev/json-schema */
-export interface StandardJSONSchemaV1<Input = unknown, Output = Input> {
-  readonly "~standard": StandardJSONSchemaV1.Props<Input, Output>;
+export interface StandardJSONSchemaV1<TInput = unknown, TOutput = TInput> {
+  readonly "~standard": StandardJSONSchemaV1.Props<TInput, TOutput>;
 }
 
 export declare namespace StandardJSONSchemaV1 {
-  export interface Props<Input = unknown, Output = Input>
-    extends StandardTypedV1.Props<Input, Output> {
+  export interface Props<TInput = unknown, TOutput = TInput>
+    extends StandardTypedV1.Props<TInput, TOutput> {
     readonly jsonSchema: StandardJSONSchemaV1.Converter;
   }
   export interface Converter {
@@ -118,12 +118,12 @@ export declare namespace StandardJSONSchemaV1 {
     readonly target: Target;
     readonly libraryOptions?: Record<string, unknown> | undefined;
   }
-  export interface Types<Input = unknown, Output = Input>
-    extends StandardTypedV1.Types<Input, Output> {}
-  export type InferInput<Schema extends StandardTypedV1> =
-    StandardTypedV1.InferInput<Schema>;
-  export type InferOutput<Schema extends StandardTypedV1> =
-    StandardTypedV1.InferOutput<Schema>;
+  export interface Types<TInput = unknown, TOutput = TInput>
+    extends StandardTypedV1.Types<TInput, TOutput> {}
+  export type InferInput<TSchema extends StandardTypedV1> =
+    StandardTypedV1.InferInput<TSchema>;
+  export type InferOutput<TSchema extends StandardTypedV1> =
+    StandardTypedV1.InferOutput<TSchema>;
 }
 
 
@@ -380,41 +380,41 @@ export const Error: {
 // full `Schema<…>` shape (whose 14-member union + `with` overloads are costly to
 // instantiate per match). `types` is optional, so the pattern keeps it optional.
 export type Output<T> = T extends {
-  readonly ["~standard"]: { readonly types?: { readonly output: infer Output } };
+  readonly ["~standard"]: { readonly types?: { readonly output: infer TOutput } };
 }
-  ? Output
+  ? TOutput
   : never;
 export type Infer<T> = Output<T>;
 export type Input<T> = T extends {
-  readonly ["~standard"]: { readonly types?: { readonly input: infer Input } };
+  readonly ["~standard"]: { readonly types?: { readonly input: infer TInput } };
 }
-  ? Input
+  ? TInput
   : never;
 
 // Utility types for decoder function with multiple schemas
-type ExtractFirstInput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [SchemaLike<infer FirstInput, any>, ...any[]]
-    ? FirstInput
+type ExtractFirstInput<TSchemas extends readonly SchemaLike<any, any>[]> =
+  TSchemas extends readonly [SchemaLike<infer TFirstInput, any>, ...any[]]
+    ? TFirstInput
     : never;
 
 // Utility types for encoder function with multiple schemas
-type ExtractFirstOutput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [SchemaLike<any, infer FirstOutput>, ...any[]]
-    ? FirstOutput
+type ExtractFirstOutput<TSchemas extends readonly SchemaLike<any, any>[]> =
+  TSchemas extends readonly [SchemaLike<any, infer TFirstOutput>, ...any[]]
+    ? TFirstOutput
     : never;
 
-type ExtractLastOutput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [...any[], SchemaLike<any, infer LastOutput>]
-    ? LastOutput
-    : T extends readonly [SchemaLike<any, infer SingleOutput>]
-    ? SingleOutput
+type ExtractLastOutput<TSchemas extends readonly SchemaLike<any, any>[]> =
+  TSchemas extends readonly [...any[], SchemaLike<any, infer TLastOutput>]
+    ? TLastOutput
+    : TSchemas extends readonly [SchemaLike<any, infer TSingleOutput>]
+    ? TSingleOutput
     : never;
 
-type ExtractLastInput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [...any[], SchemaLike<infer LastInput, any>]
-    ? LastInput
-    : T extends readonly [SchemaLike<infer SingleInput, any>]
-    ? SingleInput
+type ExtractLastInput<TSchemas extends readonly SchemaLike<any, any>[]> =
+  TSchemas extends readonly [...any[], SchemaLike<infer TLastInput, any>]
+    ? TLastInput
+    : TSchemas extends readonly [SchemaLike<infer TSingleInput, any>]
+    ? TSingleInput
     : never;
 
 // Match the `~standard` marker instead of the full `Schema<…>` shape for the
@@ -423,9 +423,9 @@ type ExtractLastInput<T extends readonly SchemaLike<any, any>[]> =
 // stamps onto every nested property — that marker only exists to keep literal
 // types from widening and shouldn't leak into the inferred Output/Input.
 export type UnknownToOutput<T> = T extends {
-  readonly ["~standard"]: { readonly types?: { readonly output: infer Output } };
+  readonly ["~standard"]: { readonly types?: { readonly output: infer TOutput } };
 }
-  ? Output
+  ? TOutput
   : T extends (...args: any[]) => any
   ? T
   : T extends unknown[]
@@ -435,9 +435,9 @@ export type UnknownToOutput<T> = T extends {
   : T;
 
 export type UnknownToInput<T> = T extends {
-  readonly ["~standard"]: { readonly types?: { readonly input: infer Input } };
+  readonly ["~standard"]: { readonly types?: { readonly input: infer TInput } };
 }
-  ? Input
+  ? TInput
   : T extends (...args: any[]) => any
   ? T
   : T extends unknown[]
@@ -470,20 +470,20 @@ export function brand<TId extends string, TInput = unknown, TOutput = unknown>(
   brandId: TId
 ): Schema<TInput, Brand<TOutput, TId>>;
 
-// `R` already holds each field's resolved type. A field is optional iff its type
-// admits `undefined`, so an `S.never` field stays required. The split is skipped
-// when no field is optional. Required keys come first, optional last — matching
-// the ordering Zod (and the wider Standard Schema ecosystem) infers, so a Sury
-// type reads the same as its cross-library equivalent.
-type ResolveObject<R> = undefined extends R[keyof R]
+// `TFields` already holds each field's resolved type. A field is optional iff
+// its type admits `undefined`, so an `S.never` field stays required. The split
+// is skipped when no field is optional. Required keys come first, optional last
+// — matching the ordering Zod (and the wider Standard Schema ecosystem) infers,
+// so a Sury type reads the same as its cross-library equivalent.
+type ResolveObject<TFields> = undefined extends TFields[keyof TFields]
   ? Flatten<
       {
-        [K in keyof R as undefined extends R[K] ? never : K]: R[K];
+        [K in keyof TFields as undefined extends TFields[K] ? never : K]: TFields[K];
       } & {
-        [K in keyof R as undefined extends R[K] ? K : never]?: R[K];
+        [K in keyof TFields as undefined extends TFields[K] ? K : never]?: TFields[K];
       }
     >
-  : Flatten<R>;
+  : Flatten<TFields>;
 
 // Flatten an intersection into one object, keeping values verbatim (incl. `never`).
 type Flatten<T> = T extends object ? { [K in keyof T]: T[K] } : T;
@@ -509,11 +509,11 @@ export function literal<const T>(
   value: T
 ): Schema<UnknownToInput<T>, UnknownToOutput<T>>;
 
-export function union<const A, const B extends unknown[]>(
-  schemas: [A, ...B]
+export function union<const TFirst, const TRest extends unknown[]>(
+  schemas: [TFirst, ...TRest]
 ): Schema<
-  UnknownToInput<A> | UnknownArrayToInput<B>[number],
-  UnknownToOutput<A> | UnknownArrayToOutput<B>[number]
+  UnknownToInput<TFirst> | UnknownArrayToInput<TRest>[number],
+  UnknownToOutput<TFirst> | UnknownArrayToOutput<TRest>[number]
 >;
 export function union<const T>(
   schemas: readonly T[]
@@ -749,8 +749,8 @@ export function deepStrict<TInput extends Record<string, unknown>, TOutput>(
 // Bare Flatten, not ResolveObject: re-splitting the merged intersection to
 // hoist optionals last nearly doubled this type's instantiation cost, so Merge
 // keeps insertion order.
-type Merge<A, B> = Flatten<
-  { [K in keyof A as K extends keyof B ? never : K]: A[K] } & B
+type Merge<TLeft, TRight> = Flatten<
+  { [K in keyof TLeft as K extends keyof TRight ? never : K]: TLeft[K] } & TRight
 >;
 
 export function merge<

--- a/packages/sury/src/S.d.ts
+++ b/packages/sury/src/S.d.ts
@@ -127,9 +127,9 @@ export declare namespace StandardJSONSchemaV1 {
 }
 
 
-export type SuccessResult<Value> = {
+export type SuccessResult<TValue> = {
   readonly success: true;
-  readonly value: Value;
+  readonly value: TValue;
   readonly error?: undefined;
 };
 
@@ -138,7 +138,7 @@ export type FailureResult = {
   readonly error: Error;
 };
 
-export type Result<Value> = SuccessResult<Value> | FailureResult;
+export type Result<TValue> = SuccessResult<TValue> | FailureResult;
 
 export type JSON =
   | string
@@ -153,73 +153,89 @@ export type StringFormat = "json" | "date-time" | "email" | "uuid" | "cuid" | "u
 export type ArrayFormat = "compactColumns";
 export type Format = NumberFormat | StringFormat | ArrayFormat;
 
-export type Schema<Output, Input = unknown> = {
-  with<TargetOutput = unknown, TargetInput = unknown>(
+// `TOutput = TInput` so an identity schema is spelled `Schema<string>`. The
+// default is dependent, so TS instantiates it at every one-arg reference —
+// internal references write `Schema<unknown, unknown>` in full to keep that
+// off the per-schema type-cost the specs measure.
+export type Schema<TInput = unknown, TOutput = TInput> = {
+  with<TTargetInput = unknown, TTargetOutput = unknown>(
     to: (
       schema: Schema<unknown, unknown>,
       target: Schema<unknown, unknown>,
       decode?: ((value: unknown) => unknown) | undefined,
-      encode?: (value: unknown) => Output
+      encode?: (value: unknown) => TOutput
     ) => Schema<unknown, unknown>,
-    target: SchemaLike<TargetOutput, TargetInput>,
-    decode?: ((value: Output) => TargetInput) | undefined,
-    encode?: (value: TargetOutput) => Output
-  ): Schema<TargetOutput, Input>;
+    target: SchemaLike<TTargetInput, TTargetOutput>,
+    decode?: ((value: TOutput) => TTargetInput) | undefined,
+    encode?: (value: TTargetOutput) => TOutput
+  ): Schema<TInput, TTargetOutput>;
   with(
     refine: (
       schema: Schema<unknown, unknown>,
       refineCheck: (value: unknown) => boolean,
       refineOptions?: { error?: string; path?: string[] }
     ) => Schema<unknown, unknown>,
-    refineCheck: (value: Output) => boolean,
+    refineCheck: (value: TOutput) => boolean,
     refineOptions?: { error?: string; path?: string[] }
-  ): Schema<Output, Input>;
+  ): Schema<TInput, TOutput>;
   // This overload is what both S.refine and S.shape resolve to under
   // overload matching — the exact mechanism that routes S.refine calls here
   // instead of the more specific `refine` overload above hasn't been pinned
   // down. Treat it as load-bearing for both call sites and verify against
   // S_refine_test.res / S_shape_test.res before changing its shape.
-  with<Shape>(
+  with<TShape>(
     fn: (
       schema: Schema<unknown, unknown>,
       callback: ((value: unknown) => unknown) | undefined
     ) => Schema<unknown, unknown>,
-    callback: ((value: Output) => Shape) | undefined
-  ): Schema<Shape, Input>;
-  with<O, I>(fn: (schema: Schema<Output, Input>) => SchemaLike<O, I>): Schema<O, I>;
-  // Constraining A1 to string makes a string-literal arg1 (e.g.
+    callback: ((value: TOutput) => TShape) | undefined
+  ): Schema<TInput, TShape>;
+  with<TNextInput, TNextOutput>(
+    fn: (schema: Schema<TInput, TOutput>) => SchemaLike<TNextInput, TNextOutput>
+  ): Schema<TNextInput, TNextOutput>;
+  // Constraining TArg1 to string makes a string-literal arg1 (e.g.
   // `.with(S.brand, "myId")`) infer its literal type instead of widening to
   // `string` — needed for brand-based nominal typing. The next overload
   // covers the general (non-string) arg1 case.
-  with<O, I, A1 extends string>(
-    fn: (schema: Schema<Output, Input>, arg1: A1) => SchemaLike<O, I>,
-    arg1: A1
-  ): Schema<O, I>;
-  with<O, I, A1>(
-    fn: (schema: Schema<Output, Input>, arg1: A1) => SchemaLike<O, I>,
-    arg1: A1
-  ): Schema<O, I>;
-  with<O, I, A1, A2>(
-    fn: (schema: Schema<Output, Input>, arg1: A1, arg2: A2) => SchemaLike<O, I>,
-    arg1: A1,
-    arg2: A2
-  ): Schema<O, I>;
+  with<TNextInput, TNextOutput, TArg1 extends string>(
+    fn: (
+      schema: Schema<TInput, TOutput>,
+      arg1: TArg1
+    ) => SchemaLike<TNextInput, TNextOutput>,
+    arg1: TArg1
+  ): Schema<TNextInput, TNextOutput>;
+  with<TNextInput, TNextOutput, TArg1>(
+    fn: (
+      schema: Schema<TInput, TOutput>,
+      arg1: TArg1
+    ) => SchemaLike<TNextInput, TNextOutput>,
+    arg1: TArg1
+  ): Schema<TNextInput, TNextOutput>;
+  with<TNextInput, TNextOutput, TArg1, TArg2>(
+    fn: (
+      schema: Schema<TInput, TOutput>,
+      arg1: TArg1,
+      arg2: TArg2
+    ) => SchemaLike<TNextInput, TNextOutput>,
+    arg1: TArg1,
+    arg2: TArg2
+  ): Schema<TNextInput, TNextOutput>;
 
-  readonly $defs?: Record<string, Schema<unknown>>;
+  readonly $defs?: Record<string, Schema<unknown, unknown>>;
 
   readonly name?: string;
   readonly title?: string;
   readonly description?: string;
   readonly deprecated?: boolean;
-  readonly examples?: Input[];
+  readonly examples?: TInput[];
   readonly noValidation?: boolean;
-  readonly default?: Input;
-  readonly to?: Schema<unknown>;
+  readonly default?: TInput;
+  readonly to?: Schema<unknown, unknown>;
   readonly errorMessage?: SchemaErrorMessage;
 
   // jsonSchema.input/.output throw until enableStandardJSONSchema() is called.
-  readonly ["~standard"]: StandardSchemaV1.Props<Input, Output> &
-    StandardJSONSchemaV1.Props<Input, Output>;
+  readonly ["~standard"]: StandardSchemaV1.Props<TInput, TOutput> &
+    StandardJSONSchemaV1.Props<TInput, TOutput>;
 } & (
   | {
       readonly type: "never";
@@ -268,17 +284,17 @@ export type Schema<Output, Input = unknown> = {
     }
   | {
       readonly type: "function";
-      readonly const?: Input;
+      readonly const?: TInput;
     }
   | {
       readonly type: "instance";
-      readonly class: Class<Input>;
-      readonly const?: Input;
+      readonly class: Class<TInput>;
+      readonly const?: TInput;
     }
   | {
       readonly type: "array";
-      readonly items: Schema<unknown>;
-      readonly additionalItems: AdditionalItemsMode | Schema<unknown>;
+      readonly items: Schema<unknown, unknown>;
+      readonly additionalItems: AdditionalItemsMode | Schema<unknown, unknown>;
       readonly format?: ArrayFormat;
       readonly minItems?: number;
       readonly maxItems?: number;
@@ -286,14 +302,14 @@ export type Schema<Output, Input = unknown> = {
   | {
       readonly type: "object";
       readonly properties: {
-        [key: string]: Schema<unknown>;
+        [key: string]: Schema<unknown, unknown>;
       };
-      readonly additionalItems: AdditionalItemsMode | Schema<unknown>;
+      readonly additionalItems: AdditionalItemsMode | Schema<unknown, unknown>;
       readonly required?: string[];
     }
   | {
       readonly type: "anyOf";
-      readonly anyOf: Schema<unknown>[];
+      readonly anyOf: Schema<unknown, unknown>[];
       readonly has: Record<
         | "string"
         | "number"
@@ -331,8 +347,8 @@ type BaseError = {
 export type Error =
   | (BaseError & {
       readonly code: "invalid_input";
-      readonly expected: Schema<unknown>;
-      readonly received: Schema<unknown>;
+      readonly expected: Schema<unknown, unknown>;
+      readonly received: Schema<unknown, unknown>;
       readonly input?: unknown;
       readonly unionErrors?: readonly Error[];
     })
@@ -341,13 +357,13 @@ export type Error =
     })
   | (BaseError & {
       readonly code: "unsupported_decode";
-      readonly from: Schema<unknown>;
-      readonly to: Schema<unknown>;
+      readonly from: Schema<unknown, unknown>;
+      readonly to: Schema<unknown, unknown>;
     })
   | (BaseError & {
       readonly code: "invalid_conversion";
-      readonly from: Schema<unknown>;
-      readonly to: Schema<unknown>;
+      readonly from: Schema<unknown, unknown>;
+      readonly to: Schema<unknown, unknown>;
       readonly cause?: unknown;
     })
   | (BaseError & {
@@ -377,27 +393,27 @@ export type Input<T> = T extends {
 
 // Utility types for decoder function with multiple schemas
 type ExtractFirstInput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [SchemaLike<any, infer FirstInput>, ...any[]]
+  T extends readonly [SchemaLike<infer FirstInput, any>, ...any[]]
     ? FirstInput
     : never;
 
 // Utility types for encoder function with multiple schemas
 type ExtractFirstOutput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [SchemaLike<infer FirstOutput, any>, ...any[]]
+  T extends readonly [SchemaLike<any, infer FirstOutput>, ...any[]]
     ? FirstOutput
     : never;
 
 type ExtractLastOutput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [...any[], SchemaLike<infer LastOutput, any>]
+  T extends readonly [...any[], SchemaLike<any, infer LastOutput>]
     ? LastOutput
-    : T extends readonly [SchemaLike<infer SingleOutput, any>]
+    : T extends readonly [SchemaLike<any, infer SingleOutput>]
     ? SingleOutput
     : never;
 
 type ExtractLastInput<T extends readonly SchemaLike<any, any>[]> =
-  T extends readonly [...any[], SchemaLike<any, infer LastInput>]
+  T extends readonly [...any[], SchemaLike<infer LastInput, any>]
     ? LastInput
-    : T extends readonly [SchemaLike<any, infer SingleInput>]
+    : T extends readonly [SchemaLike<infer SingleInput, any>]
     ? SingleInput
     : never;
 
@@ -433,24 +449,26 @@ export type UnknownToInput<T> = T extends {
 // Lightweight parameter type for inferring a schema's Output/Input: matching
 // the `~standard` marker instead of the full `Schema<…>` shape (14-member
 // union + `with` overloads) keeps per-call instantiation cost low.
-type SchemaLike<Output, Input> = {
+type SchemaLike<TInput, TOutput> = {
   readonly ["~standard"]: {
-    readonly types?: { readonly output: Output; readonly input: Input } | undefined;
+    readonly types?:
+      | { readonly output: TOutput; readonly input: TInput }
+      | undefined;
   };
 };
 
-export type Brand<T, ID extends string> = T & {
+export type Brand<T, TId extends string> = T & {
   /**
    *  TypeScript won't suggest strings beginning with a space as properties.
    *  Useful for symbol-like string properties.
    */
-  readonly [" brand"]: [T, ID];
+  readonly [" brand"]: [T, TId];
 };
 
-export function brand<ID extends string, Output = unknown, Input = unknown>(
-  schema: SchemaLike<Output, Input>,
-  brandId: ID
-): Schema<Brand<Output, ID>, Input>;
+export function brand<TId extends string, TInput = unknown, TOutput = unknown>(
+  schema: SchemaLike<TInput, TOutput>,
+  brandId: TId
+): Schema<TInput, Brand<TOutput, TId>>;
 
 // `R` already holds each field's resolved type. A field is optional iff its type
 // admits `undefined`, so an `S.never` field stays required. The split is skipped
@@ -482,24 +500,24 @@ type UnknownArrayToInput<T extends unknown[]> = number extends T["length"]
 
 export function schema<const T extends unknown[]>(
   schemas: [...T]
-): Schema<[...UnknownArrayToOutput<T>], [...UnknownArrayToInput<T>]>;
+): Schema<[...UnknownArrayToInput<T>], [...UnknownArrayToOutput<T>]>;
 export function schema<const T>(
   value: T
-): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
+): Schema<UnknownToInput<T>, UnknownToOutput<T>>;
 
 export function literal<const T>(
   value: T
-): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
+): Schema<UnknownToInput<T>, UnknownToOutput<T>>;
 
 export function union<const A, const B extends unknown[]>(
   schemas: [A, ...B]
 ): Schema<
-  UnknownToOutput<A> | UnknownArrayToOutput<B>[number],
-  UnknownToInput<A> | UnknownArrayToInput<B>[number]
+  UnknownToInput<A> | UnknownArrayToInput<B>[number],
+  UnknownToOutput<A> | UnknownArrayToOutput<B>[number]
 >;
 export function union<const T>(
   schemas: readonly T[]
-): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
+): Schema<UnknownToInput<T>, UnknownToOutput<T>>;
 
 export const string: Schema<string, string>;
 export const boolean: Schema<boolean, boolean>;
@@ -534,201 +552,199 @@ export const url: Schema<string, string>;
 
 export const date: Schema<Date, Date>;
 
-export function safe<Value>(scope: () => Value): Result<Value>;
-export function safeAsync<Value>(
-  scope: () => Promise<Value>
-): Promise<Result<Value>>;
+export function safe<TValue>(scope: () => TValue): Result<TValue>;
+export function safeAsync<TValue>(
+  scope: () => Promise<TValue>
+): Promise<Result<TValue>>;
 
-export function reverse<Output, Input>(
-  schema: SchemaLike<Output, Input>
-): Schema<Input, Output>;
+export function reverse<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): Schema<TOutput, TInput>;
 
-export function parser<Output>(
-  schema: SchemaLike<Output, unknown>
-): (data: unknown) => Output;
-export function parser<Output>(
+export function parser<TOutput>(
+  schema: SchemaLike<unknown, TOutput>
+): (data: unknown) => TOutput;
+export function parser<TOutput>(
   from: SchemaLike<unknown, unknown>,
-  target: SchemaLike<Output, unknown>
-): (data: unknown) => Output;
+  target: SchemaLike<unknown, TOutput>
+): (data: unknown) => TOutput;
 export function parser<
-  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
->(...schemas: Schemas): (data: unknown) => ExtractLastOutput<Schemas>;
+  TSchemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
+>(...schemas: TSchemas): (data: unknown) => ExtractLastOutput<TSchemas>;
 
-export function asyncParser<Output>(
-  schema: SchemaLike<Output, unknown>
-): (data: unknown) => Promise<Output>;
-export function asyncParser<Output>(
+export function asyncParser<TOutput>(
+  schema: SchemaLike<unknown, TOutput>
+): (data: unknown) => Promise<TOutput>;
+export function asyncParser<TOutput>(
   from: SchemaLike<unknown, unknown>,
-  target: SchemaLike<Output, unknown>
-): (data: unknown) => Promise<Output>;
+  target: SchemaLike<unknown, TOutput>
+): (data: unknown) => Promise<TOutput>;
 export function asyncParser<
-  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
->(...schemas: Schemas): (data: unknown) => Promise<ExtractLastOutput<Schemas>>;
+  TSchemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
+>(...schemas: TSchemas): (data: unknown) => Promise<ExtractLastOutput<TSchemas>>;
 
-export function decoder<Output, Input>(
-  schema: SchemaLike<Output, Input>
-): (data: Input) => Output;
-export function decoder<Output, Input>(
-  from: SchemaLike<unknown, Input>,
-  target: SchemaLike<Output, unknown>
-): (data: Input) => Output;
+export function decoder<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): (data: TInput) => TOutput;
+export function decoder<TInput, TOutput>(
+  from: SchemaLike<TInput, unknown>,
+  target: SchemaLike<unknown, TOutput>
+): (data: TInput) => TOutput;
 export function decoder<
-  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
+  TSchemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
-  ...schemas: Schemas
-): (data: ExtractFirstInput<Schemas>) => ExtractLastOutput<Schemas>;
+  ...schemas: TSchemas
+): (data: ExtractFirstInput<TSchemas>) => ExtractLastOutput<TSchemas>;
 
-export function asyncDecoder<Output, Input>(
-  schema: SchemaLike<Output, Input>
-): (data: Input) => Promise<Output>;
-export function asyncDecoder<Output, Input>(
-  from: SchemaLike<unknown, Input>,
-  target: SchemaLike<Output, unknown>
-): (data: Input) => Promise<Output>;
+export function asyncDecoder<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): (data: TInput) => Promise<TOutput>;
+export function asyncDecoder<TInput, TOutput>(
+  from: SchemaLike<TInput, unknown>,
+  target: SchemaLike<unknown, TOutput>
+): (data: TInput) => Promise<TOutput>;
 export function asyncDecoder<
-  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
+  TSchemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
-  ...schemas: Schemas
-): (data: ExtractFirstInput<Schemas>) => Promise<ExtractLastOutput<Schemas>>;
+  ...schemas: TSchemas
+): (data: ExtractFirstInput<TSchemas>) => Promise<ExtractLastOutput<TSchemas>>;
 
-export function encoder<Output, Input>(
-  schema: SchemaLike<Output, Input>
-): (data: Output) => Input;
-export function encoder<Output, Input>(
-  from: SchemaLike<Output, unknown>,
-  target: SchemaLike<unknown, Input>
-): (data: Output) => Input;
+export function encoder<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): (data: TOutput) => TInput;
+export function encoder<TInput, TOutput>(
+  from: SchemaLike<unknown, TOutput>,
+  target: SchemaLike<TInput, unknown>
+): (data: TOutput) => TInput;
 export function encoder<
-  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
+  TSchemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
-  ...schemas: Schemas
-): (data: ExtractFirstOutput<Schemas>) => ExtractLastInput<Schemas>;
+  ...schemas: TSchemas
+): (data: ExtractFirstOutput<TSchemas>) => ExtractLastInput<TSchemas>;
 
-export function asyncEncoder<Output, Input>(
-  schema: SchemaLike<Output, Input>
-): (data: Output) => Promise<Input>;
-export function asyncEncoder<Output, Input>(
-  from: SchemaLike<Output, unknown>,
-  target: SchemaLike<unknown, Input>
-): (data: Output) => Promise<Input>;
+export function asyncEncoder<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): (data: TOutput) => Promise<TInput>;
+export function asyncEncoder<TInput, TOutput>(
+  from: SchemaLike<unknown, TOutput>,
+  target: SchemaLike<TInput, unknown>
+): (data: TOutput) => Promise<TInput>;
 export function asyncEncoder<
-  Schemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
+  TSchemas extends readonly [SchemaLike<any, any>, ...SchemaLike<any, any>[]]
 >(
-  ...schemas: Schemas
-): (data: ExtractFirstOutput<Schemas>) => Promise<ExtractLastInput<Schemas>>;
+  ...schemas: TSchemas
+): (data: ExtractFirstOutput<TSchemas>) => Promise<ExtractLastInput<TSchemas>>;
 
-export function assert<Output, Input>(
-  schema: SchemaLike<Output, Input>,
+export function assert<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
   data: unknown
-): asserts data is Input;
-export function assert<Output, Input>(
+): asserts data is TInput;
+export function assert<TInput, TOutput>(
   data: unknown,
-  schema: SchemaLike<Output, Input>
-): asserts data is Input;
+  schema: SchemaLike<TInput, TOutput>
+): asserts data is TInput;
 
-export function is<Output, Input>(
-  schema: SchemaLike<Output, Input>,
+export function is<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
   data: unknown
-): data is Input;
-export function is<Output, Input>(
+): data is TInput;
+export function is<TInput, TOutput>(
   data: unknown,
-  schema: SchemaLike<Output, Input>
-): data is Input;
+  schema: SchemaLike<TInput, TOutput>
+): data is TInput;
 
-export function tuple<Output, Input extends unknown[]>(
+export function tuple<TInput extends unknown[], TOutput>(
   definer: (s: {
-    item: <ItemOutput>(
+    item: <TItemOutput>(
       inputIndex: number,
-      schema: SchemaLike<ItemOutput, unknown>
-    ) => ItemOutput;
+      schema: SchemaLike<unknown, TItemOutput>
+    ) => TItemOutput;
     tag: (inputIndex: number, value: unknown) => void;
-  }) => Output
-): Schema<Output, Input>;
+  }) => TOutput
+): Schema<TInput, TOutput>;
 export function tuple<const T extends unknown[]>(
   schemas: [...T]
-): Schema<[...UnknownArrayToOutput<T>], [...UnknownArrayToInput<T>]>;
+): Schema<[...UnknownArrayToInput<T>], [...UnknownArrayToOutput<T>]>;
 
 export function optional<
-  Output,
-  Input,
-  Or extends Output | undefined = undefined
+  TInput,
+  TOutput,
+  TOr extends TOutput | undefined = undefined
 >(
-  schema: SchemaLike<Output, Input>,
-  or?: (() => Or) | Or,
+  schema: SchemaLike<TInput, TOutput>,
+  or?: (() => TOr) | TOr,
   // To make .with work
   _?: never
 ): Schema<
-  Or extends undefined ? Output | undefined : Output,
-  Input | undefined
+  TInput | undefined,
+  TOr extends undefined ? TOutput | undefined : TOutput
 >;
 
-export function nullable<
-  Output,
-  Input,
-  Or extends Output | null = null
->(
-  schema: SchemaLike<Output, Input>,
-  or?: (() => Or) | Or,
+export function nullable<TInput, TOutput, TOr extends TOutput | null = null>(
+  schema: SchemaLike<TInput, TOutput>,
+  or?: (() => TOr) | TOr,
   // To make .with work
   _?: never
-): Schema<Or extends null ? Output | null : Output, Input | null>;
+): Schema<TInput | null, TOr extends null ? TOutput | null : TOutput>;
 
-export const nullish: <Output, Input>(
-  schema: SchemaLike<Output, Input>
-) => Schema<Output | undefined | null, Input | undefined | null>;
+export const nullish: <TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+) => Schema<TInput | undefined | null, TOutput | undefined | null>;
 
 export type Class<T> = new (...args: readonly any[]) => T;
 export const instance: <T>(class_: Class<T>) => Schema<T, T>;
 
-export const array: <Output, Input>(
-  schema: SchemaLike<Output, Input>
-) => Schema<Output[], Input[]>;
+export const array: <TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+) => Schema<TInput[], TOutput[]>;
 
-export const compactColumns: <Output, Input>(
-  schema: SchemaLike<Output, Input>
-) => Schema<Output[][], Input[][]>;
+export const compactColumns: <TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+) => Schema<TInput[][], TOutput[][]>;
 
-export const record: <Output, Input>(
-  schema: SchemaLike<Output, Input>
-) => Schema<Record<string, Output>, Record<string, Input>>;
+export const record: <TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+) => Schema<Record<string, TInput>, Record<string, TOutput>>;
 
-type ObjectCtx<Input extends Record<string, unknown>> = {
-  field: <FieldOutput>(
+type ObjectCtx<TInput extends Record<string, unknown>> = {
+  field: <TFieldOutput>(
     name: string,
-    schema: SchemaLike<FieldOutput, unknown>
-  ) => FieldOutput;
-  fieldOr: <FieldOutput>(
+    schema: SchemaLike<unknown, TFieldOutput>
+  ) => TFieldOutput;
+  fieldOr: <TFieldOutput>(
     name: string,
-    schema: SchemaLike<FieldOutput, unknown>,
-    or: FieldOutput
-  ) => FieldOutput;
-  tag: <TagName extends keyof Input>(
-    name: TagName,
-    value: Input[TagName]
+    schema: SchemaLike<unknown, TFieldOutput>,
+    or: TFieldOutput
+  ) => TFieldOutput;
+  tag: <TTagName extends keyof TInput>(
+    name: TTagName,
+    value: TInput[TTagName]
   ) => void;
-  flatten: <FieldOutput>(schema: SchemaLike<FieldOutput, unknown>) => FieldOutput;
+  flatten: <TFieldOutput>(
+    schema: SchemaLike<unknown, TFieldOutput>
+  ) => TFieldOutput;
   nested: (name: string) => ObjectCtx<Record<string, unknown>>;
 };
 
-export function object<Output, Input extends Record<string, unknown>>(
-  definer: (ctx: ObjectCtx<Input>) => Output
-): Schema<Output, Input>;
+export function object<TInput extends Record<string, unknown>, TOutput>(
+  definer: (ctx: ObjectCtx<TInput>) => TOutput
+): Schema<TInput, TOutput>;
 export function object<T extends Record<string, unknown>>(
   definition: T
-): Schema<UnknownToOutput<T>, UnknownToInput<T>>;
+): Schema<UnknownToInput<T>, UnknownToOutput<T>>;
 
-export function strip<Output, Input extends Record<string, unknown>>(
-  schema: SchemaLike<Output, Input>
-): Schema<Output, Input>;
-export function deepStrip<Output, Input extends Record<string, unknown>>(
-  schema: SchemaLike<Output, Input>
-): Schema<Output, Input>;
-export function strict<Output, Input extends Record<string, unknown>>(
-  schema: SchemaLike<Output, Input>
-): Schema<Output, Input>;
-export function deepStrict<Output, Input extends Record<string, unknown>>(
-  schema: SchemaLike<Output, Input>
-): Schema<Output, Input>;
+export function strip<TInput extends Record<string, unknown>, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): Schema<TInput, TOutput>;
+export function deepStrip<TInput extends Record<string, unknown>, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): Schema<TInput, TOutput>;
+export function strict<TInput extends Record<string, unknown>, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): Schema<TInput, TOutput>;
+export function deepStrict<TInput extends Record<string, unknown>, TOutput>(
+  schema: SchemaLike<TInput, TOutput>
+): Schema<TInput, TOutput>;
 
 // Bare Flatten, not ResolveObject: re-splitting the merged intersection to
 // hoist optionals last nearly doubled this type's instantiation cost, so Merge
@@ -738,19 +754,19 @@ type Merge<A, B> = Flatten<
 >;
 
 export function merge<
-  O1 extends Record<string, unknown>,
-  I1,
-  O2 extends Record<string, unknown>,
-  I2
->(schema1: SchemaLike<O1, I1>, schema2: SchemaLike<O2, I2>): Schema<
-  Merge<O1, O2>,
-  Merge<I1, I2>
->;
+  TInput1,
+  TOutput1 extends Record<string, unknown>,
+  TInput2,
+  TOutput2 extends Record<string, unknown>
+>(
+  schema1: SchemaLike<TInput1, TOutput1>,
+  schema2: SchemaLike<TInput2, TOutput2>
+): Schema<Merge<TInput1, TInput2>, Merge<TOutput1, TOutput2>>;
 
-export function recursive<Output, Input = unknown>(
+export function recursive<TInput = unknown, TOutput = TInput>(
   identifier: string,
-  definer: (schema: Schema<Output, Input>) => Schema<Output, Input>
-): Schema<Output, Input>;
+  definer: (schema: Schema<TInput, TOutput>) => Schema<TInput, TOutput>
+): Schema<TInput, TOutput>;
 
 export type SchemaErrorMessage = {
   /** Catch-all override, used when no more specific key below matches the failing check. */
@@ -766,64 +782,64 @@ export type SchemaErrorMessage = {
   pattern?: string;
 };
 
-export type Meta<Output> = {
+export type Meta<TOutput> = {
   name?: string;
   title?: string;
   description?: string;
   deprecated?: boolean;
-  examples?: Output[];
+  examples?: TOutput[];
   errorMessage?: SchemaErrorMessage;
 };
 
-export function meta<Output, Input>(
-  schema: SchemaLike<Output, Input>,
-  meta: Meta<Output>
-): Schema<Output, Input>;
+export function meta<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
+  meta: Meta<TOutput>
+): Schema<TInput, TOutput>;
 
 export function toExpression(schema: SchemaLike<unknown, unknown>): string;
-export function noValidation<Output, Input>(
-  schema: SchemaLike<Output, Input>,
+export function noValidation<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
   value: boolean
-): Schema<Output, Input>;
+): Schema<TInput, TOutput>;
 
-export function asyncDecoderAssert<Output, Input>(
-  schema: SchemaLike<Output, Input>,
-  assertFn: (value: Output) => Promise<void>
-): Schema<Output, Input>;
+export function asyncDecoderAssert<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
+  assertFn: (value: TOutput) => Promise<void>
+): Schema<TInput, TOutput>;
 
-export function refine<Output, Input>(
-  schema: SchemaLike<Output, Input>,
-  refineCheck: (value: Output) => boolean,
+export function refine<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
+  refineCheck: (value: TOutput) => boolean,
   refineOptions?: {
     error?: string;
     path?: string[];
   }
-): Schema<Output, Input>;
+): Schema<TInput, TOutput>;
 
-export const min: <Output extends string | number | unknown[], Input>(
-  schema: SchemaLike<Output, Input>,
+export const min: <TInput, TOutput extends string | number | unknown[]>(
+  schema: SchemaLike<TInput, TOutput>,
   length: number,
   message?: string
-) => Schema<Output, Input>;
-export const max: <Output extends string | number | unknown[], Input>(
-  schema: SchemaLike<Output, Input>,
+) => Schema<TInput, TOutput>;
+export const max: <TInput, TOutput extends string | number | unknown[]>(
+  schema: SchemaLike<TInput, TOutput>,
   length: number,
   message?: string
-) => Schema<Output, Input>;
-export const length: <Output extends string | unknown[], Input>(
-  schema: SchemaLike<Output, Input>,
+) => Schema<TInput, TOutput>;
+export const length: <TInput, TOutput extends string | unknown[]>(
+  schema: SchemaLike<TInput, TOutput>,
   length: number,
   message?: string
-) => Schema<Output, Input>;
+) => Schema<TInput, TOutput>;
 
-export const pattern: <Input>(
-  schema: SchemaLike<string, Input>,
+export const pattern: <TInput>(
+  schema: SchemaLike<TInput, string>,
   re: RegExp,
   message?: string
-) => Schema<string, Input>;
-export const trim: <Input>(
-  schema: SchemaLike<string, Input>
-) => Schema<string, Input>;
+) => Schema<TInput, string>;
+export const trim: <TInput>(
+  schema: SchemaLike<TInput, string>
+) => Schema<TInput, string>;
 
 export type AdditionalItemsMode = "strip" | "strict";
 
@@ -834,36 +850,36 @@ export type GlobalConfigOverride = {
 
 export function global(globalConfigOverride: GlobalConfigOverride): void;
 
-export function shape<Shape = unknown, Output = unknown, Input = unknown>(
-  schema: SchemaLike<Output, Input>,
-  shaper: (value: Output) => Shape
-): Schema<Shape, Input>;
+export function shape<TShape = unknown, TInput = unknown, TOutput = unknown>(
+  schema: SchemaLike<TInput, TOutput>,
+  shaper: (value: TOutput) => TShape
+): Schema<TInput, TShape>;
 
 export function to<
-  Output = unknown,
-  Input = unknown,
-  TargetInput = unknown,
-  TargetOutput = unknown
+  TInput = unknown,
+  TOutput = unknown,
+  TTargetInput = unknown,
+  TTargetOutput = unknown
 >(
-  schema: SchemaLike<Output, Input>,
-  target: SchemaLike<TargetOutput, TargetInput>,
-  decode?: ((value: Output) => TargetInput) | undefined,
-  encode?: (value: TargetOutput) => Output
-): Schema<TargetOutput, Input>;
+  schema: SchemaLike<TInput, TOutput>,
+  target: SchemaLike<TTargetInput, TTargetOutput>,
+  decode?: ((value: TOutput) => TTargetInput) | undefined,
+  encode?: (value: TTargetOutput) => TOutput
+): Schema<TInput, TTargetOutput>;
 
-export function toJSONSchema<Output, Input>(
-  schema: SchemaLike<Output, Input>,
+export function toJSONSchema<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
   options?: {
     target?: "draft-07" | "draft-2020-12" | "openapi-3.0";
   }
 ): JSONSchema7;
-export function fromJSONSchema<Output extends JSON>(
+export function fromJSONSchema<TOutput extends JSON>(
   jsonSchema: JSONSchema7
-): Schema<Output, JSON>;
-export function extendJSONSchema<Output, Input>(
-  schema: SchemaLike<Output, Input>,
+): Schema<JSON, TOutput>;
+export function extendJSONSchema<TInput, TOutput>(
+  schema: SchemaLike<TInput, TOutput>,
   jsonSchema: JSONSchema7
-): Schema<Output, Input>;
+): Schema<TInput, TOutput>;
 /** Enables `~standard.jsonSchema`; its input/output throw before this is called. */
 export function enableStandardJSONSchema(): void;
 

--- a/packages/sury/src/S.gen.d.ts
+++ b/packages/sury/src/S.gen.d.ts
@@ -5,8 +5,11 @@ import { Error, Path, Schema } from "./S";
 /* eslint-disable */
 /* tslint:disable */
 
-export type t<Output, Input = unknown> = Schema<Output, Input>;
-export type schema<Output, Input = unknown> = Schema<Output, Input>;
+// genType fills these positionally from ReScript's `S.t<'value>`, whose single
+// param is the output type — so the order stays output-first here even though
+// `Schema` is input-first.
+export type t<TOutput, TInput = unknown> = Schema<TInput, TOutput>;
+export type schema<TOutput, TInput = unknown> = Schema<TInput, TOutput>;
 
 export type Path_t = Path;
 

--- a/packages/sury/src/base.ts
+++ b/packages/sury/src/base.ts
@@ -642,7 +642,7 @@ export const copySchema = (schema: Internal): Internal => {
   return c;
 }
 
-export const updateOutput = <Value>(schema: Internal, fn: (schema: Internal) => void): Value => {
+export const updateOutput = <TValue>(schema: Internal, fn: (schema: Internal) => void): TValue => {
   const root = copySchema(schema);
   let mut = root;
   while (mut.to !== U) {
@@ -652,7 +652,7 @@ export const updateOutput = <Value>(schema: Internal, fn: (schema: Internal) => 
   }
   // This should be the Output schema
   fn(mut);
-  return root as unknown as Value;
+  return root as unknown as TValue;
 }
 
 export const setHas = (has: Partial<Record<Tag, boolean>>, tag: Tag): void => {

--- a/packages/sury/src/builder.ts
+++ b/packages/sury/src/builder.ts
@@ -265,8 +265,8 @@ export const B_unsupportedDecode = (b: Val, from: Internal, target: Internal): n
   });
 }
 
-export const B_failWithArg = <Arg>(b: Val, fn: (arg: Arg) => ErrorDetails, arg: string): string => {
-  return `${B_embed(b, (arg: Arg) => {
+export const B_failWithArg = <TArg>(b: Val, fn: (arg: TArg) => ErrorDetails, arg: string): string => {
+  return `${B_embed(b, (arg: TArg) => {
     B_throw(fn(arg));
   })}(${arg})`;
 }

--- a/packages/sury/src/factory.ts
+++ b/packages/sury/src/factory.ts
@@ -122,8 +122,8 @@ const proxifyShapedSchema = (schema: Internal, from: string[], fromFlattened?: n
 }
 
 // @__NO_SIDE_EFFECTS__
-export const schemaShape = <Value>(schema: Internal, definer: (value: unknown) => unknown): Value => {
-  return updateOutput<Value>(schema, (mut) => {
+export const schemaShape = <TValue>(schema: Internal, definer: (value: unknown) => unknown): TValue => {
+  return updateOutput<TValue>(schema, (mut) => {
     const fromProxy = proxifyShapedSchema(mut, inputFrom);
     const definition: unknown = definer(fromProxy);
     if (definition === fromProxy) {

--- a/packages/sury/src/jsapi.ts
+++ b/packages/sury/src/jsapi.ts
@@ -159,7 +159,7 @@ export const js_refine = (
   });
 };
 
-const noop = <A>(a: A): A => a;
+const noop = <T>(a: T): T => a;
 // @__NO_SIDE_EFFECTS__
 export const js_asyncDecoderAssert = (
   schema: Internal,

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -100,7 +100,7 @@ export type JSONSchemaTypeName =
 // `Arrayable.single`/`Arrayable.array` are %identity and are dropped at call
 // sites, `Arrayable.isArray` is Array.isArray, and `Arrayable.classify` is an
 // inline Array.isArray test.
-export type JSONSchemaArrayable<Item> = Item | Item[];
+export type JSONSchemaArrayable<TItem> = TItem | TItem[];
 
 // PORT-NOTE: JSONSchema's `definition` is `@unboxed
 // Schema(t) | @as(false) Never | @as(true) Any` — at runtime a definition is

--- a/packages/sury/src/modifiers.ts
+++ b/packages/sury/src/modifiers.ts
@@ -148,13 +148,13 @@ export const getMutErrorMessage = (mut: Internal): SchemaErrorMessage => {
   return em;
 }
 
-export type TransformDefinition<Input = unknown, Output = unknown> = {
+export type TransformDefinition<TInput = unknown, TOutput = unknown> = {
   // @as("p") — parser
-  p?: (input: Input) => Output;
+  p?: (input: TInput) => TOutput;
   // @as("a") — asyncParser
-  a?: (input: Input) => Promise<Output>;
+  a?: (input: TInput) => Promise<TOutput>;
   // @as("s") — serializer
-  s?: (output: Output) => Input;
+  s?: (output: TOutput) => TInput;
 };
 
 // PORT-NOTE: `s<'output>` (the effect ctx passed to the transformer) is what
@@ -383,18 +383,18 @@ export type TupleCtx = {
   tag: (idx: number, value: unknown) => void;
 };
 
-export type Meta<Value> = {
+export type Meta<TValue> = {
   name?: string;
   title?: string;
   description?: string;
   deprecated?: boolean;
-  examples?: Value[];
+  examples?: TValue[];
   errorMessage?: SchemaErrorMessage;
 };
 
 // TODO: Better test reverse
 // @__NO_SIDE_EFFECTS__
-export const meta = <Value>(schema: Internal, data: Meta<Value>): Internal => {
+export const meta = <TValue>(schema: Internal, data: Meta<TValue>): Internal => {
   const mut = copySchema(schema);
   if (data.name !== U) {
     if (data.name === "") {

--- a/packages/sury/src/operations.ts
+++ b/packages/sury/src/operations.ts
@@ -159,8 +159,8 @@ export const isAsync = (schema: Internal): boolean => {
   }
 }
 
-export type JsResult<V> =
-  | { success: true; value: V }
+export type JsResult<TValue> =
+  | { success: true; value: TValue }
   | { success: false; error: SuryErrorRecord };
 
 export const wrapExnToFailure = (exn: unknown): JsResult<never> => {
@@ -171,7 +171,7 @@ export const wrapExnToFailure = (exn: unknown): JsResult<never> => {
   }
 }
 
-export const js_safe = <V>(fn: () => V): JsResult<V> => {
+export const js_safe = <TValue>(fn: () => TValue): JsResult<TValue> => {
   try {
     return {
       success: true,
@@ -182,10 +182,10 @@ export const js_safe = <V>(fn: () => V): JsResult<V> => {
   }
 }
 
-export const js_safeAsync = <V>(fn: () => Promise<V>): Promise<JsResult<V>> => {
+export const js_safeAsync = <TValue>(fn: () => Promise<TValue>): Promise<JsResult<TValue>> => {
   try {
     return fn().then(
-      (value): JsResult<V> => ({ success: true, value }),
+      (value): JsResult<TValue> => ({ success: true, value }),
       wrapExnToFailure
     );
   } catch (exn) {

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -26,8 +26,8 @@ import * as S from "../src/S.mjs";
 // Exact (bidirectional) type equality. expect-type's `toEqualTypeOf` can't be
 // wrapped in a generic helper and still fire at call sites, so the dual
 // Input+Output check is enforced via a required-argument constraint instead.
-type Equal<A, B> =
-  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+type Equal<TLeft, TRight> =
+  (<T>() => T extends TLeft ? 1 : 2) extends <T>() => T extends TRight ? 1 : 2
     ? true
     : false;
 

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -25,26 +25,26 @@ import * as S from "../src/S.mjs";
 
 // Exact (bidirectional) type equality. expect-type's `toEqualTypeOf` can't be
 // wrapped in a generic helper and still fire at call sites, so the dual
-// Output+Input check is enforced via a required-argument constraint instead.
+// Input+Output check is enforced via a required-argument constraint instead.
 type Equal<A, B> =
   (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
     ? true
     : false;
 
-const expectSchemaType = <Schema extends S.Schema<unknown, unknown>>(
-  _schema: Schema,
+const expectSchemaType = <TSchema extends S.Schema<unknown, unknown>>(
+  _schema: TSchema,
 ) => ({
-  toBe: <Output, Input = Output>(
-    ..._mismatch: Equal<S.Output<Schema>, Output> extends true
-      ? Equal<S.Input<Schema>, Input> extends true
+  toBe: <TInput, TOutput = TInput>(
+    ..._mismatch: Equal<S.Input<TSchema>, TInput> extends true
+      ? Equal<S.Output<TSchema>, TOutput> extends true
         ? []
-        : [input: S.Input<Schema>]
-      : [output: S.Output<Schema>]
+        : [output: S.Output<TSchema>]
+      : [input: S.Input<TSchema>]
   ) => {},
 });
 
 // Can use genType schema
-// expectSchemaType(stringSchema).toBe<string, unknown>();
+// expectSchemaType(stringSchema).toBe<unknown, string>();
 
 test("JSON string demo", (t) => {
   t.expect(S.parser(S.jsonString)("123")).toEqual("123");
@@ -101,7 +101,7 @@ test("S.pattern preserves the Input type through a transform (#282)", (t) => {
 
   t.expect(S.decoder(schema)(123)).toEqual("123");
 
-  expectSchemaType(schema).toBe<string, number>();
+  expectSchemaType(schema).toBe<number, string>();
 });
 
 test("Successfully parses string with built-in transform", (t) => {
@@ -120,7 +120,7 @@ test("Successfully parses string to Date via S.to(S.date)", (t) => {
 
   t.expect(value).toEqual(new Date("2020-01-01T00:00:00Z"));
 
-  expectSchemaType(schema).toBe<Date, string>();
+  expectSchemaType(schema).toBe<string, Date>();
   expectTypeOf(value).toEqualTypeOf<Date>();
 });
 
@@ -141,8 +141,8 @@ test("S.to returns the schema itself when the target is the same instance", (t) 
   t.expect(doubled).not.toBe(schema);
   t.expect(S.parser(doubled)("hello")).toBe(2);
 
-  expectSchemaType(schema).toBe<number, string>();
-  expectSchemaType(S.to(schema, schema)).toBe<number, string>();
+  expectSchemaType(schema).toBe<string, number>();
+  expectSchemaType(S.to(schema, schema)).toBe<string, number>();
 });
 
 test("Successfully parses string to Date with S.to", (t) => {
@@ -151,7 +151,7 @@ test("Successfully parses string to Date with S.to", (t) => {
 
   t.expect(value).toEqual(new Date("2024-01-01T00:00:00.000Z"));
 
-  expectSchemaType(schema).toBe<Date, string>();
+  expectSchemaType(schema).toBe<string, Date>();
   expectTypeOf(value).toEqualTypeOf<Date>();
 });
 
@@ -161,7 +161,7 @@ test("Successfully converts Date to string with S.to", (t) => {
 
   t.expect(value).toBe("2024-01-01T00:00:00.000Z");
 
-  expectSchemaType(schema).toBe<string, Date>();
+  expectSchemaType(schema).toBe<Date, string>();
   expectTypeOf(value).toEqualTypeOf<string>();
 });
 
@@ -293,7 +293,7 @@ test("Successfully parses JSON string", (t) => {
   t.expect(value).toEqual(true);
   t.expect(schema.type === "string" && schema.format === "json").toEqual(true);
 
-  expectSchemaType(schema).toBe<boolean, string>();
+  expectSchemaType(schema).toBe<string, boolean>();
   expectTypeOf(value).toEqualTypeOf<boolean>();
 });
 
@@ -358,10 +358,10 @@ test("Successfully serialized JSON object", (t) => {
   const valueWithSpace = S.encoder(schemaWithSpace)({ foo: [1, 2] });
   t.expect(valueWithSpace).toEqual('{\n  "foo": [\n    1,\n    2\n  ]\n}');
 
-  expectSchemaType(schema).toBe<{ foo: [1, number] }, string>();
+  expectSchemaType(schema).toBe<string, { foo: [1, number] }>();
   expectSchemaType(schema).toBe<
-    S.Output<typeof schemaWithSpace>,
-    S.Input<typeof schemaWithSpace>
+    S.Input<typeof schemaWithSpace>,
+    S.Output<typeof schemaWithSpace>
   >();
   expectTypeOf(value).toEqualTypeOf<string>();
 });
@@ -513,7 +513,7 @@ test("Successfully parses nullable of array with default", (t) => {
   t.expect(value1).toEqual(["foo"]);
   t.expect(value2).toEqual([]);
 
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string[], string[] | null>>();
+  expectTypeOf(schema).toEqualTypeOf<S.Schema<string[] | null, string[]>>();
   expectTypeOf(value1).toEqualTypeOf<string[]>();
 });
 
@@ -533,7 +533,7 @@ test("Successfully parses nullable string with default", (t) => {
     }),
   );
 
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string, string | null>>();
+  expectTypeOf(schema).toEqualTypeOf<S.Schema<string | null, string>>();
   expectTypeOf(value1).toEqualTypeOf<string>();
 });
 
@@ -545,7 +545,7 @@ test("Successfully parses nullable string with dynamic default", (t) => {
   t.expect(value1).toEqual("foo");
   t.expect(value2).toEqual("bar");
 
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string, string | null>>();
+  expectTypeOf(schema).toEqualTypeOf<S.Schema<string | null, string>>();
   expectTypeOf(value1).toEqualTypeOf<string>();
 });
 
@@ -929,8 +929,8 @@ test("Successfully parses object with field names transform", (t) => {
   });
 
   expectSchemaType(schema).toBe<
-    { foo: string; bar: boolean },
-    Record<string, unknown>
+    Record<string, unknown>,
+    { foo: string; bar: boolean }
   >();
   expectTypeOf(value).toEqualTypeOf<{ foo: string; bar: boolean }>();
 });
@@ -963,8 +963,8 @@ test("Successfully parses advanced object with all features", (t) => {
   });
 
   expectSchemaType(schema).toBe<
-    { nested: number; flattened: { id: string }; foo: string; bar: boolean },
-    Record<string, unknown>
+    Record<string, unknown>,
+    { nested: number; flattened: { id: string }; foo: string; bar: boolean }
   >();
 });
 
@@ -984,8 +984,8 @@ test("Successfully parses object with transformed field", (t) => {
   });
 
   expectSchemaType(schema).toBe<
-    { foo: number; bar: boolean },
-    { foo: string; bar: boolean }
+    { foo: string; bar: boolean },
+    { foo: number; bar: boolean }
   >();
   expectTypeOf(value).toEqualTypeOf<{ foo: number; bar: boolean }>();
 });
@@ -1104,11 +1104,11 @@ test("Fails to parse intersected objects with transform", (t) => {
   );
 
   // expectSchemaType(schema).toBe<
+  //   Record<string, unknown>,
   //   {
   //     abc: string;
   //     baz: string;
-  //   },
-  //   Record<string, unknown>
+  //   }
   // >();
 
   // const result = S.safe(() =>
@@ -1441,12 +1441,12 @@ test("Successfully parses union with transformed items", (t) => {
 
   t.expect(value).toEqual({ success: true, value: 123 });
 
-  expectSchemaType(schema).toBe<number, string | number>();
+  expectSchemaType(schema).toBe<string | number, number>();
 });
 
 test("Correctly infers type", (t) => {
   const schema = S.string.with(S.to, S.number, Number);
-  expectSchemaType(schema).toBe<number, string>();
+  expectSchemaType(schema).toBe<string, number>();
   expectTypeOf<S.Input<typeof schema>>().toEqualTypeOf<string>();
   expectTypeOf<S.Output<typeof schema>>().toEqualTypeOf<number>();
 });
@@ -1460,7 +1460,7 @@ test("Successfully parses undefined using the default value", (t) => {
   t.expect(schema.default).toEqual("foo");
 
   expectTypeOf(schema.default).toEqualTypeOf<string | undefined>();
-  expectSchemaType(schema).toBe<string, string | undefined>();
+  expectSchemaType(schema).toBe<string | undefined, string>();
 });
 
 test("Successfully parses undefined using the default value for transformed schema", (t) => {
@@ -1474,7 +1474,7 @@ test("Successfully parses undefined using the default value for transformed sche
   t.expect(schema.default).toEqual(false);
 
   expectTypeOf(schema.default).toEqualTypeOf<boolean | undefined>();
-  expectSchemaType(schema).toBe<string, boolean | undefined>();
+  expectSchemaType(schema).toBe<boolean | undefined, string>();
 });
 
 test("Successfully parses undefined using the default value from callback", (t) => {
@@ -1487,7 +1487,7 @@ test("Successfully parses undefined using the default value from callback", (t) 
 
   //FIXME: This is broken
   // @ts-expect-error
-  expectSchemaType(schema).toBe<string, string | undefined>();
+  expectSchemaType(schema).toBe<string | undefined, string>();
 });
 
 test("Creates schema with description and title", (t) => {
@@ -1552,7 +1552,7 @@ test("Tuple with single element", (t) => {
 
   t.expect(S.parser(schema)(["123"])).toEqual([123]);
 
-  expectSchemaType(schema).toBe<[number], [string]>();
+  expectSchemaType(schema).toBe<[string], [number]>();
 });
 
 test("Tuple with multiple elements", (t) => {
@@ -1664,7 +1664,7 @@ test("Standard JSON Schema interface support", (t) => {
 });
 
 test("Env schema: Reggression version", (t) => {
-  const env = <T>(schema: S.Schema<T>): S.Schema<T, string> => {
+  const env = <T>(schema: S.Schema<unknown, T>): S.Schema<string, T> => {
     if (schema.type === "boolean") {
       return S.union([
         S.schema("t").with(S.to, S.schema(true)).with(S.to, schema),
@@ -1789,7 +1789,7 @@ test("Set schema", (t) => {
 });
 
 test("Full Set schema", (t) => {
-  const mySet = <T>(itemSchema: S.Schema<T>): S.Schema<Set<T>> =>
+  const mySet = <T>(itemSchema: S.Schema<unknown, T>): S.Schema<unknown, Set<T>> =>
     S.instance(Set<unknown>)
       .with(S.to, S.instance(Set<T>), (input) => {
         const output = new Set<T>();
@@ -1811,7 +1811,7 @@ test("Full Set schema", (t) => {
 
   const numberSetSchema = mySet(S.number);
 
-  expectSchemaType(numberSetSchema).toBe<Set<number>, unknown>();
+  expectSchemaType(numberSetSchema).toBe<unknown, Set<number>>();
 
   t.expect(S.parser(numberSetSchema)(new Set([1, 2, 3]))).toEqual(
     new Set([1, 2, 3]),
@@ -1836,7 +1836,7 @@ test("Coerce string to number", (t) => {
 
   t.expect(schema.to).toBe(S.number);
 
-  expectSchemaType(schema).toBe<number, string>();
+  expectSchemaType(schema).toBe<string, number>();
   expectTypeOf(schema.to).toEqualTypeOf<S.Schema<unknown> | undefined>();
 
   t.expect(S.parser(schema)("123")).toEqual(123);
@@ -1862,7 +1862,7 @@ test("Tuple with transform to object", (t) => {
 
   t.expect(S.parser(pointSchema)(["point", 1, -4])).toEqual({ x: 1, y: -4 });
 
-  expectSchemaType(pointSchema).toBe<{ x: number; y: number }, unknown[]>();
+  expectSchemaType(pointSchema).toBe<unknown[], { x: number; y: number }>();
 });
 
 test("Assert throws with invalid data", (t) => {
@@ -1968,7 +1968,7 @@ test("Assert throws a Sury error for null/undefined data in both arg orders", (t
 });
 
 test("Schema of object with empty prototype", (t) => {
-  const obj = Object.create(null) as { foo: S.Schema<string, string> };
+  const obj = Object.create(null) as { foo: S.Schema<string> };
   obj.foo = S.string;
   const schema = S.schema(obj);
 
@@ -2021,12 +2021,12 @@ test("Mutually recursive objects", (t) => {
     author: User;
   };
 
-  const makeUserSchema = (postSchema: S.Schema<Post>) =>
+  const makeUserSchema = (postSchema: S.Schema<unknown, Post>) =>
     S.schema({
       email: S.string,
       posts: S.array(postSchema),
     });
-  const makePostSchema = (userSchema: S.Schema<User>) =>
+  const makePostSchema = (userSchema: S.Schema<unknown, User>) =>
     S.schema({
       Title: S.string,
       Author: userSchema,
@@ -2035,19 +2035,19 @@ test("Mutually recursive objects", (t) => {
       author: post.Author,
     }));
 
-  const userSchema = S.recursive<User>("User", (userSchema) =>
+  const userSchema = S.recursive<unknown, User>("User", (userSchema) =>
     makeUserSchema(
-      S.recursive<Post>("Post", (_) => makePostSchema(userSchema)),
+      S.recursive<unknown, Post>("Post", (_) => makePostSchema(userSchema)),
     ),
   );
-  const postSchema = S.recursive<Post>("Post", (postSchema) =>
+  const postSchema = S.recursive<unknown, Post>("Post", (postSchema) =>
     makePostSchema(
-      S.recursive<User>("User", (_) => makeUserSchema(postSchema)),
+      S.recursive<unknown, User>("User", (_) => makeUserSchema(postSchema)),
     ),
   );
 
-  expectSchemaType(userSchema).toBe<User, unknown>();
-  expectSchemaType(postSchema).toBe<Post, unknown>();
+  expectSchemaType(userSchema).toBe<unknown, User>();
+  expectSchemaType(postSchema).toBe<unknown, Post>();
 
   t.expect(
     S.parser(userSchema)({
@@ -2075,7 +2075,7 @@ test("Recursive object with S.shape", (t) => {
     children: Node[];
   };
 
-  let nodeSchema = S.recursive<Node>("Node", (nodeSchema) =>
+  let nodeSchema = S.recursive<unknown, Node>("Node", (nodeSchema) =>
     S.schema({
       ID: S.string,
       CHILDREN: S.array(nodeSchema),
@@ -2085,7 +2085,7 @@ test("Recursive object with S.shape", (t) => {
     })),
   );
 
-  expectSchemaType(nodeSchema).toBe<Node, unknown>();
+  expectSchemaType(nodeSchema).toBe<unknown, Node>();
 
   t.expect(
     S.parser(nodeSchema)({
@@ -2108,10 +2108,10 @@ test("Recursive with self as transform target", (t) => {
   type Node = Node[];
 
   t.expect(() => {
-    let nodeSchema = S.recursive<Node, string>("Node", (self) =>
+    let nodeSchema = S.recursive<string, Node>("Node", (self) =>
       S.string.with(S.to, S.array(self)),
     );
-    expectSchemaType(nodeSchema).toBe<Node, string>();
+    expectSchemaType(nodeSchema).toBe<string, Node>();
 
     t.expect(S.parser(nodeSchema)(`["[]","[]"]`)).toEqual([[], []]);
   }).toThrow(
@@ -2142,7 +2142,7 @@ test("Port schema", (t) => {
   );
 
   const portCoercedFromString = S.string.with(S.to, S.port);
-  expectSchemaType(portCoercedFromString).toBe<number, string>();
+  expectSchemaType(portCoercedFromString).toBe<string, number>();
 
   if (portCoercedFromString.type === "string") {
     t.expect(portCoercedFromString.format).toEqual(undefined);
@@ -2400,7 +2400,7 @@ test("Example of transformed schema", (t) => {
 test("Brand", (t) => {
   const schema = S.string.with(S.brand, "Foo");
   type Foo = S.Infer<typeof schema>;
-  expectSchemaType(schema).toBe<S.Brand<string, "Foo">, string>();
+  expectSchemaType(schema).toBe<string, S.Brand<string, "Foo">>();
   const result = S.parser(schema)("hello");
   assertType<S.Brand<string, "Foo">>(result);
   t.expect(result).toEqual("hello");
@@ -2415,7 +2415,7 @@ test("fromJSONSchema", (t) => {
     type: "string",
     format: "email",
   });
-  expectSchemaType(emailSchema).toBe<string, S.JSON>();
+  expectSchemaType(emailSchema).toBe<S.JSON, string>();
   const result = S.safe(() => S.assert(emailSchema, "example.com"));
 
   t.expect(result.error?.message).toBe(
@@ -2561,10 +2561,10 @@ test("Compile types", async (t) => {
 });
 
 test("Preprocess nested fields", (t) => {
-  const stripPrefix = <Input>(
-    schema: S.Schema<string, Input>,
+  const stripPrefix = <TInput>(
+    schema: S.Schema<TInput, string>,
     prefix: string,
-  ): S.Schema<string, Input> =>
+  ): S.Schema<TInput, string> =>
     S.to(
       schema,
       S.string,
@@ -2669,7 +2669,9 @@ test("Union of dynamic enum as const", (t) => {
 test("Overwrite error message", (t) => {
   const schema = S.string.with(S.min, 3, "Invalid string");
 
-  const fieldSchema = <O, I>(schema: S.Schema<O, I>): S.Schema<O, I> => {
+  const fieldSchema = <TInput, TOutput>(
+    schema: S.Schema<TInput, TOutput>,
+  ): S.Schema<TInput, TOutput> => {
     return S.any.with(S.to, schema, (v) => {
       try {
         S.assert(schema, v);

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -1985,7 +1985,9 @@ test("Successfully parses recursive object", (t) => {
     children: Node[];
   };
 
-  let nodeSchema = S.recursive<Node, Node>("Node", (nodeSchema) =>
+  // The one-arg form relies on `TOutput = TInput` — keep it compiling for
+  // identity recursion even if the signature changes.
+  let nodeSchema = S.recursive<Node>("Node", (nodeSchema) =>
     S.schema({
       id: S.string,
       children: S.array(nodeSchema),

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -259,7 +259,7 @@ test("identity claimed but the operation doesn't actually compile to identity", 
         input: string
         output: string
     -   instantiations: 254
-    +   instantiations: 5181
+    +   instantiations: 5160
       vs:
         zod: z.string()
       jsonSchema:
@@ -332,7 +332,7 @@ test("eq-to-parse claimed but the operation doesn't actually compile to the same
     -   instantiations: 254
     +   input: string
     +   output: string
-    +   instantiations: 5181
+    +   instantiations: 5160
       vs:
         zod: z.never()
       jsonSchema:


### PR DESCRIPTION
Rename all generic type parameters across the codebase to use a consistent `T` prefix convention (e.g., `TInput`, `TOutput`, `TSchema` instead of `Input`, `Output`, `Schema`), making generic parameters visually distinct from concrete types.

## ⚠️ Breaking change

This PR also flips the public `Schema` type parameter order from `Schema<Output, Input = unknown>` to **`Schema<TInput = unknown, TOutput = TInput>`**, so type parameters read in the direction data flows — input first, output second. The generic order of every public signature (`S.recursive`, `S.brand`, `S.to`, `S.shape`, operations, modifiers) is flipped to match. Runtime behavior is unchanged; this is a types-only, semver-major change.

### Migration

- `S.Schema<A, B>` annotations: swap the arguments — the old order compiles but means the opposite, so existing two-arg annotations must be updated by hand.
- "Any schema producing `T`" is now spelled `S.Schema<unknown, T>` (previously `S.Schema<T>`).
- `S.Schema<T>` now means `S.Schema<T, T>` — identity-schema annotations keep working unchanged.
- `S.recursive<T>` keeps working for identity (non-transforming) recursion thanks to the `TOutput = TInput` default; transformed recursion takes both parameters in the new input-first order: `S.recursive<Input, Output>`.
- Explicit type arguments elsewhere were previously all-or-nothing with no defaults, so inferred call sites (the norm) are unaffected.

## Changes

- **Type definitions (`S.d.ts`)**: Updated all generic parameters in `StandardSchemaV1`, `StandardTypedV1`, `StandardJSONSchemaV1`, `Schema`, and utility types to use `T` prefix; flipped `Schema` and `SchemaLike` to input-first order
- **Function signatures**: Renamed and reordered parameters in `brand()`, `parser()`, `decoder()`, `encoder()`, `assert()`, `is()`, and other public APIs
- **Internal types**: Updated helper types like `SchemaLike`, `ExtractFirstInput`, `ExtractLastOutput`, `ResolveObject`, and conditional type inference utilities
- **genType shim (`S.gen.d.ts`)**: stays output-first positionally (ReScript's `S.t<'value>` single param is the output) and adapts inside the alias
- **Test files**: Updated type assertions to the new order; added coverage locking the one-arg `S.recursive<T>` form
- **Documentation**: Updated `js-usage.md` and `README.md` to the new parameter order, documented the `S.Schema<Input, Output>` convention and both `S.recursive` forms
- **Specs**: Refreshed type instantiation counts (uniformly −21 per spec from the reworked `with` overloads)

https://claude.ai/code/session_01QmyFpB7Aeqi2wt4d36bpSj

## Summary by CodeRabbit

- **Documentation**
  - Updated JavaScript API and README guidance to consistently describe schema types as input first and output second.
  - Added clearer examples for annotations, parsing, encoding, assertions, type guards, and transformations.

- **Refactor**
  - Standardized public schema-related type signatures across the API for consistent input/output ordering.
  - Preserved compatibility for generated type aliases and runtime behavior.

- **Tests**
  - Updated type-level expectations and validation snapshots to reflect the corrected schema typing.
  - Refreshed recorded TypeScript instantiation counts across codec and union specifications.