### PR TITLE
Reuse sibling bindings in mutually recursive groups

### DIFF
--- a/packages/e2e/src/ppx/Ppx_Recursive_test.res
+++ b/packages/e2e/src/ppx/Ppx_Recursive_test.res
@@ -69,6 +69,18 @@ test("Three-way mutual cycle works from every entry point", t => {
 })
 
 @schema
+type rec root = {mid: option<mid>, last: option<last>}
+@schema
+and mid = {tail: option<last>}
+@schema
+and last = {back: option<root>}
+test("A sibling needed by several members is bound once and reused", t => {
+  t->assertReverseParsesBack(rootSchema, {mid: Some({tail: Some({back: None})}), last: None})
+  t->assertReverseParsesBack(midSchema, {tail: Some({back: Some({mid: None, last: None})})})
+  t->assertReverseParsesBack(lastSchema, {back: Some({mid: None, last: Some({back: None})})})
+})
+
+@schema
 type rec leaf = {name: string}
 @schema
 and holder = {leaf: leaf, next: option<holder>}

--- a/packages/e2e/src/ppx/Ppx_Recursive_test.res.mjs
+++ b/packages/e2e/src/ppx/Ppx_Recursive_test.res.mjs
@@ -265,6 +265,76 @@ Vitest$1.test("Three-way mutual cycle works from every entry point", t => {
   });
 });
 
+let rootSchema = Sury.recursive("root", rootSchema => {
+  let lastSchema = Sury.recursive("last", lastSchema => Sury.$res_schema(s => ({
+    back: s.m(Sury.$res_option(rootSchema))
+  })));
+  let midSchema = Sury.recursive("mid", midSchema => Sury.$res_schema(s => ({
+    tail: s.m(Sury.$res_option(lastSchema))
+  })));
+  return Sury.$res_schema(s => ({
+    mid: s.m(Sury.$res_option(midSchema)),
+    last: s.m(Sury.$res_option(lastSchema))
+  }));
+});
+
+let midSchema = Sury.recursive("mid", midSchema => {
+  let lastSchema = Sury.recursive("last", lastSchema => {
+    let rootSchema = Sury.recursive("root", rootSchema => Sury.$res_schema(s => ({
+      mid: s.m(Sury.$res_option(midSchema)),
+      last: s.m(Sury.$res_option(lastSchema))
+    })));
+    return Sury.$res_schema(s => ({
+      back: s.m(Sury.$res_option(rootSchema))
+    }));
+  });
+  return Sury.$res_schema(s => ({
+    tail: s.m(Sury.$res_option(lastSchema))
+  }));
+});
+
+let lastSchema = Sury.recursive("last", lastSchema => {
+  let rootSchema = Sury.recursive("root", rootSchema => {
+    let midSchema = Sury.recursive("mid", midSchema => Sury.$res_schema(s => ({
+      tail: s.m(Sury.$res_option(lastSchema))
+    })));
+    return Sury.$res_schema(s => ({
+      mid: s.m(Sury.$res_option(midSchema)),
+      last: s.m(Sury.$res_option(lastSchema))
+    }));
+  });
+  return Sury.$res_schema(s => ({
+    back: s.m(Sury.$res_option(rootSchema))
+  }));
+});
+
+Vitest$1.test("A sibling needed by several members is bound once and reused", t => {
+  U.assertReverseParsesBack(t, rootSchema, {
+    mid: {
+      tail: {
+        back: undefined
+      }
+    },
+    last: undefined
+  });
+  U.assertReverseParsesBack(t, midSchema, {
+    tail: {
+      back: {
+        mid: undefined,
+        last: undefined
+      }
+    }
+  });
+  U.assertReverseParsesBack(t, lastSchema, {
+    back: {
+      mid: undefined,
+      last: {
+        back: undefined
+      }
+    }
+  });
+});
+
 let leafSchema = Sury.$res_schema(s => ({
   name: s.m(Sury.string)
 }));
@@ -359,6 +429,9 @@ export {
   aSchema,
   bSchema,
   cSchema,
+  rootSchema,
+  midSchema,
+  lastSchema,
   leafSchema,
   holderSchema,
   strictNodeSchema,

--- a/packages/sury-ppx/README.md
+++ b/packages/sury-ppx/README.md
@@ -157,6 +157,20 @@ type rec expr = Num(int) | Block(array<stmt>)
 and stmt = {label: string, body: expr}
 ```
 
+A few things to know about mutually recursive groups:
+
+- Every schema of the group is a separate entry point, so each generated
+  binding carries its own copy of the group inside its `S.recursive` callback
+  (the runtime resolves them through shared `$defs`). Generated code grows with
+  the group size, and the schemas don't share compiled instances — groups of
+  more than 4 types are rejected; write those by hand with `S.recursive`.
+- Every member referenced from another `@schema` member needs `@schema` too —
+  otherwise the generated code refers to a `<name>Schema` binding that only
+  exists if you've defined it by hand earlier in scope.
+- Inside the group, an identifier like `nodeSchema` (for example in an
+  `@s.matches` payload) resolves to the schema being defined, shadowing any
+  earlier binding with the same name.
+
 Recursive types with type parameters are not supported yet — write those by hand
 with `S.recursive`.
 

--- a/packages/sury-ppx/README.md
+++ b/packages/sury-ppx/README.md
@@ -159,16 +159,12 @@ and stmt = {label: string, body: expr}
 
 A few things to know about mutually recursive groups:
 
-- Every schema of the group is a separate entry point, so each generated
-  binding carries its own copy of the group inside its `S.recursive` callback
-  (the runtime resolves them through shared `$defs`). Generated code grows with
-  the group size, and the schemas don't share compiled instances — groups of
-  more than 4 types are rejected; write those by hand with `S.recursive`.
+- Generated code grows with the group size, so groups of more than 4 types are
+  rejected — write those by hand with `S.recursive`.
 - Every member referenced from another `@schema` member needs `@schema` too —
-  otherwise the generated code refers to a `<name>Schema` binding that only
-  exists if you've defined it by hand earlier in scope.
+  or a hand-written `<name>Schema` binding earlier in scope.
 - Inside the group, an identifier like `nodeSchema` (for example in an
-  `@s.matches` payload) resolves to the schema being defined, shadowing any
+  `@s.matches` payload) refers to the schema being defined, shadowing any
   earlier binding with the same name.
 
 Recursive types with type parameters are not supported yet — write those by hand

--- a/packages/sury-ppx/src/ppx/Structure.ml
+++ b/packages/sury-ppx/src/ppx/Structure.ml
@@ -560,8 +560,11 @@ let referencedMembers members expr =
 (* Each member of a mutually recursive group re-expands the others inside its own
    S.recursive callback. A nested S.recursive registers into the enclosing call's
    shared $defs, so the copies resolve each other's $refs — but only the
-   outermost call carries $defs, so a binding cannot borrow a sibling's and each
-   needs its own expansion. Duplicated bodies are the cost; the group size cap
+   outermost call carries $defs, so a top-level binding cannot borrow another
+   top-level binding's copy and each entry point needs its own expansion.
+   Within one callback, sibling bindings are ordered so an expansion reuses an
+   already-bound sibling instead of expanding its own copy; the duplication that
+   remains is one expansion of the group per entry point, and the group size cap
    below keeps it bounded. *)
 let maxMutualGroupSize = 4
 
@@ -579,16 +582,27 @@ let mapRecursiveTypeDeclarations decls =
     in
     let declOf name = fst (List.assoc name generated) in
     let bodyOf name = snd (List.assoc name generated) in
-    let directDeps name = referencedMembers members (bodyOf name) in
-    let reachable name =
+    let directDepsByName =
+      members
+      |> List.map (fun name -> (name, referencedMembers members (bodyOf name)))
+    in
+    let directDeps name = List.assoc name directDepsByName in
+    (* Members whose expansion `name` still needs, given that `blocked` ones are
+       already bound in scope: a path through a bound member forces nothing,
+       because the reference resolves to the existing binding. *)
+    let reachableAvoiding blocked name =
       let rec collect visited = function
         | [] -> visited
         | n :: rest ->
-          if List.mem n visited then collect visited rest
+          if List.mem n visited || List.mem n blocked then collect visited rest
           else collect (n :: visited) (directDeps n @ rest)
       in
       collect [] (directDeps name)
     in
+    let reachableByName =
+      members |> List.map (fun name -> (name, reachableAvoiding [] name))
+    in
+    let reachable name = List.assoc name reachableByName in
     let sameGroup a b =
       a = b || (List.mem b (reachable a) && List.mem a (reachable b))
     in
@@ -616,9 +630,35 @@ let mapRecursiveTypeDeclarations decls =
         in
         match ready with
         (* Unreachable: groups are cycles collapsed to a point, so what is left
-           is a DAG and something is always ready. Emit rather than loop. *)
-        | [] -> remaining
+           is a DAG and something is always ready. If this ever fires, emitting
+           anyway would miscompile into "unbound value" errors in generated
+           code, so fail loudly instead. *)
+        | [] ->
+          fail (declOf (List.hd (List.hd remaining))).ptype_loc
+            "sury-ppx internal error: failed to order recursive type groups. \
+             Please report the issue to https://github.com/DZakh/sury/issues"
         | _ -> ready @ topological (emitted @ List.concat ready) blocked)
+    in
+    (* Order sibling bindings innermost-first: a dep that other pending deps
+       still need goes later, and later deps end up as *outer* `let`s, in scope
+       for the earlier ones — so an expansion reuses the sibling binding instead
+       of expanding its own copy (which would also re-register the same $defs
+       entry). Cyclic siblings stay put; nested expansion resolves them. *)
+    let rec orderDeps ~blocked deps =
+      match deps with
+      | [] -> []
+      | _ -> (
+        let inner, rest =
+          deps
+          |> List.partition (fun d ->
+                 deps
+                 |> List.for_all (fun other ->
+                        other = d
+                        || not (List.mem d (reachableAvoiding blocked other))))
+        in
+        match inner with
+        | [] -> deps
+        | _ -> inner @ orderDeps ~blocked rest)
     in
     let rec expand ~group ~in_scope name =
       let in_scope = name :: in_scope in
@@ -630,16 +670,20 @@ let mapRecursiveTypeDeclarations decls =
         directDeps name
         |> List.filter (fun dep ->
                List.mem dep group && not (List.mem dep in_scope))
+        |> orderDeps ~blocked:in_scope
       in
-      wrapRecursive (declOf name)
-        (List.fold_left
-           (fun acc dep ->
-             Exp.let_ Nonrecursive
+      let rec bind body = function
+        | [] -> body
+        | dep :: outer ->
+          bind
+            (Exp.let_ Nonrecursive
                [ Vb.mk
                    (Pat.var (mknoloc (generateSchemaName dep)))
-                   (expand ~group ~in_scope dep) ]
-               acc)
-           (bodyOf name) deps)
+                   (expand ~group ~in_scope:(outer @ in_scope) dep) ]
+               body)
+            outer
+      in
+      wrapRecursive (declOf name) (bind (bodyOf name) deps)
     in
     topological [] groups
     |> List.map (fun group ->

--- a/packages/sury-ppx/src/ppx/Structure.ml
+++ b/packages/sury-ppx/src/ppx/Structure.ml
@@ -485,11 +485,9 @@ let generateSchemaValueBinding type_name ptype_params schema_expr =
     fail (fst (List.hd ptype_params)).ptyp_loc
       "Parametrized types with more than one type parameter are not supported yet"
 
-(* The schema expression for one declaration, without its value binding: the
-   recursive wrapper has to apply the type-level @s.* attributes *inside* its
-   callback, so that the definition registered under $defs — the one every
-   self-reference resolves to — is the transformed schema rather than the bare
-   one. *)
+(* Applies type-level @s.* attributes inside the body, so a recursive wrapper
+   registers the transformed schema — the one self-references resolve to —
+   rather than the bare one. *)
 let generateDeclarationSchemaExpression type_declaration =
   let {ptype_attributes; ptype_name = {txt = type_name}; ptype_loc; ptype_params}
       =
@@ -514,11 +512,9 @@ let mapTypeDeclaration type_declaration =
         (generateDeclarationSchemaExpression type_declaration) ]
   else []
 
-(* Bind the S.recursive placeholder under exactly the name a self-reference
-   already compiles to, so recursion resolves by ordinary shadowing and nothing
-   has to rewrite the body. That is also why a `nodeSchema` written by hand
-   inside an @s.matches payload picks up the placeholder like a generated
-   reference does. *)
+(* The placeholder is bound under the exact name a self-reference compiles to,
+   so recursion resolves by shadowing — including hand-written references in
+   @s.matches payloads. *)
 let wrapRecursive {ptype_name = {txt = type_name}; ptype_loc} body =
   let param_pat =
     Pat.constraint_
@@ -532,11 +528,9 @@ let wrapRecursive {ptype_name = {txt = type_name}; ptype_loc} body =
         uncurriedFun ~loc:ptype_loc ~arity:1
           (Exp.fun_ Nolabel None param_pat body)]]
 
-(* Which of `members` the generated expression mentions. Reading the emitted
-   code rather than the source type is what lets @s.matches payloads count: a
-   hand-written reference has to end up in scope just like a generated one, and
-   conversely a field whose schema comes entirely from @s.matches contributes no
-   dependency even though its type names a group member. *)
+(* Which of `members` the generated expression mentions. Scans the emitted code
+   rather than the source type, so hand-written @s.matches references count as
+   dependencies and a field fully replaced by @s.matches contributes none. *)
 let referencedMembers members expr =
   let found = ref [] in
   let scanner =
@@ -557,15 +551,10 @@ let referencedMembers members expr =
   scanner#expression expr;
   !found
 
-(* Each member of a mutually recursive group re-expands the others inside its own
-   S.recursive callback. A nested S.recursive registers into the enclosing call's
-   shared $defs, so the copies resolve each other's $refs — but only the
-   outermost call carries $defs, so a top-level binding cannot borrow another
-   top-level binding's copy and each entry point needs its own expansion.
-   Within one callback, sibling bindings are ordered so an expansion reuses an
-   already-bound sibling instead of expanding its own copy; the duplication that
-   remains is one expansion of the group per entry point, and the group size cap
-   below keeps it bounded. *)
+(* Only the outermost S.recursive call carries $defs, so each entry point of a
+   mutual group re-expands the whole group inside its own callback — nested
+   calls register into the shared $defs. One expansion per entry point is the
+   cost; the cap keeps it bounded. *)
 let maxMutualGroupSize = 4
 
 let mapRecursiveTypeDeclarations decls =
@@ -573,8 +562,7 @@ let mapRecursiveTypeDeclarations decls =
   | [] -> []
   | annotated ->
     let members = annotated |> List.map (fun d -> d.ptype_name.txt) in
-    (* Bodies are generated once and shared: they are immutable and generating
-       them twice would repeat the work for every copy in a mutual expansion. *)
+    (* Bodies are generated once and reused by every copy in a mutual expansion. *)
     let generated =
       annotated
       |> List.map (fun d ->
@@ -587,9 +575,8 @@ let mapRecursiveTypeDeclarations decls =
       |> List.map (fun name -> (name, referencedMembers members (bodyOf name)))
     in
     let directDeps name = List.assoc name directDepsByName in
-    (* Members whose expansion `name` still needs, given that `blocked` ones are
-       already bound in scope: a path through a bound member forces nothing,
-       because the reference resolves to the existing binding. *)
+    (* Transitive deps of `name`, not crossing `blocked` members — a reference
+       to a member already bound in scope forces no expansion behind it. *)
     let reachableAvoiding blocked name =
       let rec collect visited = function
         | [] -> visited
@@ -614,7 +601,7 @@ let mapRecursiveTypeDeclarations decls =
         [] members
     in
     (* Emit groups dependencies-first: a member that merely *uses* another one
-       binds against its top-level schema, so that binding has to come first. *)
+       binds against its already-emitted top-level schema. *)
     let rec topological emitted remaining =
       match remaining with
       | [] -> []
@@ -629,21 +616,18 @@ let mapRecursiveTypeDeclarations decls =
                                List.mem dep group || List.mem dep emitted)))
         in
         match ready with
-        (* Unreachable: groups are cycles collapsed to a point, so what is left
-           is a DAG and something is always ready. If this ever fires, emitting
-           anyway would miscompile into "unbound value" errors in generated
-           code, so fail loudly instead. *)
+        (* Unreachable — groups are collapsed cycles, so the rest is a DAG.
+           Fail loudly rather than emit unresolvable bindings. *)
         | [] ->
           fail (declOf (List.hd (List.hd remaining))).ptype_loc
             "sury-ppx internal error: failed to order recursive type groups. \
              Please report the issue to https://github.com/DZakh/sury/issues"
         | _ -> ready @ topological (emitted @ List.concat ready) blocked)
     in
-    (* Order sibling bindings innermost-first: a dep that other pending deps
-       still need goes later, and later deps end up as *outer* `let`s, in scope
-       for the earlier ones — so an expansion reuses the sibling binding instead
-       of expanding its own copy (which would also re-register the same $defs
-       entry). Cyclic siblings stay put; nested expansion resolves them. *)
+    (* A dep that other pending deps need goes later: later deps become *outer*
+       `let`s, in scope for earlier ones, so an expansion reuses the sibling
+       binding instead of duplicating it (and its $defs entry). Cyclic siblings
+       stay put; nested expansion resolves them. *)
     let rec orderDeps ~blocked deps =
       match deps with
       | [] -> []
@@ -662,10 +646,8 @@ let mapRecursiveTypeDeclarations decls =
     in
     let rec expand ~group ~in_scope name =
       let in_scope = name :: in_scope in
-      (* Only direct dependencies get a binding: an indirect one is bound by
-         whichever expansion actually references it, and binding it here too
-         would emit an unused `let` — which projects that build warnings as
-         errors reject. *)
+      (* Only direct deps get a binding — an indirect one is bound by the
+         expansion that references it; here it would be an unused `let`. *)
       let deps =
         directDeps name
         |> List.filter (fun dep ->


### PR DESCRIPTION
When generating code for mutually recursive type groups, the PPX now orders sibling bindings to enable reuse. Previously, each member's expansion would include its own copy of all dependencies, leading to unnecessary duplication. Now, when a sibling binding is already in scope, subsequent members reference it instead of expanding their own copy.

## Key changes

- **Sibling binding reordering**: Added `orderDeps` function that sorts dependencies innermost-first, so members that other pending members depend on are bound as outer `let`s and available for reuse.
- **Reachability tracking**: Introduced `reachableAvoiding` to compute which members still need expansion given that some are already bound in scope. A path through a bound member forces nothing since the reference resolves to the existing binding.
- **Improved error handling**: Changed the topological sort to fail loudly with a clear error message if it encounters an impossible state, rather than silently emitting incorrect code.
- **Test coverage**: Added a test case demonstrating the optimization with a three-member group where one member (`last`) is needed by two others (`root` and `mid`).

## Implementation details

The optimization works by:
1. Computing direct dependencies for each member upfront
2. When expanding a member, filtering its direct dependencies to only those in the current group and not yet in scope
3. Ordering those dependencies so members needed by other pending members come later (become outer bindings)
4. Passing the growing `in_scope` list through the recursion so later expansions can reference earlier bindings

This reduces generated code size for mutually recursive groups while maintaining correctness through the runtime's shared `$defs` mechanism.

https://claude.ai/code/session_01FfAjn2kb1UWMvxVLTrrjJM