### PR TITLE
Ship per-format type declarations for ESM and CJS

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -19,5 +19,8 @@
     "valibot": "1.4.2",
     "zod": "4.4.3",
     "@sinclair/typebox": "0.34.52"
+  },
+  "devDependencies": {
+    "typescript": "5.8.3"
   }
 }

--- a/packages/sury/index.d.mts
+++ b/packages/sury/index.d.mts
@@ -1,5 +1,5 @@
 // Types for the generated index.mjs (TS resolves .mjs imports to .d.mts).
-// Dev tree only: in-repo importers reach index.mjs by path, while consumers of
-// the artifact resolve through the "." export's `types` condition — so this
-// file is deliberately absent from scripts/pack.ts's sourcePaths.
+// Shipped in the artifact too: that package is `type: "commonjs"`, so typing
+// its ESM entry with the lone index.d.ts would hand node16 resolution a CJS
+// declaration for an ESM file — hence the import condition's own `types`.
 export * from "./index.js";

--- a/packages/sury/scripts/pack.ts
+++ b/packages/sury/scripts/pack.ts
@@ -34,7 +34,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const projectPath = path.join(__dirname, "..");
 const repoRootPath = path.join(projectPath, "../..");
 const artifactsPath = path.join(projectPath, "artifacts");
-const sourcePaths = ["package.json", "src", "index.d.ts", "rescript.json", "README.md"];
+const sourcePaths = ["package.json", "src", "index.d.ts", "index.d.mts", "rescript.json", "README.md"];
 // Sury's user-facing docs live at the repo root, next to the README they link
 // from; LICENSE has to sit in the packed root for npm to pick it up.
 const repoRootPaths = ["LICENSE", "docs"];
@@ -166,18 +166,19 @@ async function pack(): Promise<void> {
     pkg.main = "./index.js";
     pkg.module = "./index.mjs";
     pkg.types = "./index.d.ts";
-    // TypeScript only honors "types" when it precedes the runtime conditions.
+    // Per-format declarations: the package is commonjs, so a lone index.d.ts
+    // would type the ESM entry as CJS under node16 resolution. TypeScript only
+    // honors "types" when it comes first within its condition.
     pkg.exports = {
       ".": {
-        types: "./index.d.ts",
-        import: "./index.mjs",
-        require: "./index.js",
+        import: { types: "./index.d.mts", default: "./index.mjs" },
+        require: { types: "./index.d.ts", default: "./index.js" },
       },
       "./src/*": "./src/*",
       "./S.gen.js": { types: "./src/S.gen.d.ts" },
       "./package.json": "./package.json",
     };
-    pkg.files = ["index.mjs", "index.js", "index.d.ts", "src", "rescript.json", "docs"];
+    pkg.files = ["index.mjs", "index.js", "index.d.ts", "index.d.mts", "src", "rescript.json", "docs"];
     // Nothing here builds the artifact, and dropping the scripts also drops the
     // prepublishOnly guard that makes publishing the dev package fail.
     delete pkg.devDependencies;
@@ -202,6 +203,7 @@ async function pack(): Promise<void> {
           "!index.mjs",
           "!index.js",
           "!index.d.ts",
+          "!index.d.mts",
           "!src",
           "!rescript.json",
           "!README.md",

--- a/packages/sury/tests/artifact_test.ts
+++ b/packages/sury/tests/artifact_test.ts
@@ -17,6 +17,7 @@ const FILES = [
   "README.md",
   "docs/js-usage.md",
   "docs/rescript-usage.md",
+  "index.d.mts",
   "index.d.ts",
   "index.js",
   "index.mjs",
@@ -87,6 +88,11 @@ const describeArtifact = existsSync(artifactsPath) ? describe : describe.skip;
 // during collection and take the whole file with it.
 const requireCjsEntry = (): any =>
   createRequire(import.meta.url)(path.join(artifactsPath, "index.js"));
+
+// The "." export nests a types/default pair per condition; every string leaf
+// is a file the tarball must carry.
+const exportTargets = (entry: unknown): string[] =>
+  typeof entry === "string" ? [entry] : Object.values(entry as object).flatMap(exportTargets);
 
 describeArtifact("artifact", () => {
   test("contains exactly the files it ships", () => {
@@ -163,7 +169,7 @@ describeArtifact("artifact", () => {
 
   test("every exports target resolves to a shipped file", () => {
     const pkg = readJson("package.json");
-    const targets = [...Object.values<string>(pkg.exports["."]), pkg.exports["./S.gen.js"].types];
+    const targets = [...exportTargets(pkg.exports["."]), pkg.exports["./S.gen.js"].types];
     for (const target of [...targets, pkg.main, pkg.module, pkg.types]) {
       expect(existsSync(path.join(artifactsPath, target)), target).toBe(true);
     }
@@ -176,8 +182,13 @@ describeArtifact("artifact", () => {
     expect(pkg.type).toBe("commonjs");
     expect(pkg.scripts).toBeUndefined();
     expect(pkg.devDependencies).toBeUndefined();
-    // TypeScript only honors "types" when it precedes the runtime conditions.
-    expect(Object.keys(pkg.exports["."])[0]).toBe("types");
+    // TypeScript only honors "types" when it comes first in its condition, and
+    // each entry format needs declarations of its own flavor — the package is
+    // commonjs, so index.d.ts typing the ESM entry would misreport its format.
+    expect(pkg.exports["."]).toEqual({
+      import: { types: "./index.d.mts", default: "./index.mjs" },
+      require: { types: "./index.d.ts", default: "./index.js" },
+    });
   });
 
   test("JSR publishes the same entry as npm", () => {
@@ -194,7 +205,7 @@ describeArtifact("artifact", () => {
       .map((e: string) => e.slice(1));
     const pkg = readJson("package.json");
     const targets = [
-      ...Object.values<string>(pkg.exports["."]),
+      ...exportTargets(pkg.exports["."]),
       pkg.exports["./S.gen.js"].types,
       pkg.main,
       pkg.module,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,10 @@ importers:
       zod:
         specifier: 4.4.3
         version: 4.4.3
+    devDependencies:
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
 
   packages/json-schema-test-suite:
     dependencies:


### PR DESCRIPTION
TypeScript's node16 resolution requires format-specific type declarations: a lone `index.d.ts` in a `type: "commonjs"` package incorrectly types ESM imports as CommonJS. This change ships `index.d.mts` alongside `index.d.ts` and restructures the `"."` export to nest type declarations within their runtime conditions.

**Key changes:**

- Add `index.d.mts` to ship ESM type declarations alongside the existing `index.d.ts` for CommonJS
- Restructure `pkg.exports["."]` from a flat condition list to nested objects:
  - `import: { types: "./index.d.mts", default: "./index.mjs" }`
  - `require: { types: "./index.d.ts", default: "./index.js" }`
- Update pack script to include `index.d.mts` in source paths and artifact files
- Add helper function `exportTargets()` to recursively extract file paths from nested export conditions
- Update artifact tests to validate the new export structure and verify all targets resolve to shipped files
- Add TypeScript to e2e devDependencies for testing type resolution

The new structure ensures TypeScript resolves the correct declaration file based on the import condition, fixing type accuracy under node16 resolution.

https://claude.ai/code/session_019FW4BMmozbfGyusmdQEyvY