### PR TITLE
Move test cases to spec files and add comprehensive spec coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -336,10 +336,6 @@ error message, a strictness gap that let a bad spec through — add a bullet her
 instead of silently working around it.
 
 - <placeholder>
-- No operation dimension for JSON-target conversions (`.to(S.json)` / `.to(S.jsonString)`), so bugs like #311 (nested optional fields failing to encode) can't be captured as spec examples — their repros live in `tests/` instead.
-- Example results are serialized back to spec source, so a value with symbol keys can't be recorded ("cannot represent an object with symbol keys as spec source code"). `S.record`'s unvalidated symbol-keyed values are pinned in `tests/` instead of `specs/record.yaml`, where the rest of that gap lives.
-- The same serializer emits an own `__proto__` key as `{ __proto__: … }`, which is prototype syntax and reads back as a *different* value, so `check --write` rewrites such an example into one that no longer reproduces and the goldens oscillate between runs. `specs/object-proto-key.yaml` works around it by covering only inputs without that key; a computed-key form (`{ ["__proto__"]: … }`) would let the example be recorded directly.
-- Scenario measurements can be bimodal across child processes: the identical `encoder-lookup` build measured "unchanged" and "−44%" against the same baseline in back-to-back runs, each individually printed as `confirmed`. The screening/rounds design averages within a process but can't see a whole process landing in a different JIT state (IC/feedback shapes settle per child, then every block agrees with itself). Until runs repeat the *process* (not just the rounds) and require agreement across them, treat any single scenario delta on a shared-arity path as one sample, not a verdict.
 
 ## License
 

--- a/packages/spec/bench.ts
+++ b/packages/spec/bench.ts
@@ -44,6 +44,14 @@ const WARMUP_BATCHES = 20;
 // of magnitude stricter.
 const BLOCKS = 8;
 const ROUNDS_PER_BLOCK = 2;
+// A whole child process can land in one JIT state and stay there — IC and
+// feedback shapes settle early, after which every block in that process agrees
+// with itself. The identical build has measured "unchanged" and "−44%" against
+// the same baseline in back-to-back runs, each individually "confirmed", so
+// within-process repetition (blocks) cannot see this failure mode at all. A
+// candidate is therefore confirmed by fresh PROCESSES, and kept only when the
+// screening process and every confirm process agree on direction.
+const CONFIRM_PROCESSES = 2;
 // Controls are sampled PER PHASE, and the floor is computed per phase too,
 // because the phases are not equally measurable: `create` allocates millions of
 // schemas and so runs against the garbage collector, which is a real cost but a
@@ -418,7 +426,15 @@ export const runPerf = async (
   // set are established under the same quiet serial conditions as the values
   // those floors gate. Screened under contention they would read as noisier
   // than the run they describe, and suppress real regressions to match.
-  const confirmed = collect(await measureAll([...candidates, ...controls], "confirm", 1));
+  // Each confirm pass spawns a fresh child process per target (see measureAll),
+  // so the CONFIRM_PROCESSES passes are independent JIT states, not repeats of
+  // one.
+  const confirmRuns: Map<string, { pct: number; median: number; batch: number }>[] = [];
+  for (let i = 0; i < CONFIRM_PROCESSES; i++)
+    confirmRuns.push(
+      collect(await measureAll(i === 0 ? [...candidates, ...controls] : candidates, `confirm ${i + 1}/${CONFIRM_PROCESSES}`, 1)),
+    );
+  const confirmed = confirmRuns[0]!;
 
   const floors = PHASES.map((phase) => {
     const measured = controls
@@ -441,18 +457,23 @@ export const runPerf = async (
   });
   const floorFor = (phase: Phase) => floors.find((f) => f.phase === phase)!.pct;
 
-  // Kept only if the serial re-measurement agrees on direction, reporting the
-  // smaller magnitude. Deliberately not an average of the two: re-measuring
-  // only the large values and pooling them pulls a real regression toward the
-  // mean exactly as hard as a false one, so this confirms rather than estimates.
+  // Kept only if every serial re-measurement agrees on direction, reporting the
+  // smallest magnitude. Deliberately not an average: re-measuring only the
+  // large values and pooling them pulls a real regression toward the mean
+  // exactly as hard as a false one, so this confirms rather than estimates.
   const changed = candidates
     .flatMap((t) => {
       const first = screened.get(t.name)!;
-      const again = confirmed.get(t.name);
-      if (!again || Math.sign(again.pct) !== Math.sign(first.pct)) return [];
-      const pct = Math.sign(first.pct) * Math.min(Math.abs(first.pct), Math.abs(again.pct));
+      const samples = [first];
+      for (const run of confirmRuns) {
+        const again = run.get(t.name);
+        if (!again || Math.sign(again.pct) !== Math.sign(first.pct)) return [];
+        samples.push(again);
+      }
+      const pct = Math.sign(first.pct) * Math.min(...samples.map((s) => Math.abs(s.pct)));
       if (Math.abs(pct) < floorFor(t.phase)) return [];
-      return [{ name: t.name, phase: t.phase, pct, median: again.median, batch: again.batch }];
+      const last = samples[samples.length - 1]!;
+      return [{ name: t.name, phase: t.phase, pct, median: last.median, batch: last.batch }];
     })
     .sort((a, b) => b.pct - a.pct);
 
@@ -469,6 +490,6 @@ export const runPerf = async (
     outcomeChanged: [...new Map(outcomeChanged.map((o) => [o.name, o])).values()],
     meta:
       `node ${process.versions.node} · ${process.platform} ${process.arch} · ${cpu.length} cores · ` +
-      `${BLOCKS}×${ROUNDS_PER_BLOCK} rounds · ${SCREEN_JOBS} screening jobs · confirmed`,
+      `${BLOCKS}×${ROUNDS_PER_BLOCK} rounds · ${SCREEN_JOBS} screening jobs · confirmed by ${CONFIRM_PROCESSES} fresh processes`,
   };
 };

--- a/packages/spec/bench.ts
+++ b/packages/spec/bench.ts
@@ -428,21 +428,19 @@ export const runPerf = async (
   // than the run they describe, and suppress real regressions to match.
   // Each confirm pass spawns a fresh child process per target (see measureAll),
   // so the CONFIRM_PROCESSES passes are independent JIT states, not repeats of
-  // one.
+  // one. Controls ride along in EVERY pass, not just the first: the floor they
+  // set gates the candidates, so a floor read from a single process would keep
+  // the one-sample failure mode this loop exists to remove.
   const confirmRuns: Map<string, { pct: number; median: number; batch: number }>[] = [];
   for (let i = 0; i < CONFIRM_PROCESSES; i++)
     confirmRuns.push(
-      collect(await measureAll(i === 0 ? [...candidates, ...controls] : candidates, `confirm ${i + 1}/${CONFIRM_PROCESSES}`, 1)),
+      collect(await measureAll([...candidates, ...controls], `confirm ${i + 1}/${CONFIRM_PROCESSES}`, 1)),
     );
-  const confirmed = confirmRuns[0]!;
 
   const floors = PHASES.map((phase) => {
     const measured = controls
       .filter((c) => c.phase === phase)
-      .flatMap((c) => {
-        const m = confirmed.get(c.name);
-        return m ? [m] : [];
-      });
+      .flatMap((c) => confirmRuns.flatMap((run) => run.get(c.name) ?? []));
     // Both statistics: the conservative bound catches a control that produced
     // an outright false positive, the median the subtler case of a phase that
     // is visibly biased without any single control clearing the bar.
@@ -486,7 +484,9 @@ export const runPerf = async (
     unchanged: real.length - changed.length,
     added: [...new Set(added)],
     skippedConstants,
-    errors,
+    // Deduped by name like outcomeChanged: collect runs over the screening pass
+    // plus every confirm pass, so one target can report the same failure twice.
+    errors: [...new Map(errors.map((e) => [e.name, e])).values()],
     outcomeChanged: [...new Map(outcomeChanged.map((o) => [o.name, o])).values()],
     meta:
       `node ${process.versions.node} · ${process.platform} ${process.arch} · ${cpu.length} cores · ` +

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -457,9 +457,17 @@ export const serialize = (obj: Spec, comments: SpecComments = NO_COMMENTS): stri
 // ---- golden recomputation --------------------------------------------------
 
 // An object key needs quotes only when it isn't a valid identifier — matches
-// how a human would hand-write the same literal.
+// how a human would hand-write the same literal. `__proto__` must be computed
+// (`["__proto__"]`): both the bare and the quoted form are prototype-setter
+// syntax in an object literal, so either would read back as a different value
+// (the key silently dropped) and `--write` would oscillate the golden.
 const IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
-const keyToCode = (k: string): string => (IDENT_RE.test(k) ? k : JSON.stringify(k));
+const keyToCode = (k: string): string =>
+  k === "__proto__"
+    ? '["__proto__"]'
+    : IDENT_RE.test(k)
+      ? k
+      : JSON.stringify(k);
 
 // Recursive (not JSON.stringify) because JSON.stringify throws outright on a
 // bare (or nested) bigint, and silently mangles Date (→ a plain string, not a
@@ -469,10 +477,9 @@ const keyToCode = (k: string): string => (IDENT_RE.test(k) ? k : JSON.stringify(
 // no source expression can reproduce it.
 //
 // Anything the emitted source would NOT evaluate back to (structurally) must
-// throw rather than emit: a cyclic value would recurse forever, a class
-// instance would silently flatten to a plain-object literal, and symbol keys
-// would be dropped by Object.entries — each of those would record a golden
-// that looks fine but doesn't equal the real output.
+// throw rather than emit: a cyclic value would recurse forever, and a class
+// instance would silently flatten to a plain-object literal — each of those
+// would record a golden that looks fine but doesn't equal the real output.
 const valueToCode = (v: unknown, seen: WeakSet<object> = new WeakSet()): string => {
   if (v === undefined) return "undefined";
   if (typeof v === "bigint") return `${v}n`;
@@ -499,11 +506,15 @@ const valueToCode = (v: unknown, seen: WeakSet<object> = new WeakSet()): string 
       throw new Error(
         `cannot represent a ${(v as object).constructor?.name ?? "unknown-class"} instance as spec source code`,
       );
-    if (Object.getOwnPropertySymbols(v).length)
-      throw new Error("cannot represent an object with symbol keys as spec source code");
-    const entries = Object.entries(v);
-    if (entries.length === 0) return "{}";
-    return `{ ${entries.map(([k, val]) => `${keyToCode(k)}: ${valueToCode(val, seen)}`).join(", ")} }`;
+    // Symbol keys ride along as computed keys — only registry symbols, for the
+    // same reason as symbol values above. Object.entries would drop them.
+    const parts = Object.entries(v).map(([k, val]) => `${keyToCode(k)}: ${valueToCode(val, seen)}`);
+    for (const sym of Object.getOwnPropertySymbols(v)) {
+      if (!Object.getOwnPropertyDescriptor(v, sym)!.enumerable) continue;
+      parts.push(`[${valueToCode(sym, seen)}]: ${valueToCode((v as Record<symbol, unknown>)[sym], seen)}`);
+    }
+    if (parts.length === 0) return "{}";
+    return `{ ${parts.join(", ")} }`;
   }
   throw new Error(`cannot represent a ${typeof v} as spec source code`);
 };

--- a/packages/sury/specs/array-length-range.yaml
+++ b/packages/sury/specs/array-length-range.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.array(S.string).with(S.minLength, 1).with(S.maxLength, 2)
+  input: string[]
+  output: string[]
+  instantiations: 5402
+vs:
+  zod: z.array(z.string()).min(1).max(2)
+jsonSchema:
+  input: '{ items: { type: "string" }, type: "array", minItems: 1, maxItems: 2 }'
+  output: '{ items: { type: "string" }, type: "array", minItems: 1, maxItems: 2 }'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)||e[3](i);for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];typeof v1==="string"||e[0](v1);}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}i.length>0||e[1](i);i.length<3||e[2](i);return i}
+    examples:
+      within-range:
+        input: '["foo"]'
+        output: '["foo"]'
+      at-the-max:
+        input: '["a", "b"]'
+        output: '["a", "b"]'
+      too-short:
+        input: "[]"
+        error: Expected 1 <= string[].length <= 2, received []
+      too-long:
+        input: '["a", "b", "c"]'
+        error: Expected 1 <= string[].length <= 2, received ["a", "b", "c"]
+  decode:
+    expression: i=>{i.length>0||e[0](i);i.length<3||e[1](i);return i}
+    examples:
+      within-range:
+        input: '["foo"]'
+        output: '["foo"]'
+      too-short:
+        input: "[]"
+        error: Expected 1 <= string[].length <= 2, received []
+  encode:
+    expression: i=>{i.length>0||e[0](i);i.length<3||e[1](i);return i}
+    examples:
+      within-range:
+        input: '["foo"]'
+        output: '["foo"]'
+      too-short:
+        input: "[]"
+        error: Expected 1 <= string[].length <= 2, received []

--- a/packages/sury/specs/array.yaml
+++ b/packages/sury/specs/array.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.array(S.string)
+  input: string[]
+  output: string[]
+  instantiations: 377
+vs:
+  zod: z.array(z.string())
+jsonSchema:
+  input: '{ items: { type: "string" }, type: "array" }'
+  output: '{ items: { type: "string" }, type: "array" }'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)||e[1](i);for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];typeof v1==="string"||e[0](v1);}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}return i}
+    examples:
+      valid:
+        input: '["foo"]'
+        output: '["foo"]'
+      empty:
+        input: "[]"
+        output: "[]"
+      invalid-item:
+        input: '["foo", 1]'
+        error: 'Failed at ["1"]: Expected string, received 1'
+      not-an-array:
+        input: '"x"'
+        error: Expected string[], received "x"
+      null-is-not-an-array:
+        input: "null"
+        error: Expected string[], received null
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/codec-array-bigint-string.yaml
+++ b/packages/sury/specs/codec-array-bigint-string.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.array(S.bigint).with(S.to, S.array(S.string))
+  input: bigint[]
+  output: string[]
+  instantiations: 5344
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: "Failed at []: Expected JSON, received bigint"
+  output: '{ items: { type: "string" }, type: "array" }'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)||e[1](i);for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];typeof v1==="bigint"||e[0](v1);}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}let v4=new Array(i.length);for(let v3=0;v3<i.length;++v3){v4[v3]=""+i[v3]}return v4}
+    examples:
+      valid:
+        input: "[123n]"
+        output: '["123"]'
+      not-a-bigint-item:
+        input: '["123"]'
+        error: 'Failed at ["0"]: Expected bigint, received "123"'
+  decode:
+    expression: i=>{let v2=new Array(i.length);for(let v1=0;v1<i.length;++v1){v2[v1]=""+i[v1]}return v2}
+    examples:
+      valid:
+        input: "[123n]"
+        output: '["123"]'
+  encode:
+    expression: i=>{let v5=new Array(i.length);for(let v1=0;v1<i.length;++v1){try{let v3=i[v1];let v2;try{v2=BigInt(v3)}catch(_){e[0](v3)}v5[v1]=v2}catch(v4){v4.path='["'+v1+'"]'+v4.path;throw v4}}return v5}
+    examples:
+      valid:
+        input: '["123"]'
+        output: "[123n]"
+      not-numeric-text:
+        input: '["abc"]'
+        error: 'Failed at ["0"]: Expected bigint, received "abc"'

--- a/packages/sury/specs/codec-json-object-date.yaml
+++ b/packages/sury/specs/codec-json-object-date.yaml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.json.with(S.to, S.schema({ field: S.date }))"
+  input: JSON
+  output: "{ field: Date; }"
+  instantiations: 6094
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "object", properties: { field: { type: "string", format: "date-time" } }, additionalProperties: false, required: ["field"] }'
+  output: 'Failed at ["field"]: Expected JSON, received Date'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[2](i);let v1=i["field"];typeof v1==="string"||e[1](v1);let v0=new Date(i["field"]);!Number.isNaN(v0.getTime())||e[0](v0);return {"field":v0,}}
+    examples:
+      iso-string-becomes-date:
+        input: '{ field: "2024-01-01T00:00:00.000Z" }'
+        output: '{ field: new Date("2024-01-01T00:00:00.000Z") }'
+      not-a-date-text:
+        input: '{ field: "nope" }'
+        error: 'Failed at ["field"]: Expected Date, received invalid Date'
+      wrong-type:
+        input: "{ field: 5 }"
+        error: 'Failed at ["field"]: Expected string, received 5'
+  decode: eq-to-parse
+  encode:
+    expression: i=>{return {"field":i["field"].toISOString(),}}
+    examples:
+      date-becomes-iso-string:
+        input: '{ field: new Date("2024-01-01T00:00:00.000Z") }'
+        output: '{ field: "2024-01-01T00:00:00.000Z" }'

--- a/packages/sury/specs/codec-jsonstring-bigint-array.yaml
+++ b/packages/sury/specs/codec-jsonstring-bigint-array.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.jsonString.with(S.to, S.array(S.bigint))
+  input: string
+  output: bigint[]
+  instantiations: 5247
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: "Failed at []: Expected JSON, received bigint"
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[4](i);let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}Array.isArray(v0)||e[3](v0);let v5=new Array(v0.length);for(let v1=0;v1<v0.length;++v1){try{let v3=v0[v1];typeof v3==="string"||e[2](v3);let v2;try{v2=BigInt(v3)}catch(_){e[1](v3)}v5[v1]=v2}catch(v4){v4.path='["'+v1+'"]'+v4.path;throw v4}}return v5}
+    examples:
+      valid:
+        input: '"[\"123\"]"'
+        output: "[123n]"
+      not-bigint-text:
+        input: '"[\"abc\"]"'
+        error: 'Failed at ["0"]: Expected bigint, received "abc"'
+  decode:
+    expression: i=>{let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}Array.isArray(v0)||e[3](v0);let v5=new Array(v0.length);for(let v1=0;v1<v0.length;++v1){try{let v3=v0[v1];typeof v3==="string"||e[2](v3);let v2;try{v2=BigInt(v3)}catch(_){e[1](v3)}v5[v1]=v2}catch(v4){v4.path='["'+v1+'"]'+v4.path;throw v4}}return v5}
+    examples:
+      valid:
+        input: '"[\"123\"]"'
+        output: "[123n]"
+  encode:
+    expression: i=>{let v2=new Array(i.length);for(let v1=0;v1<i.length;++v1){v2[v1]=""+i[v1]}return JSON.stringify(v2)}
+    examples:
+      valid:
+        input: "[123n]"
+        output: '"[\"123\"]"'
+      empty:
+        input: "[]"
+        output: '"[]"'

--- a/packages/sury/specs/codec-jsonstring-boolean.yaml
+++ b/packages/sury/specs/codec-jsonstring-boolean.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.jsonString.with(S.to, S.boolean)
+  input: string
+  output: boolean
+  instantiations: 5091
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "boolean" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="boolean"||e[1](v0);return v0}
+    examples:
+      true-text:
+        input: '"true"'
+        output: "true"
+      false-text:
+        input: '"false"'
+        output: "false"
+      not-a-boolean-payload:
+        input: '"123"'
+        error: Expected boolean, received 123
+      not-a-string:
+        input: "true"
+        error: Expected JSON string, received true
+  decode:
+    expression: i=>{let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="boolean"||e[1](v0);return v0}
+    examples:
+      true-text:
+        input: '"true"'
+        output: "true"
+  encode:
+    expression: i=>{return ""+i}
+    examples:
+      "true":
+        input: "true"
+        output: '"true"'
+      "false":
+        input: "false"
+        output: '"false"'

--- a/packages/sury/specs/codec-jsonstring-extract-field.yaml
+++ b/packages/sury/specs/codec-jsonstring-extract-field.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.jsonString.with(S.to, S.schema({ type: "info", value: S.number }).with(S.shape, (msg) => msg.value)).with(S.to, S.jsonString)'
+  input: string
+  output: string
+  instantiations: 7976
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[4](i);let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="object"&&v0&&!Array.isArray(v0)||e[3](v0);let v1=v0["type"],v2=v0["value"];v1==="info"||e[1](v1);typeof v2==="number"&&!Number.isNaN(v2)||e[2](v2);return ""+v2}
+    examples:
+      extracts-the-field:
+        input: '"{\"type\": \"info\", \"value\": 123}"'
+        output: '"123"'
+      invalid-field:
+        input: '"{\"type\": \"info\", \"value\": \"123\"}"'
+        error: 'Failed at ["value"]: Expected number, received "123"'
+  decode:
+    expression: i=>{let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="object"&&v0&&!Array.isArray(v0)||e[3](v0);let v1=v0["type"],v2=v0["value"];v1==="info"||e[1](v1);typeof v2==="number"&&!Number.isNaN(v2)||e[2](v2);return ""+v2}
+    examples:
+      extracts-the-field:
+        input: '"{\"type\": \"info\", \"value\": 123}"'
+        output: '"123"'
+  encode:
+    expression: i=>{let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="number"&&!Number.isNaN(v0)||e[1](v0);return JSON.stringify({"type":"info","value":v0,})}
+    examples:
+      rebuilds-the-envelope:
+        input: '"123"'
+        output: '"{\"type\":\"info\",\"value\":123}"'

--- a/packages/sury/specs/codec-number-jsonstring-pattern.yaml
+++ b/packages/sury/specs/codec-number-jsonstring-pattern.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.number.with(S.to, S.jsonString).with(S.pattern, /^\d+$/)
+  input: number
+  output: string
+  instantiations: 5450
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "number" }'
+  output: '{ type: "string", pattern: "^\\d+$" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="number"&&!Number.isNaN(i)||e[2](i);let v0=""+i;e[0].test(v0)||e[1](v0);return v0}
+    examples:
+      valid:
+        input: "123"
+        output: '"123"'
+      negative-fails-pattern:
+        input: "-5"
+        error: Invalid pattern
+  decode:
+    expression: i=>{let v0=""+i;e[0].test(v0)||e[1](v0);return v0}
+    examples:
+      valid:
+        input: "123"
+        output: '"123"'
+      negative-fails-pattern:
+        input: "-5"
+        error: Invalid pattern
+  encode:
+    expression: i=>{e[0].test(i)||e[3](i);let v0;try{v0=JSON.parse(i)}catch(t){e[1](i)}typeof v0==="number"&&!Number.isNaN(v0)||e[2](v0);return v0}
+    examples:
+      valid:
+        input: '"123"'
+        output: "123"
+      fails-pattern:
+        input: '"abc"'
+        error: Invalid pattern

--- a/packages/sury/specs/codec-number-jsonstring.yaml
+++ b/packages/sury/specs/codec-number-jsonstring.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.number.with(S.to, S.jsonString)
+  input: number
+  output: string
+  instantiations: 5091
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "number" }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="number"&&!Number.isNaN(i)||e[0](i);return ""+i}
+    examples:
+      valid:
+        input: "123"
+        output: '"123"'
+      not-a-number:
+        input: '"123"'
+        error: Expected number, received "123"
+  decode:
+    expression: i=>{return ""+i}
+    examples:
+      valid:
+        input: "123"
+        output: '"123"'
+      float:
+        input: "123.4"
+        output: '"123.4"'
+  encode:
+    expression: i=>{let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="number"&&!Number.isNaN(v0)||e[1](v0);return v0}
+    examples:
+      number-text:
+        input: '"123"'
+        output: "123"
+      not-a-number-payload:
+        input: '"\"abc\""'
+        error: Expected number, received "abc"

--- a/packages/sury/specs/codec-optional-object-json.yaml
+++ b/packages/sury/specs/codec-optional-object-json.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.schema({ a: S.optional(S.schema({ s: S.optional(S.string) })) }).with(S.to, S.json)"
+  input: "{ a?: { s?: string | undefined; } | undefined; }"
+  output: JSON
+  instantiations: 8985
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "object", properties: { a: { type: "object", properties: { s: { type: "string" } } } } }'
+  output: '{ type: "object", properties: { a: { type: "object", properties: { s: { type: "string" } }, additionalProperties: false } }, additionalProperties: false }'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[5](i);let v0=i["a"];for(;;){if(typeof v0==="object"&&v0&&!Array.isArray(v0)){let v1=v0["s"];(typeof v1==="string"||v1===void 0)||e[0](v1);v0={"s":v1,};break}if(v0===void 0)break;e[1](v0)}for(;;){if(typeof v0==="object"&&v0&&!Array.isArray(v0)){let v2=v0["s"],v3;(typeof v2==="string"||v2===void 0)||e[2](v2);for(v3 in v0){if(v3!=="s"){e[3](v3)}}let v4={};if(v2!==void 0){v4["s"]=v2}v0=v4;break}if(v0===void 0)break;e[4](v0)}let v5={};if(v0!==void 0){v5["a"]=v0}return v5}
+    examples:
+      none-omits-the-field:
+        input: "{ a: { s: undefined } }"
+        output: "{ a: {} }"
+      outer-none-omits-too:
+        input: "{ a: undefined }"
+        output: "{}"
+      present:
+        input: '{ a: { s: "x" } }'
+        output: '{ a: { s: "x" } }'
+  decode:
+    expression: i=>{let v0=i["a"];for(;;){if(typeof v0==="object"&&v0&&!Array.isArray(v0)){let v1=v0["s"];(typeof v1==="string"||v1===void 0)||e[0](v1);let v2={};if(v1!==void 0){v2["s"]=v1}v0=v2;break}if(v0===void 0)break;e[1](v0)}let v3={};if(v0!==void 0){v3["a"]=v0}return v3}
+    examples:
+      none-omits-the-field:
+        input: "{ a: { s: undefined } }"
+        output: "{ a: {} }"
+      outer-none-omits-too:
+        input: "{ a: undefined }"
+        output: "{}"
+      present:
+        input: '{ a: { s: "x" } }'
+        output: '{ a: { s: "x" } }'
+  encode:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[2](i);let v0=(i["a"]??null);for(;;){if(typeof v0==="object"&&v0&&!Array.isArray(v0)){let v1=v0["s"];(typeof v1==="string"||v1===void 0)||e[0](v1);v0={"s":v1,};break}if(v0===null){v0=void 0;break}e[1](v0)}return {"a":v0,}}
+    examples:
+      omitted-round-trips-to-none:
+        input: "{}"
+        output: "{ a: undefined }"
+      present:
+        input: '{ a: { s: "x" } }'
+        output: '{ a: { s: "x" } }'

--- a/packages/sury/specs/codec-string-date.yaml
+++ b/packages/sury/specs/codec-string-date.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.to, S.date)
+  aliases:
+    - S.to(S.string, S.date)
+  input: string
+  output: Date
+  instantiations: 5091
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string", format: "date-time" }'
+  output: Expected JSON, received Date
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[1](i);let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);return v0}
+    examples:
+      valid:
+        input: '"2024-01-01T00:00:00.000Z"'
+        output: new Date("2024-01-01T00:00:00.000Z")
+      not-a-date-text:
+        input: '"nope"'
+        error: Expected Date, received invalid Date
+      not-a-string:
+        input: "0"
+        error: Expected string, received 0
+  decode:
+    expression: i=>{let v0=new Date(i);!Number.isNaN(v0.getTime())||e[0](v0);return v0}
+    examples:
+      valid:
+        input: '"2024-01-01T00:00:00.000Z"'
+        output: new Date("2024-01-01T00:00:00.000Z")
+  encode:
+    expression: i=>{return i.toISOString()}
+    examples:
+      valid:
+        input: new Date("2024-01-01T00:00:00.000Z")
+        output: '"2024-01-01T00:00:00.000Z"'

--- a/packages/sury/specs/codec-string-number-transform.yaml
+++ b/packages/sury/specs/codec-string-number-transform.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.to, S.number, (string) => { const number = Number(string); if (Number.isNaN(number)) { throw new Error("Invalid number") } return number }, (number) => { if (number < 100) { throw new Error("Number is too small") } return number.toString() })
+  input: string
+  output: number
+  instantiations: 5135
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "number" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);let v0;try{v0=e[0](i)}catch(x){e[1](x)}return v0}
+    examples:
+      valid:
+        input: '"123"'
+        output: "123"
+      small:
+        input: '"80"'
+        output: "80"
+      user-error:
+        input: '"asdf"'
+        error: Invalid number
+  decode:
+    expression: i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}return v0}
+    examples:
+      valid:
+        input: '"123"'
+        output: "123"
+  encode:
+    expression: i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}return v0}
+    examples:
+      valid:
+        input: "123"
+        output: '"123"'
+      user-error-too-small:
+        input: "80"
+        error: Number is too small

--- a/packages/sury/specs/codec-string-number.yaml
+++ b/packages/sury/specs/codec-string-number.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.to, S.number)
+  aliases:
+    - S.to(S.string, S.number)
+  input: string
+  output: number
+  instantiations: 5091
+vs:
+  zod: z.string().transform((value) => Number(value))
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "number" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[1](i);let v0=+i;!Number.isNaN(v0)||e[0](i);return v0}
+    examples:
+      integer:
+        input: '"123"'
+        output: "123"
+      float:
+        input: '"123.4"'
+        output: "123.4"
+      not-a-number-text:
+        input: '"abc"'
+        error: Expected number, received "abc"
+      not-a-string:
+        input: "123"
+        error: Expected string, received 123
+  decode:
+    expression: i=>{let v0=+i;!Number.isNaN(v0)||e[0](i);return v0}
+    examples:
+      valid:
+        input: '"123"'
+        output: "123"
+  encode:
+    expression: i=>{return ""+i}
+    examples:
+      valid:
+        input: "123"
+        output: '"123"'

--- a/packages/sury/specs/codec-string-port.yaml
+++ b/packages/sury/specs/codec-string-port.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.to, S.port)
+  input: string
+  output: number
+  instantiations: 5091
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "integer", minimum: 0, maximum: 65535 }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);let v0=+i;!Number.isNaN(v0)||e[1](i);v0>=0&&v0<65536&&v0%1===0||e[0](v0);return v0}
+    examples:
+      valid:
+        input: '"10"'
+        output: "10"
+      fractional-port:
+        input: '"10.2"'
+        error: Expected port, received 10.2
+      not-a-string:
+        input: "10.2"
+        error: Expected string, received 10.2
+  decode:
+    expression: i=>{let v0=+i;!Number.isNaN(v0)||e[1](i);v0>=0&&v0<65536&&v0%1===0||e[0](v0);return v0}
+    examples:
+      valid:
+        input: '"10"'
+        output: "10"
+  encode:
+    expression: i=>{i>=0&&i<65536&&i%1===0||e[0](i);return ""+i}
+    examples:
+      valid:
+        input: "10"
+        output: '"10"'

--- a/packages/sury/specs/compact-columns-json-bigint.yaml
+++ b/packages/sury/specs/compact-columns-json-bigint.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.compactColumns(S.json).with(S.to, S.array(S.schema({ id: S.string, amount: S.bigint })))"
+  input: JSON[][]
+  output: "{ id: string; amount: bigint; }[]"
+  instantiations: 6739
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ items: { items: {}, type: "array" }, type: "array" }'
+  output: 'Failed at []["amount"]: Expected JSON, received bigint'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)&&i.length===2&&Array.isArray(i[0])&&Array.isArray(i[1])||e[3](i);let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];typeof v2==="string"||e[0](v2);let v4=i[1][v0];typeof v4==="string"||e[2](v4);let v3;try{v3=BigInt(v4)}catch(_){e[1](v4)}v1[v0]={"id":v2,"amount":v3,};}catch(v5){v5.path='["'+v0+'"]'+v5.path;throw v5}}return v1}
+    examples:
+      beyond-float-precision:
+        input: '[["0", "1"], ["12345678901234567890", "98765432109876543210"]]'
+        output: '[{ id: "0", amount: 12345678901234567890n }, { id: "1", amount: 98765432109876543210n }]'
+  decode:
+    expression: i=>{let v1=new Array(Math.max(i[0].length,i[1].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];typeof v2==="string"||e[0](v2);let v4=i[1][v0];typeof v4==="string"||e[2](v4);let v3;try{v3=BigInt(v4)}catch(_){e[1](v4)}v1[v0]={"id":v2,"amount":v3,};}catch(v5){v5.path='["'+v0+'"]'+v5.path;throw v5}}return v1}
+    examples:
+      beyond-float-precision:
+        input: '[["0", "1"], ["12345678901234567890", "98765432109876543210"]]'
+        output: '[{ id: "0", amount: 12345678901234567890n }, { id: "1", amount: 98765432109876543210n }]'
+  encode:
+    expression: i=>{for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}let v4=[new Array(i.length),new Array(i.length),];for(let v3=0;v3<i.length;++v3){v4[0][v3]=i[v3]["id"];v4[1][v3]=""+i[v3]["amount"];}return v4}
+    examples:
+      round-trip:
+        input: '[{ id: "0", amount: 12345678901234567890n }, { id: "1", amount: 98765432109876543210n }]'
+        output: '[["0", "1"], ["12345678901234567890", "98765432109876543210"]]'

--- a/packages/sury/specs/compact-columns-nullable.yaml
+++ b/packages/sury/specs/compact-columns-nullable.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.compactColumns(S.unknown).with(S.to, S.array(S.schema({ id: S.string, name: S.nullable(S.string), deleted: S.boolean })))"
+  input: unknown[][]
+  output: "{ id: string; name: string | null; deleted: boolean; }[]"
+  instantiations: 7008
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: "Failed at [][]: Expected JSON, received unknown"
+  output: '{ items: { type: "object", properties: { id: { type: "string" }, name: { anyOf: [{ type: "string" }, { type: "null" }] }, deleted: { type: "boolean" } }, required: ["id", "name", "deleted"] }, type: "array" }'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)&&i.length===3&&Array.isArray(i[0])&&Array.isArray(i[1])&&Array.isArray(i[2])||e[3](i);let v1=new Array(Math.max(i[0].length,i[1].length,i[2].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];typeof v2==="string"||e[0](v2);let v3=i[1][v0];(typeof v3==="string"||v3===null)||e[1](v3);let v4=i[2][v0];typeof v4==="boolean"||e[2](v4);v1[v0]={"id":v2,"name":v3,"deleted":v4,};}catch(v5){v5.path='["'+v0+'"]'+v5.path;throw v5}}return v1}
+    examples:
+      valid:
+        input: '[["0", "1"], ["Hello", null], [false, true]]'
+        output: '[{ id: "0", name: "Hello", deleted: false }, { id: "1", name: null, deleted: true }]'
+  decode:
+    expression: i=>{let v1=new Array(Math.max(i[0].length,i[1].length,i[2].length,));for(let v0=0;v0<v1.length;++v0){try{let v2=i[0][v0];typeof v2==="string"||e[0](v2);let v3=i[1][v0];(typeof v3==="string"||v3===null)||e[1](v3);let v4=i[2][v0];typeof v4==="boolean"||e[2](v4);v1[v0]={"id":v2,"name":v3,"deleted":v4,};}catch(v5){v5.path='["'+v0+'"]'+v5.path;throw v5}}return v1}
+    examples:
+      valid:
+        input: '[["0", "1"], ["Hello", null], [false, true]]'
+        output: '[{ id: "0", name: "Hello", deleted: false }, { id: "1", name: null, deleted: true }]'
+  encode:
+    expression: i=>{for(let v0=0;v0<i.length;++v0){try{let v1=i[v0];}catch(v2){v2.path='["'+v0+'"]'+v2.path;throw v2}}let v4=[new Array(i.length),new Array(i.length),new Array(i.length),];for(let v3=0;v3<i.length;++v3){v4[0][v3]=i[v3]["id"];v4[1][v3]=i[v3]["name"];v4[2][v3]=i[v3]["deleted"];}return v4}
+    examples:
+      round-trip:
+        input: '[{ id: "0", name: "Hello", deleted: false }, { id: "1", name: null, deleted: true }]'
+        output: '[["0", "1"], ["Hello", null], [false, true]]'

--- a/packages/sury/specs/email.yaml
+++ b/packages/sury/specs/email.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.email
+  input: string
+  output: string
+  instantiations: 254
+vs:
+  zod: z.email()
+jsonSchema:
+  input: '{ type: "string", format: "email" }'
+  output: '{ type: "string", format: "email" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);e[0].test(i)||e[1](i);return i}
+    examples:
+      valid:
+        input: '"jane@example.com"'
+        output: '"jane@example.com"'
+      empty:
+        input: '""'
+        error: Expected email, received ""
+      not-an-email:
+        input: '"example.com"'
+        error: Expected email, received "example.com"
+      not-a-string:
+        input: "42"
+        error: Expected email, received 42
+  decode:
+    expression: i=>{e[0].test(i)||e[1](i);return i}
+    examples:
+      valid:
+        input: '"jane@example.com"'
+        output: '"jane@example.com"'
+      empty:
+        input: '""'
+        error: Expected email, received ""
+  encode:
+    expression: i=>{e[0].test(i)||e[1](i);return i}
+    examples:
+      valid:
+        input: '"jane@example.com"'
+        output: '"jane@example.com"'
+      empty:
+        input: '""'
+        error: Expected email, received ""

--- a/packages/sury/specs/instance-set.yaml
+++ b/packages/sury/specs/instance-set.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.instance(Set)
+  input: Set<unknown>
+  output: Set<unknown>
+  instantiations: 2253
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: Expected JSON, received Set
+  output: Expected JSON, received Set
+operations:
+  parse:
+    expression: i=>{i instanceof e[0]||e[1](i);return i}
+    examples:
+      valid:
+        input: new Set(["foo", "bar"])
+        output: new Set(["foo", "bar"])
+      not-a-set:
+        input: "123"
+        error: Expected Set, received 123
+      array-is-not-a-set:
+        input: '["foo"]'
+        error: Expected Set, received ["foo"]
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/json-novalidation.yaml
+++ b/packages/sury/specs/json-novalidation.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.json.with(S.noValidation, true)
+  input: JSON
+  output: JSON
+  instantiations: 5163
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: "{}"
+  output: "{}"
+operations:
+  parse: identity
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/json.yaml
+++ b/packages/sury/specs/json.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.json
+  input: JSON
+  output: JSON
+  instantiations: 254
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: "{}"
+  output: "{}"
+operations:
+  parse:
+    expression: i=>{e[0](i);return i}
+    examples:
+      valid-object:
+        input: '{ a: [1, "x", true, null] }'
+        output: '{ a: [1, "x", true, null] }'
+      valid-null:
+        input: "null"
+        output: "null"
+      invalid-undefined:
+        input: undefined
+        error: Expected JSON, received undefined
+      invalid-bigint:
+        input: 5n
+        error: Expected JSON, received 5n
+      invalid-nan:
+        input: NaN
+        error: Expected JSON, received NaN
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/jsonstring-with-space.yaml
+++ b/packages/sury/specs/jsonstring-with-space.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.jsonStringWithSpace(2).with(S.to, S.schema({ foo: [1, S.number] }))"
+  input: string
+  output: "{ foo: [1, number]; }"
+  instantiations: 6464
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "object", properties: { foo: { type: "array", minItems: 2, maxItems: 2, items: [{ type: "number", const: 1 }, { type: "number" }] } }, required: ["foo"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[6](i);let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="object"&&v0&&!Array.isArray(v0)||e[5](v0);let v1=v0["foo"];Array.isArray(v1)||e[4](v1);v1.length===2||e[3](v1);let v2=v1["0"],v3=v1["1"];v2===1||e[1](v2);typeof v3==="number"&&!Number.isNaN(v3)||e[2](v3);return {"foo":v1,}}
+    examples:
+      valid:
+        input: '"{\"foo\":[1,2]}"'
+        output: "{ foo: [1, 2] }"
+  decode:
+    expression: i=>{let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}typeof v0==="object"&&v0&&!Array.isArray(v0)||e[5](v0);let v1=v0["foo"];Array.isArray(v1)||e[4](v1);v1.length===2||e[3](v1);let v2=v1["0"],v3=v1["1"];v2===1||e[1](v2);typeof v3==="number"&&!Number.isNaN(v3)||e[2](v3);return {"foo":v1,}}
+    examples:
+      valid:
+        input: '"{\"foo\":[1,2]}"'
+        output: "{ foo: [1, 2] }"
+  encode:
+    expression: i=>{let v0=i["foo"];return JSON.stringify(i,null,2)}
+    examples:
+      pretty-prints:
+        input: "{ foo: [1, 2] }"
+        output: '"{\n  \"foo\": [\n    1,\n    2\n  ]\n}"'

--- a/packages/sury/specs/jsonstring.yaml
+++ b/packages/sury/specs/jsonstring.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.jsonString
+  input: string
+  output: string
+  instantiations: 254
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[1](i);try{JSON.parse(i)}catch(t){e[0](i)}return i}
+    examples:
+      valid-json-number-text:
+        input: '"123"'
+        output: '"123"'
+      valid-json-object-text:
+        input: '"{\"foo\":[1,2]}"'
+        output: '"{\"foo\":[1,2]}"'
+      invalid-json-text:
+        input: '"{"'
+        error: Expected JSON string, received "{"
+      not-a-string:
+        input: "123"
+        error: Expected JSON string, received 123
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/merge-overwrite.yaml
+++ b/packages/sury/specs/merge-overwrite.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.merge(S.schema({ type: S.union(["foo", "bar"]), name: S.string }), S.schema({ type: "foo", fooCount: S.number }))'
+  input: '{ name: string; type: "foo"; fooCount: number; }'
+  output: '{ name: string; type: "foo"; fooCount: number; }'
+  instantiations: 4450
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "object", properties: { type: { type: "string", const: "foo" }, name: { type: "string" }, fooCount: { type: "number" } }, required: ["type", "name", "fooCount"] }'
+  output: '{ type: "object", properties: { type: { type: "string", const: "foo" }, name: { type: "string" }, fooCount: { type: "number" } }, required: ["type", "name", "fooCount"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[3](i);let v0=i["type"],v1=i["name"],v2=i["fooCount"];v0==="foo"||e[0](v0);typeof v1==="string"||e[1](v1);typeof v2==="number"&&!Number.isNaN(v2)||e[2](v2);return {"type":v0,"name":v1,"fooCount":v2,}}
+    examples:
+      valid:
+        input: '{ type: "foo", name: "foo", fooCount: 123 }'
+        output: '{ type: "foo", name: "foo", fooCount: 123 }'
+      left-tag-is-overwritten:
+        input: '{ type: "bar", name: "foo", fooCount: 123 }'
+        error: 'Failed at ["type"]: Expected "foo", received "bar"'
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/nullable-default.yaml
+++ b/packages/sury/specs/nullable-default.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.nullable(S.string, "bar")
+  input: string | null
+  output: string
+  instantiations: 382
+vs:
+  zod: z.string().nullable().transform((value) => value ?? "bar")
+jsonSchema:
+  input: '{ default: "bar", anyOf: [{ type: "string" }, { type: "null" }] }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{for(;;){if(typeof i==="string")break;if(i===null){i=void 0;break}e[0](i)}return i===void 0?"bar":i}
+    examples:
+      string:
+        input: '"foo"'
+        output: '"foo"'
+      null-becomes-the-default:
+        input: "null"
+        output: '"bar"'
+      undefined-is-not-accepted:
+        input: undefined
+        error: Expected string | null, received undefined
+  decode: eq-to-parse
+  encode: identity

--- a/packages/sury/specs/nullable.yaml
+++ b/packages/sury/specs/nullable.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.nullable(S.string)
+  aliases:
+    - S.nullable(S.nullable(S.nullable(S.string)))
   input: string | null
   output: string | null
   instantiations: 380

--- a/packages/sury/specs/nullish.yaml
+++ b/packages/sury/specs/nullish.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.nullish(S.string)
+  input: string | null | undefined
+  output: string | null | undefined
+  instantiations: 377
+vs:
+  zod: z.string().nullish()
+jsonSchema:
+  input: Expected JSON, received string | undefined | null
+  output: Expected JSON, received string | undefined | null
+operations:
+  parse:
+    expression: i=>{(typeof i==="string"||i===void 0||i===null)||e[0](i);return i}
+    examples:
+      string:
+        input: '"foo"'
+        output: '"foo"'
+      undefined:
+        input: undefined
+        output: undefined
+      "null":
+        input: "null"
+        output: "null"
+      invalid-type:
+        input: "1"
+        error: Expected string | undefined | null, received 1
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/object-advanced.yaml
+++ b/packages/sury/specs/object-advanced.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.object((s) => { s.tag("type", 0); return { nested: s.nested("nested").field("field", S.number), flattened: s.flatten(S.schema({ id: S.string })), foo: s.field("Foo", S.string), bar: s.fieldOr("Bar", S.boolean, true) } })'
+  input: "{ [x: string]: unknown; }"
+  output: "{ nested: number; flattened: { id: string; }; foo: string; bar: boolean; }"
+  instantiations: 1482
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "object", properties: { type: { type: "number", const: 0 }, nested: { type: "object", properties: { field: { type: "number" } }, required: ["field"] }, id: { type: "string" }, Foo: { type: "string" }, Bar: { default: true, type: "boolean" } }, required: ["type", "nested", "id", "Foo"] }'
+  output: '{ type: "object", properties: { nested: { type: "number" }, flattened: { type: "object", properties: { id: { type: "string" } }, required: ["id"] }, foo: { type: "string" }, bar: { type: "boolean" } }, required: ["nested", "flattened", "foo", "bar"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[6](i);let v0=i["type"],v1=i["nested"],v3=i["id"],v4=i["Foo"],v5=i["Bar"];v0===0||e[0](v0);typeof v1==="object"&&v1&&!Array.isArray(v1)||e[2](v1);let v2=v1["field"];typeof v2==="number"&&!Number.isNaN(v2)||e[1](v2);typeof v3==="string"||e[3](v3);typeof v4==="string"||e[4](v4);(typeof v5==="boolean"||v5===void 0)||e[5](v5);return {"nested":v2,"flattened":{"id":v3,},"foo":v4,"bar":v5===void 0?true:v5,}}
+    examples:
+      all-features:
+        input: '{ nested: { field: 123 }, type: 0, id: "id", Foo: "bar" }'
+        output: '{ nested: 123, flattened: { id: "id" }, foo: "bar", bar: true }'
+      with-explicit-bar:
+        input: '{ nested: { field: 123 }, type: 0, id: "id", Foo: "bar", Bar: false }'
+        output: '{ nested: 123, flattened: { id: "id" }, foo: "bar", bar: false }'
+      missing-tag:
+        input: '{ nested: { field: 123 }, id: "id", Foo: "bar" }'
+        error: 'Failed at ["type"]: Expected 0, received undefined'
+  decode:
+    expression: i=>{let v0=i["nested"],v1=i["Bar"];return {"nested":v0["field"],"flattened":{"id":i["id"],},"foo":i["Foo"],"bar":v1===void 0?true:v1,}}
+    examples:
+      all-features:
+        input: '{ nested: { field: 123 }, type: 0, id: "id", Foo: "bar" }'
+        output: '{ nested: 123, flattened: { id: "id" }, foo: "bar", bar: true }'
+  encode:
+    expression: i=>{let v0=i["flattened"];return {"id":v0["id"],"type":0,"nested":{"field":i["nested"],},"Foo":i["foo"],"Bar":i["bar"],}}
+    examples:
+      round-trip:
+        input: '{ nested: 123, flattened: { id: "id" }, foo: "bar", bar: true }'
+        output: '{ id: "id", type: 0, nested: { field: 123 }, Foo: "bar", Bar: true }'

--- a/packages/sury/specs/object-deep-strict.yaml
+++ b/packages/sury/specs/object-deep-strict.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.schema({ foo: { a: S.string } }).with(S.deepStrict)"
+  input: "{ foo: { a: string; }; }"
+  output: "{ foo: { a: string; }; }"
+  instantiations: 1708
+vs:
+  zod: "z.strictObject({ foo: z.strictObject({ a: z.string() }) })"
+jsonSchema:
+  input: '{ type: "object", properties: { foo: { type: "object", properties: { a: { type: "string" } }, additionalProperties: false, required: ["a"] } }, additionalProperties: false, required: ["foo"] }'
+  output: '{ type: "object", properties: { foo: { type: "object", properties: { a: { type: "string" } }, additionalProperties: false, required: ["a"] } }, additionalProperties: false, required: ["foo"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[4](i);let v0=i["foo"],v3;typeof v0==="object"&&v0&&!Array.isArray(v0)||e[2](v0);let v1=v0["a"],v2;typeof v1==="string"||e[0](v1);for(v2 in v0){if(v2!=="a"){e[1](v2)}}for(v3 in i){if(v3!=="foo"){e[3](v3)}}return i}
+    examples:
+      valid:
+        input: '{ foo: { a: "bar" } }'
+        output: '{ foo: { a: "bar" } }'
+      nested-excess-field:
+        input: '{ foo: { a: "bar", b: true } }'
+        error: 'Failed at ["foo"]: Unrecognized key "b"'
+  decode:
+    expression: i=>{let v0=i["foo"];return i}
+    examples:
+      valid:
+        input: '{ foo: { a: "bar" } }'
+        output: '{ foo: { a: "bar" } }'
+      nested-excess-field:
+        input: '{ foo: { a: "bar", b: true } }'
+        output: '{ foo: { a: "bar", b: true } }'
+  encode:
+    expression: i=>{let v0=i["foo"];return i}
+    examples:
+      valid:
+        input: '{ foo: { a: "bar" } }'
+        output: '{ foo: { a: "bar" } }'
+      nested-excess-field:
+        input: '{ foo: { a: "bar", b: true } }'
+        output: '{ foo: { a: "bar", b: true } }'

--- a/packages/sury/specs/object-proto-key.yaml
+++ b/packages/sury/specs/object-proto-key.yaml
@@ -17,10 +17,9 @@ vs:
 # the reversed dict onto the property's own schema and made `outputExpression`
 # render schema internals; that one is fixed (Object.create(null) in reverseDict,
 # the guard fromJSONSchema already uses for this key).
-# The examples cover only inputs the harness can serialize back to source; an
-# object with a `__proto__` own property is not one (see CONTRIBUTING.md), which
-# is also why both `jsonSchema` sides below are harness markers rather than
-# schemas — the output side reaching the same marker is what the fix restored.
+# Both `jsonSchema` sides below are harness markers rather than schemas because
+# S.toJSONSchema builds `properties` by plain assignment, so the emitted
+# document's own prototype is polluted the same way.
 jsonSchema:
   input: cannot represent a Object instance as spec source code
   output: cannot represent a Object instance as spec source code
@@ -40,5 +39,12 @@ operations:
       missing-field:
         input: "{}"
         error: 'Failed at ["__proto__"]: Expected string, received {}'
+      # FIXME: the one valid input. The result literal `{"__proto__":v0,}` runs
+      # the prototype setter (a string is ignored), so the key is dropped and a
+      # valid input parses to `{}` — the bug the comment above describes,
+      # pinned end to end.
+      present-key-is-dropped:
+        input: '{ ["__proto__"]: "x" }'
+        output: "{}"
   decode: identity
   encode: identity

--- a/packages/sury/specs/object-quoted-keys.yaml
+++ b/packages/sury/specs/object-quoted-keys.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.schema({ ['\"']: S.string, [\"'\"]: S.string, [\"`\"]: S.string })"
+  input: "{ \"\\\"\": string; \"'\": string; \"`\": string; }"
+  output: "{ \"\\\"\": string; \"'\": string; \"`\": string; }"
+  instantiations: 1233
+vs:
+  zod:
+    schema: "z.object({ '\"': z.string(), \"'\": z.string(), \"`\": z.string() })"
+    divergence: Same structural type — Zod's printer single-quotes the `"` key where Sury's escapes it inside double quotes.
+    input: "{ '\"': string; \"'\": string; \"`\": string; }"
+    output: "{ '\"': string; \"'\": string; \"`\": string; }"
+jsonSchema:
+  input: "{ type: \"object\", properties: { \"\\\"\": { type: \"string\" }, \"'\": { type: \"string\" }, \"`\": { type: \"string\" } }, required: [\"\\\"\", \"'\", \"`\"] }"
+  output: "{ type: \"object\", properties: { \"\\\"\": { type: \"string\" }, \"'\": { type: \"string\" }, \"`\": { type: \"string\" } }, required: [\"\\\"\", \"'\", \"`\"] }"
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[3](i);let v0=i["\""],v1=i["'"],v2=i["`"];typeof v0==="string"||e[0](v0);typeof v1==="string"||e[1](v1);typeof v2==="string"||e[2](v2);return {"\"":v0,"'":v1,"`":v2,}}
+    examples:
+      valid:
+        input: "{ \"\\\"\": \"\\\"\", \"'\": \"'\", \"`\": \"`\" }"
+        output: "{ \"\\\"\": \"\\\"\", \"'\": \"'\", \"`\": \"`\" }"
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/object-strict.yaml
+++ b/packages/sury/specs/object-strict.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.schema({ foo: S.string }).with(S.strict)"
+  aliases:
+    - "S.strict(S.schema({ foo: S.string }))"
+  input: "{ foo: string; }"
+  output: "{ foo: string; }"
+  instantiations: 1548
+vs:
+  zod: "z.strictObject({ foo: z.string() })"
+jsonSchema:
+  input: '{ type: "object", properties: { foo: { type: "string" } }, additionalProperties: false, required: ["foo"] }'
+  output: '{ type: "object", properties: { foo: { type: "string" } }, additionalProperties: false, required: ["foo"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[2](i);let v0=i["foo"],v1;typeof v0==="string"||e[0](v0);for(v1 in i){if(v1!=="foo"){e[1](v1)}}return i}
+    examples:
+      valid:
+        input: '{ foo: "bar" }'
+        output: '{ foo: "bar" }'
+      excess-field:
+        input: '{ foo: "bar", bar: true }'
+        error: Unrecognized key "bar"
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/object1.yaml
+++ b/packages/sury/specs/object1.yaml
@@ -3,6 +3,7 @@ ts:
   schema: "S.schema({a: S.string})"
   aliases:
     - "S.object({a: S.string})"
+    - "S.strip(S.strict(S.schema({a: S.string})))"
   input: "{ a: string; }"
   output: "{ a: string; }"
   instantiations: 1205

--- a/packages/sury/specs/optional-default.yaml
+++ b/packages/sury/specs/optional-default.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.optional, "foo")
+  input: string | undefined
+  output: string
+  instantiations: 5216
+vs:
+  zod: z.string().optional().transform((value) => value ?? "foo")
+jsonSchema:
+  input: Expected JSON, received string | undefined
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{(typeof i==="string"||i===void 0)||e[0](i);return i===void 0?"foo":i}
+    examples:
+      string:
+        input: '"bar"'
+        output: '"bar"'
+      undefined-becomes-the-default:
+        input: undefined
+        output: '"foo"'
+      null-is-not-accepted:
+        input: "null"
+        error: Expected string | undefined, received null
+  decode:
+    expression: i=>{return i===void 0?"foo":i}
+    examples:
+      string:
+        input: '"bar"'
+        output: '"bar"'
+      undefined-becomes-the-default:
+        input: undefined
+        output: '"foo"'
+  encode: identity

--- a/packages/sury/specs/optional.yaml
+++ b/packages/sury/specs/optional.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.optional(S.string)
+  aliases:
+    - S.optional(S.optional(S.optional(S.string)))
+  input: string | undefined
+  output: string | undefined
+  instantiations: 380
+vs:
+  zod: z.string().optional()
+jsonSchema:
+  input: Expected JSON, received string | undefined
+  output: Expected JSON, received string | undefined
+operations:
+  parse:
+    expression: i=>{(typeof i==="string"||i===void 0)||e[0](i);return i}
+    examples:
+      string:
+        input: '"foo"'
+        output: '"foo"'
+      undefined:
+        input: undefined
+        output: undefined
+      null-is-not-accepted:
+        input: "null"
+        error: Expected string | undefined, received null
+      invalid-type:
+        input: "1"
+        error: Expected string | undefined, received 1
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/record.yaml
+++ b/packages/sury/specs/record.yaml
@@ -26,6 +26,12 @@ operations:
       empty:
         input: "{}"
         output: "{}"
+      # FIXME: the `for (let v0 in i)` loop skips symbol keys entirely, so a
+      # value under one is never reached, whatever the value schema says — 123
+      # passes through a record of strings unvalidated and unstripped.
+      symbol-keyed-value-is-not-validated:
+        input: '{ [Symbol.for("k")]: 123 }'
+        output: '{ [Symbol.for("k")]: 123 }'
       invalid-value:
         input: "{ a: 1 }"
         error: 'Failed at ["a"]: Expected string, received 1'

--- a/packages/sury/specs/shape-string-to-object.yaml
+++ b/packages/sury/specs/shape-string-to-object.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: "S.shape(S.string, (string) => ({ foo: string }))"
+  input: string
+  output: "{ foo: string; }"
+  instantiations: 503
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "object", properties: { foo: { type: "string" } }, required: ["foo"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[0](i);return {"foo":i,}}
+    examples:
+      valid:
+        input: '"bar"'
+        output: '{ foo: "bar" }'
+      not-a-string:
+        input: "1"
+        error: Expected string, received 1
+  decode:
+    expression: i=>{return {"foo":i,}}
+    examples:
+      valid:
+        input: '"bar"'
+        output: '{ foo: "bar" }'
+  encode:
+    expression: i=>{return i["foo"]}
+    examples:
+      round-trip:
+        input: '{ foo: "bar" }'
+        output: '"bar"'

--- a/packages/sury/specs/string-length-custom-message.yaml
+++ b/packages/sury/specs/string-length-custom-message.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.length, 5, "Postcode must have 5 symbols")
+  input: string
+  output: string
+  instantiations: 5167
+vs:
+  zod: z.string().length(5, "Postcode must have 5 symbols")
+jsonSchema:
+  input: '{ type: "string", minLength: 5, maxLength: 5 }'
+  output: '{ type: "string", minLength: 5, maxLength: 5 }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[1](i);i.length===5||e[0](i);return i}
+    examples:
+      at-the-length:
+        input: '"12345"'
+        output: '"12345"'
+      too-short:
+        input: '"123"'
+        error: Postcode must have 5 symbols
+      wrong-type:
+        input: "42"
+        error: Expected string.length == 5, received 42
+  decode:
+    expression: i=>{i.length===5||e[0](i);return i}
+    examples:
+      too-short:
+        input: '"123"'
+        error: Postcode must have 5 symbols
+      at-the-length:
+        input: '"12345"'
+        output: '"12345"'
+  encode:
+    expression: i=>{i.length===5||e[0](i);return i}
+    examples:
+      too-short:
+        input: '"123"'
+        error: Postcode must have 5 symbols
+      at-the-length:
+        input: '"12345"'
+        output: '"12345"'

--- a/packages/sury/specs/string-refine-path.yaml
+++ b/packages/sury/specs/string-refine-path.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.string.with(S.refine, () => false, { error: "User error", path: ["data", "field"] })'
+  input: string
+  output: string
+  instantiations: 4966
+vs:
+  zod: 'z.string().refine(() => false, { message: "User error", path: ["data", "field"] })'
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);e[0](i)||e[1](i);return i}
+    examples:
+      always-fails-at-path:
+        input: '"123"'
+        error: 'Failed at ["data"]["field"]: User error'
+  decode:
+    expression: i=>{e[0](i)||e[1](i);return i}
+    examples:
+      always-fails-at-path:
+        input: '"123"'
+        error: 'Failed at ["data"]["field"]: User error'
+  encode:
+    expression: i=>{e[0](i)||e[1](i);return i}
+    examples:
+      always-fails-at-path:
+        input: '"123"'
+        error: 'Failed at ["data"]["field"]: User error'

--- a/packages/sury/specs/string-refine.yaml
+++ b/packages/sury/specs/string-refine.yaml
@@ -1,0 +1,42 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.string.with(S.refine, (value) => value !== "bad", { error: "User error" })'
+  input: string
+  output: string
+  instantiations: 4960
+vs:
+  zod: z.string().refine((value) => value !== "bad", "User error")
+jsonSchema:
+  input: '{ type: "string" }'
+  output: '{ type: "string" }'
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);e[0](i)||e[1](i);return i}
+    examples:
+      valid:
+        input: '"123"'
+        output: '"123"'
+      refuted:
+        input: '"bad"'
+        error: User error
+      not-a-string:
+        input: "1"
+        error: Expected string, received 1
+  decode:
+    expression: i=>{e[0](i)||e[1](i);return i}
+    examples:
+      valid:
+        input: '"123"'
+        output: '"123"'
+      refuted:
+        input: '"bad"'
+        error: User error
+  encode:
+    expression: i=>{e[0](i)||e[1](i);return i}
+    examples:
+      valid:
+        input: '"123"'
+        output: '"123"'
+      refuted:
+        input: '"bad"'
+        error: User error

--- a/packages/sury/specs/string-trim.yaml
+++ b/packages/sury/specs/string-trim.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.trim(S.string)
+  aliases:
+    - S.string.with(S.trim)
+  input: string
+  output: string
+  instantiations: 330
+vs:
+  zod: z.string().trim()
+jsonSchema:
+  input: '{ type: "string" }'
+  output: Expected JSON, received unknown
+operations:
+  parse:
+    expression: i=>{typeof i==="string"||e[2](i);let v0;try{v0=e[0](i)}catch(x){e[1](x)}return v0}
+    examples:
+      leading-whitespace:
+        input: '"  123"'
+        output: '"123"'
+      already-trimmed:
+        input: '"123"'
+        output: '"123"'
+      not-a-string:
+        input: "1"
+        error: Expected string, received 1
+  decode:
+    expression: i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}return v0}
+    examples:
+      leading-whitespace:
+        input: '"  123"'
+        output: '"123"'
+  encode:
+    expression: i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}typeof v0==="string"||e[2](v0);return v0}
+    examples:
+      valid:
+        input: '"123"'
+        output: '"123"'

--- a/packages/sury/specs/string.yaml
+++ b/packages/sury/specs/string.yaml
@@ -1,6 +1,8 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: S.string
+  aliases:
+    - S.schema(S.string)
   input: string
   output: string
   instantiations: 254

--- a/packages/sury/specs/tuple-transform-object.yaml
+++ b/packages/sury/specs/tuple-transform-object.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.tuple((s) => { s.tag(0, "point"); return { x: s.item(1, S.int32), y: s.item(2, S.int32) } })'
+  input: unknown[]
+  output: "{ x: number; y: number; }"
+  instantiations: 505
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "array", minItems: 3, maxItems: 3, items: [{ type: "string", const: "point" }, { type: "integer", minimum: -2147483648, maximum: 2147483647 }, { type: "integer", minimum: -2147483648, maximum: 2147483647 }] }'
+  output: '{ type: "object", properties: { x: { type: "integer", minimum: -2147483648, maximum: 2147483647 }, y: { type: "integer", minimum: -2147483648, maximum: 2147483647 } }, required: ["x", "y"] }'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)&&i.length===3||e[3](i);let v0=i["0"],v1=i["1"],v2=i["2"];v0==="point"||e[0](v0);typeof v1==="number"&&v1<=2147483647&&v1>=-2147483648&&v1%1===0||e[1](v1);typeof v2==="number"&&v2<=2147483647&&v2>=-2147483648&&v2%1===0||e[2](v2);return {"x":v1,"y":v2,}}
+    examples:
+      valid:
+        input: '["point", 1, -4]'
+        output: "{ x: 1, y: -4 }"
+      wrong-tag:
+        input: '["dot", 1, -4]'
+        error: 'Failed at ["0"]: Expected "point", received "dot"'
+      not-an-int32:
+        input: '["point", 1.5, -4]'
+        error: 'Failed at ["1"]: Expected int32, received 1.5'
+  decode:
+    expression: i=>{return {"x":i["1"],"y":i["2"],}}
+    examples:
+      valid:
+        input: '["point", 1, -4]'
+        output: "{ x: 1, y: -4 }"
+  encode:
+    expression: i=>{return ["point",i["x"],i["y"],]}
+    examples:
+      round-trip:
+        input: "{ x: 1, y: -4 }"
+        output: '["point", 1, -4]'

--- a/packages/sury/specs/tuple1-transform.yaml
+++ b/packages/sury/specs/tuple1-transform.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.schema([S.string.with(S.to, S.number, (s) => Number(s))])
+  input: "[string]"
+  output: "[number]"
+  instantiations: 5857
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "array", minItems: 1, maxItems: 1, items: [{ type: "string" }] }'
+  output: '{ type: "array", minItems: 1, maxItems: 1, items: [{ type: "number" }] }'
+operations:
+  parse:
+    expression: i=>{Array.isArray(i)&&i.length===1||e[3](i);let v1=i["0"];typeof v1==="string"||e[2](v1);let v0;try{v0=e[0](i["0"])}catch(x){e[1](x)}return [v0,]}
+    examples:
+      valid:
+        input: '["123"]'
+        output: "[123]"
+      not-numeric-text:
+        input: '["abc"]'
+        output: "[NaN]"
+      not-a-string-item:
+        input: "[123]"
+        error: 'Failed at ["0"]: Expected string, received 123'
+  decode:
+    expression: i=>{let v0;try{v0=e[0](i["0"])}catch(x){e[1](x)}return [v0,]}
+    examples:
+      valid:
+        input: '["123"]'
+        output: "[123]"
+  encode:
+    expression: i=>{return [""+i["0"],]}
+    examples:
+      round-trip:
+        input: "[123]"
+        output: '["123"]'

--- a/packages/sury/specs/union3-literals.yaml
+++ b/packages/sury/specs/union3-literals.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.union(["foo", 123, true])
+  input: true | "foo" | 123
+  output: true | "foo" | 123
+  instantiations: 617
+vs:
+  zod: z.union([z.literal("foo"), z.literal(123), z.literal(true)])
+jsonSchema:
+  input: '{ enum: ["foo", 123, true] }'
+  output: '{ enum: ["foo", 123, true] }'
+operations:
+  parse:
+    expression: i=>{(typeof i==="string"&&i==="foo"||typeof i==="number"&&!Number.isNaN(i)&&i===123||typeof i==="boolean"&&i===true)||e[0](i);return i}
+    examples:
+      string:
+        input: '"foo"'
+        output: '"foo"'
+      number:
+        input: "123"
+        output: "123"
+      boolean:
+        input: "true"
+        output: "true"
+      invalid:
+        input: '"bar"'
+        error: Expected "foo" | 123 | true, received "bar"
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/union5-env-boolean.yaml
+++ b/packages/sury/specs/union5-env-boolean.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.union([S.schema("t").with(S.to, S.schema(true)).with(S.to, S.boolean), S.schema("1").with(S.to, S.schema(true)).with(S.to, S.boolean), S.schema("f").with(S.to, S.schema(false)).with(S.to, S.boolean), S.schema("0").with(S.to, S.schema(false)).with(S.to, S.boolean), S.string.with(S.to, S.boolean)])
+  input: string
+  output: boolean
+  instantiations: 9234
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ anyOf: [{ type: "string", const: "t" }, { type: "string", const: "1" }, { type: "string", const: "f" }, { type: "string", const: "0" }, { type: "string" }] }'
+  output: '{ anyOf: [{ type: "boolean", const: true }, { type: "boolean", const: false }, { type: "boolean" }] }'
+operations:
+  parse:
+    expression: i=>{for(;;){if(typeof i==="string"&&i==="t"){i=true;break}if(typeof i==="string"&&i==="1"){i=true;break}if(typeof i==="string"&&i==="f"){i=false;break}if(typeof i==="string"&&i==="0"){i=false;break}if(typeof i==="string"){let v0;(v0=i==="true")||i==="false"||e[0](i);i=v0;break}e[1](i)}return i}
+    examples:
+      t-shorthand:
+        input: '"t"'
+        output: "true"
+      one-shorthand:
+        input: '"1"'
+        output: "true"
+      f-shorthand:
+        input: '"f"'
+        output: "false"
+      zero-shorthand:
+        input: '"0"'
+        output: "false"
+      true-text:
+        input: '"true"'
+        output: "true"
+      false-text:
+        input: '"false"'
+        output: "false"
+      not-a-boolean-text:
+        input: '"x"'
+        error: Expected boolean, received "x"
+      not-a-string:
+        input: "1"
+        error: Expected "t" | "1" | "f" | "0" | string, received 1
+  decode: eq-to-parse
+  encode:
+    expression: i=>{for(;;){if(typeof i==="boolean"&&i===true){i="t";break}if(typeof i==="boolean"&&i===false){i="f";break}if(typeof i==="boolean"){i=""+i;break}e[0](i)}return i}
+    examples:
+      "true":
+        input: "true"
+        output: '"t"'
+      "false":
+        input: "false"
+        output: '"f"'

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -47,84 +47,6 @@ const expectSchemaType = <TSchema extends S.Schema<unknown, unknown>>(
 // Can use genType schema
 // expectSchemaType(stringSchema).toBe<unknown, string>();
 
-test("JSON string demo", (t) => {
-  t.expect(S.parser(S.jsonString)("123")).toEqual("123");
-  // i=>{if(typeof i!=="string"){e[1](i)}try{JSON.parse(i)}catch(t){e[0](i)}return i}
-
-  const schemaWithTo = S.jsonString.with(S.to, S.number);
-  t.expect(S.parser(schemaWithTo)("123")).toEqual(123);
-  // i=>{if(typeof i!=="string"){e[2](i)}let v0;try{v0=JSON.parse(i)}catch(t){e[0](i)}if(typeof v0!=="number"||Number.isNaN(v0)){e[1](v0)}return v0}
-
-  const schemaWithTo2 = S.number.with(S.to, S.jsonString);
-  t.expect(S.decoder(schemaWithTo2)(123)).toEqual("123");
-  // i=>{return ""+i}
-});
-
-test("Successfully parses string with built-in refinement", (t) => {
-  const schema = S.string.with(S.length, 5);
-  const result = S.safe(() => S.parser(schema)("123"));
-
-  expectTypeOf(result).toEqualTypeOf<S.Result<string>>();
-
-  if (result.success) {
-    t.expect.fail("Should fail");
-    return;
-  }
-  t.expect(result.error.message).toBe(
-    'Expected string.length == 5, received "123"',
-  );
-
-  expectSchemaType(schema).toBe<string, string>();
-  expectTypeOf(result).toEqualTypeOf<{
-    readonly success: false;
-    readonly error: S.Error;
-  }>();
-});
-
-test("Successfully parses string with built-in refinement and custom message", (t) => {
-  const schema = S.string.with(S.length, 5, "Postcode must have 5 symbols");
-  const result = S.safe(() => S.parser(schema)("123"));
-
-  if (result.success) {
-    t.expect.fail("Should fail");
-    return;
-  }
-  t.expect(result.error.message).toBe("Postcode must have 5 symbols");
-
-  expectSchemaType(schema).toBe<string, string>();
-});
-
-test("S.pattern preserves the Input type through a transform (#282)", (t) => {
-  // Regression test for https://github.com/DZakh/sury/pull/282 — pattern's
-  // .d.ts declaration was missing the `schema` param, which hard-coded
-  // Input to `string` and broke any schema whose Input differs from Output.
-  const schema = S.number.with(S.to, S.jsonString).with(S.pattern, /^\d+$/);
-
-  t.expect(S.decoder(schema)(123)).toEqual("123");
-
-  expectSchemaType(schema).toBe<number, string>();
-});
-
-test("Successfully parses string with built-in transform", (t) => {
-  const schema = S.trim(S.string);
-  const value = S.parser(schema)("  123");
-
-  t.expect(value).toEqual("123");
-
-  expectSchemaType(schema).toBe<string, string>();
-  expectTypeOf(value).toEqualTypeOf<string>();
-});
-
-test("Successfully parses string to Date via S.to(S.date)", (t) => {
-  const schema = S.to(S.string, S.date);
-  const value = S.parser(schema)("2020-01-01T00:00:00Z");
-
-  t.expect(value).toEqual(new Date("2020-01-01T00:00:00Z"));
-
-  expectSchemaType(schema).toBe<string, Date>();
-  expectTypeOf(value).toEqualTypeOf<Date>();
-});
-
 test("S.to returns the schema itself when the target is the same instance", (t) => {
   const make = () => S.string.with(S.to, S.number, (string) => string.length);
   const schema = make();
@@ -144,26 +66,6 @@ test("S.to returns the schema itself when the target is the same instance", (t) 
 
   expectSchemaType(schema).toBe<string, number>();
   expectSchemaType(S.to(schema, schema)).toBe<string, number>();
-});
-
-test("Successfully parses string to Date with S.to", (t) => {
-  const schema = S.string.with(S.to, S.date);
-  const value = S.parser(schema)("2024-01-01T00:00:00.000Z");
-
-  t.expect(value).toEqual(new Date("2024-01-01T00:00:00.000Z"));
-
-  expectSchemaType(schema).toBe<string, Date>();
-  expectTypeOf(value).toEqualTypeOf<Date>();
-});
-
-test("Successfully converts Date to string with S.to", (t) => {
-  const schema = S.date.with(S.to, S.string);
-  const value = S.decoder(schema)(new Date("2024-01-01T00:00:00.000Z"));
-
-  t.expect(value).toBe("2024-01-01T00:00:00.000Z");
-
-  expectSchemaType(schema).toBe<Date, string>();
-  expectTypeOf(value).toEqualTypeOf<string>();
 });
 
 test("Function literal schema", (t) => {
@@ -198,42 +100,6 @@ test("Successfully parses float when NaN is provided and NaN check disabled in g
   expectTypeOf(value).toEqualTypeOf<number>();
 });
 
-test("Successfully parses json", (t) => {
-  const schema = S.json;
-  const value = S.parser(schema)(true);
-
-  t.expect(value).toEqual(true);
-
-  expectSchemaType(schema).toBe<S.JSON, S.JSON>();
-  expectTypeOf(value).toEqualTypeOf<S.JSON>();
-});
-
-test("Successfully parses invalid json without validation", (t) => {
-  const schema = S.json.with(S.noValidation, true);
-
-  let fn = S.parser(schema);
-
-  const value = fn(undefined);
-  t.expect(value).toEqual(undefined);
-
-  t.expect(fn.name).toEqual(`noopOperation`);
-
-  t.expect(fn([undefined])).toEqual([undefined]);
-
-  expectSchemaType(schema).toBe<S.JSON, S.JSON>();
-  expectTypeOf(value).toEqualTypeOf<S.JSON>();
-});
-
-test("Successfully parses undefined", (t) => {
-  const schema = S.schema(undefined);
-  const value = S.parser(schema)(undefined);
-
-  t.expect(value).toEqual(undefined);
-
-  expectSchemaType(schema).toBe<undefined, undefined>();
-  expectTypeOf(value).toEqualTypeOf<undefined>();
-});
-
 test("Can get a reason from an error", (t) => {
   const schema = S.never;
 
@@ -244,82 +110,6 @@ test("Can get a reason from an error", (t) => {
     return;
   }
   t.expect(result.error.reason).toBe("Expected never, received true");
-});
-
-test("Successfully parses array", (t) => {
-  const schema = S.array(S.string);
-  const value = S.parser(schema)(["foo"]);
-
-  t.expect(value).toEqual(["foo"]);
-
-  expectSchemaType(schema).toBe<string[], string[]>();
-  expectTypeOf(value).toEqualTypeOf<string[]>();
-});
-
-test("Transforms array of bigint to array of string", (t) => {
-  const fn = S.decoder(S.array(S.bigint), S.array(S.string));
-
-  t.expect(fn.toString()).toEqual(
-    `i=>{let v2=new Array(i.length);for(let v1=0;v1<i.length;++v1){v2[v1]=""+i[v1]}return v2}`,
-  );
-  t.expect(fn([123n])).toEqual(["123"]);
-});
-
-test("Successfully parses array with min and max refinements", (t) => {
-  const schema = S.array(S.string).with(S.minLength, 1).with(S.maxLength, 2);
-  const value = S.parser(schema)(["foo"]);
-  t.expect(value).toEqual(["foo"]);
-
-  const result = S.safe(() => S.parser(schema)([]));
-  t.expect(result.error?.message).toEqual("Expected 1 <= string[].length <= 2, received []");
-
-  expectSchemaType(schema).toBe<string[], string[]>();
-  expectTypeOf(value).toEqualTypeOf<string[]>();
-});
-
-test("Successfully parses record", (t) => {
-  const schema = S.record(S.string);
-  const value = S.parser(schema)({ foo: "bar" });
-
-  t.expect(value).toEqual({ foo: "bar" });
-
-  expectSchemaType(schema).toBe<Record<string, string>>();
-  expectTypeOf(value).toEqualTypeOf<Record<string, string>>();
-});
-
-test("Successfully parses JSON string", (t) => {
-  const schema = S.jsonString.with(S.to, S.boolean);
-  const value = S.parser(schema)(`true`);
-
-  t.expect(value).toEqual(true);
-  t.expect(schema.type === "string" && schema.format === "json").toEqual(true);
-
-  expectSchemaType(schema).toBe<string, boolean>();
-  expectTypeOf(value).toEqualTypeOf<boolean>();
-});
-
-test("Parse JSON string, extract a field, and serialize it back to JSON string", (t) => {
-  const schema = S.jsonString
-    .with(
-      S.to,
-      S.schema({
-        type: "info",
-        value: S.number,
-      }).with(S.shape, (msg) => msg.value),
-    )
-    .with(S.to, S.jsonString);
-
-  t.expect(S.parser(schema)(`{"type": "info", "value": 123}`)).toEqual("123");
-  t.expect(() => S.parser(schema)(`{"type": "info", "value": "123"}`)).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: `Failed at ["value"]: Expected number, received "123"`,
-    }),
-  );
-
-  t.expect(S.encoder(schema)("123")).toEqual(`{"type":"info","value":123}`);
-
-  expectSchemaType(schema).toBe<string, string>();
 });
 
 test("Parse JSON string to object with bigint and back", (t) => {
@@ -346,40 +136,6 @@ test("Parse JSON string to object with bigint and back", (t) => {
       118, 97, 108, 117, 101, 34, 58, 34, 49, 50, 51, 34, 125,
     ]),
   );
-});
-
-test("Successfully serialized JSON object", (t) => {
-  const objectSchema = S.schema({ foo: [1, S.number] });
-  const schema = S.jsonString.with(S.to, objectSchema);
-  const schemaWithSpace = S.jsonStringWithSpace(2).with(S.to, objectSchema);
-
-  const value = S.encoder(schema)({ foo: [1, 2] });
-  t.expect(value).toEqual('{"foo":[1,2]}');
-
-  const valueWithSpace = S.encoder(schemaWithSpace)({ foo: [1, 2] });
-  t.expect(valueWithSpace).toEqual('{\n  "foo": [\n    1,\n    2\n  ]\n}');
-
-  expectSchemaType(schema).toBe<string, { foo: [1, number] }>();
-  expectSchemaType(schema).toBe<
-    S.Input<typeof schemaWithSpace>,
-    S.Output<typeof schemaWithSpace>
-  >();
-  expectTypeOf(value).toEqualTypeOf<string>();
-});
-
-test("Successfully parses optional string", (t) => {
-  const schema = S.optional(S.string);
-  const value1 = S.parser(schema)("foo");
-  const value2 = S.parser(schema)(undefined);
-
-  t.expect(value1).toEqual("foo");
-  t.expect(value2).toEqual(undefined);
-
-  expectTypeOf(schema).toEqualTypeOf<
-    S.Schema<string | undefined, string | undefined>
-  >();
-  expectTypeOf(value1).toEqualTypeOf<string | undefined>();
-  expectTypeOf(value2).toEqualTypeOf<string | undefined>();
 });
 
 test("Optional enum", (t) => {
@@ -479,65 +235,6 @@ test("Optional enum", (t) => {
   >();
 });
 
-test("Successfully parses schema wrapped in optional multiple times", (t) => {
-  const schema = S.optional(S.optional(S.optional(S.string)));
-  const value1 = S.parser(schema)("foo");
-  const value2 = S.parser(schema)(undefined);
-
-  t.expect(value1).toEqual("foo");
-  t.expect(value2).toEqual(undefined);
-
-  expectTypeOf(schema).toEqualTypeOf<
-    S.Schema<string | undefined, string | undefined>
-  >();
-  expectTypeOf(value1).toEqualTypeOf<string | undefined>();
-  expectTypeOf(value2).toEqualTypeOf<string | undefined>();
-});
-
-test("Successfully parses nullable string", (t) => {
-  const schema = S.nullable(S.string);
-  const value1 = S.parser(schema)("foo");
-  const value2 = S.parser(schema)(null);
-
-  t.expect(value1).toEqual("foo");
-  t.expect(value2).toEqual(null);
-
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string | null, string | null>>();
-  expectTypeOf(value1).toEqualTypeOf<string | null>();
-});
-
-test("Successfully parses nullable of array with default", (t) => {
-  const schema = S.nullable(S.array(S.string), []);
-  const value1 = S.parser(schema)(["foo"]);
-  const value2 = S.parser(schema)(null);
-
-  t.expect(value1).toEqual(["foo"]);
-  t.expect(value2).toEqual([]);
-
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string[] | null, string[]>>();
-  expectTypeOf(value1).toEqualTypeOf<string[]>();
-});
-
-test("Successfully parses nullable string with default", (t) => {
-  const schema = S.nullable(S.string, "bar");
-
-  const value1 = S.parser(schema)("foo");
-  const value2 = S.parser(schema)(null);
-
-  t.expect(value1).toEqual("foo");
-  t.expect(value2).toEqual("bar");
-
-  t.expect(() => S.parser(schema)(undefined)).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "Expected string | null, received undefined",
-    }),
-  );
-
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string | null, string>>();
-  expectTypeOf(value1).toEqualTypeOf<string>();
-});
-
 test("Successfully parses nullable string with dynamic default", (t) => {
   const schema = S.nullable(S.string, () => "bar");
   const value1 = S.parser(schema)("foo");
@@ -548,51 +245,6 @@ test("Successfully parses nullable string with dynamic default", (t) => {
 
   expectTypeOf(schema).toEqualTypeOf<S.Schema<string | null, string>>();
   expectTypeOf(value1).toEqualTypeOf<string>();
-});
-
-test("Successfully parses nullish string", (t) => {
-  const schema = S.nullish(S.string);
-  const value1 = S.parser(schema)("foo");
-  const value2 = S.parser(schema)(undefined);
-  const value3 = S.parser(schema)(null);
-
-  t.expect(value1).toEqual("foo");
-  t.expect(value2).toEqual(undefined);
-  t.expect(value3).toEqual(null);
-
-  expectTypeOf(schema).toEqualTypeOf<
-    S.Schema<string | undefined | null, string | undefined | null>
-  >();
-  expectTypeOf(value1).toEqualTypeOf<string | undefined | null>();
-});
-
-test("Successfully parses schema wrapped in nullable multiple times", (t) => {
-  const nullable = S.nullable(S.string);
-  const schema = S.nullable(S.nullable(nullable));
-  const value1 = S.parser(schema)("foo");
-  const value2 = S.parser(schema)(null);
-
-  // TODO: Test that it should flatten nested nullable schemas
-
-  t.expect(value1).toEqual("foo");
-  t.expect(value2).toEqual(null);
-
-  expectTypeOf(schema).toEqualTypeOf<S.Schema<string | null, string | null>>();
-  expectTypeOf(value1).toEqualTypeOf<string | null>();
-  expectTypeOf(value2).toEqualTypeOf<string | null>();
-});
-
-test("Fails to parse with invalid data", (t) => {
-  const schema = S.string;
-
-  t.expect(() => {
-    S.parser(schema)(123);
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "Expected string, received 123",
-    }),
-  );
 });
 
 test("Pattern match on schema", (t) => {
@@ -621,164 +273,6 @@ test("Test extended JSON Schema", (t) => {
     minimum: -2147483648,
     maximum: 2147483647,
   });
-});
-
-test("Successfully reverse converts with valid value", (t) => {
-  const schema = S.string;
-  const result = S.encoder(schema)("123");
-
-  t.expect(result).toEqual("123");
-
-  expectTypeOf(result).toEqualTypeOf<string>();
-});
-
-test("Successfully reverse converts to Json with valid value", (t) => {
-  const schema = S.string;
-  const result = S.encoder(schema, S.json)("123");
-
-  t.expect(result).toEqual("123");
-
-  expectTypeOf(result).toEqualTypeOf<S.JSON>();
-});
-
-test("Successfully reverse converts to Json string with valid value", (t) => {
-  const result = S.encoder(S.int32, S.jsonString)(123);
-
-  t.expect(result).toEqual(`123`);
-
-  expectTypeOf(result).toEqualTypeOf<string>();
-});
-
-test("Fails to serialize never", (t) => {
-  const schema = S.never;
-
-  t.expect(() => {
-    S.encoder(schema)("123" as never);
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: `Expected never, received "123"`,
-    }),
-  );
-});
-
-test("Successfully parses with transform to another type", (t) => {
-  const schema = S.string.with(S.to, S.number, (string) => Number(string));
-  const value = S.parser(schema)("123");
-
-  t.expect(value).toEqual(123);
-
-  expectTypeOf(value).toEqualTypeOf<number>();
-});
-
-test("Handles errors during custom encoding", (t) => {
-  const schema = S.string.with(S.to, S.number, undefined, (number) => {
-    if (number < 100) {
-      throw new Error("Number is too small");
-    }
-    return number.toString();
-  });
-
-  const output = S.parser(schema)("80");
-  t.expect(output).toEqual(80);
-
-  t.expect(() => {
-    S.encoder(schema)(output);
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "Number is too small",
-    }),
-  );
-});
-
-test("Fails to parse with transform with user error", (t) => {
-  const schema = S.string.with(S.to, S.number, (string) => {
-    const number = Number(string);
-    if (Number.isNaN(number)) {
-      throw new Error("Invalid number");
-    }
-    return number;
-  });
-  const value = S.parser(schema)("123");
-  t.expect(value).toEqual(123);
-  expectTypeOf(value).toEqualTypeOf<number>();
-
-  t.expect(() => {
-    S.parser(schema)("asdf");
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "Invalid number",
-    }),
-  );
-});
-
-test("Successfully converts reversed schema with transform to another type", (t) => {
-  const schema = S.string.with(S.to, S.number, undefined, (number) => {
-    expectTypeOf(number).toEqualTypeOf<number>();
-    return number.toString();
-  });
-  const result = S.encoder(schema)(123);
-
-  t.expect(result).toEqual("123");
-
-  expectTypeOf(result).toEqualTypeOf<string>();
-});
-
-test("Successfully parses with refine", (t) => {
-  const schema = S.string.with(S.refine, (string) => {
-    expectTypeOf(string).toEqualTypeOf<string>();
-    return true;
-  });
-  const value = S.parser(schema)("123");
-
-  t.expect(value).toEqual("123");
-
-  expectTypeOf(value).toEqualTypeOf<string>();
-});
-
-test("Successfully reverse converts with refine", (t) => {
-  const schema = S.string.with(S.refine, (string) => {
-    expectTypeOf(string).toEqualTypeOf<string>();
-    return true;
-  });
-  const result = S.encoder(schema)("123");
-
-  t.expect(result).toEqual("123");
-
-  expectTypeOf(result).toEqualTypeOf<string>();
-});
-
-test("Fails to parses with refine raising an error", (t) => {
-  const schema = S.string.with(S.refine, () => false, {
-    error: "User error",
-  });
-
-  t.expect(() => {
-    S.parser(schema)("123");
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "User error",
-    }),
-  );
-});
-
-test("Fails to parse with refine with path option", (t) => {
-  const schema = S.string.with(S.refine, () => false, {
-    error: "User error",
-    path: ["data", "field"],
-  });
-
-  t.expect(() => {
-    S.parser(schema)("123");
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: `Failed at ["data"]["field"]: User error`,
-    }),
-  );
 });
 
 test("JS refine produces invalid_input error with expected/received populated", (t) => {
@@ -832,210 +326,6 @@ test("Fails to parses async schema", async (t) => {
   t.expect(result.error.code).toBe("invalid_conversion");
 });
 
-test("Successfully parses object by provided shape", (t) => {
-  const schema = S.schema({
-    foo: S.string,
-    bar: S.boolean,
-  });
-  const value = S.parser(schema)({
-    foo: "bar",
-    bar: true,
-  });
-
-  t.expect(value).toEqual({
-    foo: "bar",
-    bar: true,
-  });
-
-  expectSchemaType(schema).toBe<
-    { foo: string; bar: boolean },
-    { foo: string; bar: boolean }
-  >();
-  expectTypeOf(value).toEqualTypeOf<{ foo: string; bar: boolean }>();
-});
-
-test("Successfully parses object with quoted keys", (t) => {
-  const schema = S.schema({
-    [`"`]: S.string,
-    [`'`]: S.string,
-    ["`"]: S.string,
-  });
-  const value = S.parser(schema)({
-    '"': '"',
-    "'": "'",
-    "`": "`",
-  });
-
-  t.expect(value).toEqual({
-    '"': '"',
-    "'": "'",
-    "`": "`",
-  });
-
-  expectSchemaType(schema).toBe<{ '"': string; "'": string; "`": string }>();
-});
-
-test("Successfully parses tagged object", (t) => {
-  const schema = S.schema({
-    tag: "block" as const,
-    bar: S.boolean,
-  });
-  const value = S.parser(schema)({
-    tag: "block",
-    bar: true,
-  });
-
-  t.expect(value).toEqual({
-    tag: "block",
-    bar: true,
-  });
-
-  expectSchemaType(schema).toBe<
-    { tag: "block"; bar: boolean },
-    { tag: "block"; bar: boolean }
-  >();
-  expectTypeOf(value).toEqualTypeOf<{ tag: "block"; bar: boolean }>();
-});
-
-test("Successfully parses and reverse convert object with optional field", (t) => {
-  const schema = S.schema({
-    bar: S.optional(S.boolean),
-    baz: S.boolean,
-  });
-  const value = S.parser(schema)({ baz: true });
-  t.expect(value).toEqual({ bar: undefined, baz: true });
-
-  const reversed = S.encoder(schema)({ baz: true });
-  t.expect(reversed).toEqual({ baz: true });
-
-  expectSchemaType(schema).toBe<
-    { bar?: boolean | undefined; baz: boolean },
-    { bar?: boolean | undefined; baz: boolean }
-  >();
-});
-
-test("Successfully parses object with field names transform", (t) => {
-  const schema = S.object((s) => ({
-    foo: s.field("Foo", S.string),
-    bar: s.field("Bar", S.boolean),
-  }));
-  const value = S.parser(schema)({
-    Foo: "bar",
-    Bar: true,
-  });
-
-  t.expect(value).toEqual({
-    foo: "bar",
-    bar: true,
-  });
-
-  expectSchemaType(schema).toBe<
-    Record<string, unknown>,
-    { foo: string; bar: boolean }
-  >();
-  expectTypeOf(value).toEqualTypeOf<{ foo: string; bar: boolean }>();
-});
-
-test("Successfully parses advanced object with all features", (t) => {
-  const schema = S.object((s) => {
-    s.tag("type", 0);
-    return {
-      nested: s.nested("nested").field("field", S.number),
-      flattened: s.flatten(S.schema({ id: S.string })),
-      foo: s.field("Foo", S.string),
-      bar: s.fieldOr("Bar", S.boolean, true),
-    };
-  });
-
-  const value = S.parser(schema)({
-    nested: {
-      field: 123,
-    },
-    type: 0,
-    id: "id",
-    Foo: "bar",
-  });
-
-  t.expect(value).toEqual({
-    nested: 123,
-    flattened: { id: "id" },
-    foo: "bar",
-    bar: true,
-  });
-
-  expectSchemaType(schema).toBe<
-    Record<string, unknown>,
-    { nested: number; flattened: { id: string }; foo: string; bar: boolean }
-  >();
-});
-
-test("Successfully parses object with transformed field", (t) => {
-  const schema = S.schema({
-    foo: S.string.with(S.to, S.number, (string) => Number(string)),
-    bar: S.boolean,
-  });
-  const value = S.parser(schema)({
-    foo: "123",
-    bar: true,
-  });
-
-  t.expect(value).toEqual({
-    foo: 123,
-    bar: true,
-  });
-
-  expectSchemaType(schema).toBe<
-    { foo: string; bar: boolean },
-    { foo: number; bar: boolean }
-  >();
-  expectTypeOf(value).toEqualTypeOf<{ foo: number; bar: boolean }>();
-});
-
-test("Fails to parse strict object with exccess fields", (t) => {
-  const schema = S.schema({
-    foo: S.string,
-  }).with(S.strict);
-
-  t.expect(() => {
-    const value = S.parser(schema)({
-      foo: "bar",
-      bar: true,
-    });
-    expectTypeOf(schema).toEqualTypeOf<
-      S.Schema<{ foo: string }, { foo: string }>
-    >();
-    expectTypeOf(value).toEqualTypeOf<{ foo: string }>();
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: `Unrecognized key "bar"`,
-    }),
-  );
-});
-
-test("Fails to parse deep strict object with exccess fields", (t) => {
-  const schema = S.schema({
-    foo: {
-      a: S.string,
-    },
-  }).with(S.deepStrict);
-
-  t.expect(() => {
-    const value = S.parser(schema)({
-      foo: {
-        a: "bar",
-        b: true,
-      },
-    });
-    expectSchemaType(schema).toBe<{ foo: { a: string } }>();
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: `Failed at ["foo"]: Unrecognized key "b"`,
-    }),
-  );
-});
-
 test("Fails to parse strict object with exccess fields which created using global config override", (t) => {
   S.global({
     defaultAdditionalItems: "strict",
@@ -1061,26 +351,6 @@ test("Fails to parse strict object with exccess fields which created using globa
       message: `Unrecognized key "bar"`,
     }),
   );
-});
-
-test("Resets object strict mode with strip method", (t) => {
-  const schema = S.strip(
-    S.strict(
-      S.schema({
-        foo: S.string,
-      }),
-    ),
-  );
-
-  const value = S.parser(schema)({
-    foo: "bar",
-    bar: true,
-  });
-
-  t.expect(value).toEqual({ foo: "bar" });
-
-  expectSchemaType(schema).toBe<{ foo: string }, { foo: string }>();
-  expectTypeOf(value).toEqualTypeOf<{ foo: string }>();
 });
 
 test("Fails to parse intersected objects with transform", (t) => {
@@ -1144,135 +414,6 @@ test("Fails to parse intersected objects with transform", (t) => {
   // });
 });
 
-test("Merge overwrites the left fields by schema from the right", (t) => {
-  const baseSchema = S.schema({
-    type: S.union(["foo", "bar"]),
-    name: S.string,
-  });
-
-  const fooSchema = S.merge(
-    baseSchema,
-    S.schema({
-      type: "foo" as const,
-      fooCount: S.number,
-    }),
-  );
-
-  const value = S.parser(fooSchema)({
-    type: "foo",
-    name: "foo",
-    fooCount: 123,
-  });
-
-  expectSchemaType(fooSchema).toBe<
-    { type: "foo"; name: string; fooCount: number },
-    { type: "foo"; name: string; fooCount: number }
-  >();
-
-  t.expect(value).toEqual({
-    type: "foo",
-    name: "foo",
-    fooCount: 123,
-  });
-
-  t.expect(() =>
-    S.parser(fooSchema)({
-      type: "bar",
-      name: "foo",
-      fooCount: 123,
-    }),
-  ).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: `Failed at ["type"]: Expected "foo", received "bar"`,
-    }),
-  );
-});
-
-test("Name of merge schema", (t) => {
-  const schema = S.merge(
-    S.schema({
-      foo: S.string,
-      bar: S.boolean,
-    }),
-    S.schema({
-      baz: S.string,
-    }),
-  );
-
-  t.expect(S.inputExpression(schema)).toBe(
-    `{ foo: string; bar: boolean; baz: string; }`,
-  );
-});
-
-test("Successfully parses object using S.schema", (t) => {
-  const schema = S.schema({
-    foo: S.string,
-    bar: S.boolean,
-  });
-  const value = S.parser(schema)({
-    foo: "bar",
-    bar: true,
-  });
-
-  t.expect(value).toEqual({
-    foo: "bar",
-    bar: true,
-  });
-
-  expectSchemaType(schema).toBe<{ foo: string; bar: boolean }>();
-  expectTypeOf(value).toEqualTypeOf<{ foo: string; bar: boolean }>();
-});
-
-test("Successfully parses tuple using S.schema", (t) => {
-  const schema = S.schema([S.string, S.boolean] as const);
-  const value = S.parser(schema)(["bar", true]);
-
-  t.expect(value).toEqual(["bar", true]);
-
-  expectSchemaType(schema).toBe<[string, boolean]>();
-  expectTypeOf(value).toEqualTypeOf<[string, boolean]>();
-});
-
-test("Successfully parses primitive schema passed to S.schema", (t) => {
-  const schema = S.schema(S.string);
-  const value = S.parser(schema)("bar");
-
-  t.expect(value).toEqual("bar");
-
-  expectSchemaType(schema).toBe<string, string>();
-  expectTypeOf(value).toEqualTypeOf<string>();
-});
-
-test("Successfully parses literal using S.schema with as cost", (t) => {
-  const schema = S.schema("foo" as const);
-
-  const value = S.parser(schema)("foo");
-
-  t.expect(value).toEqual("foo");
-
-  expectSchemaType(schema).toBe<"foo">();
-  expectTypeOf(value).toEqualTypeOf<"foo">();
-});
-
-test("Successfully parses nested object using S.schema", (t) => {
-  const schema = S.schema({
-    foo: {
-      bar: S.number,
-    },
-  });
-  const value = S.parser(schema)({
-    foo: { bar: 123 },
-  });
-
-  t.expect(value).toEqual({
-    foo: { bar: 123 },
-  });
-
-  expectSchemaType(schema).toBe<{ foo: { bar: number } }>();
-  expectTypeOf(value).toEqualTypeOf<{ foo: { bar: number } }>();
-});
-
 test("Object with an S.never field is inferred as a required never property", (t) => {
   const schema = S.schema({
     key: S.string,
@@ -1304,30 +445,6 @@ test("Object with an S.optional(S.never) field is inferred as optional undefined
 
   const value = S.parser(schema)({ key: "value" });
   t.expect(value).toEqual({ key: "value", oldKey: undefined });
-});
-
-test("S.schema example", (t) => {
-  type Shape =
-    | { kind: "circle"; radius: number }
-    | { kind: "square"; x: number };
-
-  let circleSchema: S.Schema<Shape, Shape> = S.schema({
-    kind: "circle",
-    radius: S.number,
-  });
-
-  const value = S.parser(circleSchema)({
-    kind: "circle",
-    radius: 123,
-  });
-
-  t.expect(value).toEqual({
-    kind: "circle",
-    radius: 123,
-  });
-
-  expectTypeOf(circleSchema).toEqualTypeOf<S.Schema<Shape, Shape>>();
-  expectTypeOf(value).toEqualTypeOf<Shape>();
 });
 
 test("S.name", (t) => {
@@ -1375,93 +492,6 @@ test("Successfully reverse converts and returns result", (t) => {
       readonly error: S.Error;
     }>();
   }
-});
-
-test("Successfully parses union", (t) => {
-  const schema = S.union([S.string, S.number]);
-  const value = S.safe(() => S.parser(schema)("123"));
-
-  t.expect(value).toEqual({ success: true, value: "123" });
-
-  expectSchemaType(schema).toBe<string | number>();
-});
-
-test("Successfully parses union of literals", (t) => {
-  const schema = S.union(["foo", 123, true]);
-  const value = S.safe(() => S.parser(schema)("foo"));
-
-  t.expect(value).toEqual({ success: true, value: "foo" });
-
-  expectSchemaType(schema).toBe<"foo" | 123 | true>();
-});
-
-test("Shape union", (t) => {
-  const shapeSchema = S.union([
-    {
-      kind: "circle" as const,
-      radius: S.number,
-    },
-    {
-      kind: "square" as const,
-      x: S.number,
-    },
-    {
-      kind: "triangle" as const,
-      x: S.number,
-      y: S.number,
-    },
-  ]);
-  const value = S.parser(shapeSchema)({
-    kind: "circle",
-    radius: 123,
-  });
-
-  t.expect(value).toEqual({
-    kind: "circle",
-    radius: 123,
-  });
-
-  expectTypeOf(shapeSchema).toEqualTypeOf<
-    S.Schema<
-      | { kind: "circle"; radius: number }
-      | { kind: "square"; x: number }
-      | { kind: "triangle"; x: number; y: number },
-      | { kind: "circle"; radius: number }
-      | { kind: "square"; x: number }
-      | { kind: "triangle"; x: number; y: number }
-    >
-  >();
-});
-
-test("Successfully parses union with transformed items", (t) => {
-  const schema = S.union([
-    S.string.with(S.to, S.number, (string) => Number(string)),
-    S.number,
-  ]);
-  const value = S.safe(() => S.parser(schema)("123"));
-
-  t.expect(value).toEqual({ success: true, value: 123 });
-
-  expectSchemaType(schema).toBe<string | number, number>();
-});
-
-test("Correctly infers type", (t) => {
-  const schema = S.string.with(S.to, S.number, Number);
-  expectSchemaType(schema).toBe<string, number>();
-  expectTypeOf<S.Input<typeof schema>>().toEqualTypeOf<string>();
-  expectTypeOf<S.Output<typeof schema>>().toEqualTypeOf<number>();
-});
-
-test("Successfully parses undefined using the default value", (t) => {
-  const schema = S.string.with(S.optional, "foo");
-
-  const value = S.parser(schema)(undefined);
-
-  t.expect(value).toEqual("foo");
-  t.expect(schema.default).toEqual("foo");
-
-  expectTypeOf(schema.default).toEqualTypeOf<string | undefined>();
-  expectSchemaType(schema).toBe<string | undefined, string>();
 });
 
 test("Successfully parses undefined using the default value for transformed schema", (t) => {
@@ -1546,22 +576,6 @@ test("Creates schema with deprecation", (t) => {
   t.expect(schema.deprecated).toEqual(undefined);
   t.expect(deprecatedStringSchema.deprecated).toEqual(true);
   t.expect(deprecatedStringSchema.description).toEqual("Use number instead.");
-});
-
-test("Tuple with single element", (t) => {
-  const schema = S.schema([S.string.with(S.to, S.number, (s) => Number(s))]);
-
-  t.expect(S.parser(schema)(["123"])).toEqual([123]);
-
-  expectSchemaType(schema).toBe<[string], [number]>();
-});
-
-test("Tuple with multiple elements", (t) => {
-  const schema = S.schema([S.string, S.number, true]);
-
-  t.expect(S.parser(schema)(["123", 123, true])).toEqual(["123", 123, true]);
-
-  expectSchemaType(schema).toBe<[string, number, true]>();
 });
 
 test("Tuple types", (t) => {
@@ -1773,131 +787,6 @@ test("Standard JSON Schema interface support", (t) => {
   ).toThrow("Unsupported JSON Schema target: unsupported-target");
 });
 
-test("Env schema: Reggression version", (t) => {
-  const env = <T>(schema: S.Schema<unknown, T>): S.Schema<string, T> => {
-    if (schema.type === "boolean") {
-      return S.union([
-        S.schema("t").with(S.to, S.schema(true)).with(S.to, schema),
-        S.schema("1").with(S.to, S.schema(true)).with(S.to, schema),
-        S.schema("f").with(S.to, S.schema(false)).with(S.to, schema),
-        S.schema("0").with(S.to, S.schema(false)).with(S.to, schema),
-        S.string.with(S.to, schema),
-      ]);
-    } else if (
-      schema.type === "number" ||
-      schema.type === "bigint" ||
-      schema.type === "string"
-    ) {
-      return S.string.with(S.to, schema);
-    } else {
-      return S.jsonString.with(S.to, schema);
-    }
-  };
-
-  t.expect(S.parser(env(S.boolean)).toString()).toEqual(
-    `i=>{for(;;){if(typeof i==="string"&&i==="t"){i=true;break}if(typeof i==="string"&&i==="1"){i=true;break}if(typeof i==="string"&&i==="f"){i=false;break}if(typeof i==="string"&&i==="0"){i=false;break}if(typeof i==="string"){let v0;(v0=i==="true")||i==="false"||e[0](i);i=v0;break}e[1](i)}return i}`,
-  );
-
-  t.expect(S.parser(env(S.boolean))("t")).toEqual(true);
-  t.expect(S.parser(env(S.boolean))("true")).toEqual(true);
-});
-
-test("CompactColumns schema", (t) => {
-  const schema = S.to(
-    S.compactColumns(S.unknown),
-    S.array(
-      S.schema({
-        id: S.string,
-        name: S.nullable(S.string),
-        deleted: S.boolean,
-      }),
-    ),
-  );
-
-  // Test parsing columnar data to row objects
-  const parse = S.parser(schema);
-  const parsed = parse([
-    ["0", "1"],
-    ["Hello", null],
-    [false, true],
-  ] as unknown[][]);
-  t.expect(parsed).toEqual([
-    { id: "0", name: "Hello", deleted: false },
-    { id: "1", name: null, deleted: true },
-  ]);
-
-  // Test encoding row objects back to columnar data
-  const encode = S.encoder(schema);
-  const encoded = encode([
-    { id: "0", name: "Hello", deleted: false },
-    { id: "1", name: null, deleted: true },
-  ]);
-  t.expect(encoded).toEqual([
-    ["0", "1"],
-    ["Hello", null],
-    [false, true],
-  ]);
-});
-
-test("CompactColumns with json and bigint", (t) => {
-  const schema = S.to(
-    S.compactColumns(S.json),
-    S.array(
-      S.schema({
-        id: S.string,
-        amount: S.bigint,
-      }),
-    ),
-  );
-
-  // Test parsing - json strings are converted to bigint via BigInt()
-  const parse = S.parser(schema);
-  const parsed = parse([
-    ["0", "1"],
-    ["12345678901234567890", "98765432109876543210"],
-  ]);
-  t.expect(parsed).toEqual([
-    { id: "0", amount: 12345678901234567890n },
-    { id: "1", amount: 98765432109876543210n },
-  ]);
-
-  // Test encoding - bigint values are converted back to strings for json
-  const encode = S.encoder(schema);
-  const encoded = encode([
-    { id: "0", amount: 12345678901234567890n },
-    { id: "1", amount: 98765432109876543210n },
-  ]);
-  t.expect(encoded).toEqual([
-    ["0", "1"],
-    ["12345678901234567890", "98765432109876543210"],
-  ]);
-});
-
-test("Set schema", (t) => {
-  const schema = S.instance(Set);
-
-  expectSchemaType(schema).toBe<Set<unknown>, Set<unknown>>();
-  if (schema.type === "instance") {
-    expectTypeOf(schema.class).toEqualTypeOf<S.Class<Set<unknown>>>();
-    t.expect(schema.class).toBe(Set);
-  }
-
-  const parser = S.parser(schema);
-  expectTypeOf(parser).toEqualTypeOf<(input: unknown) => Set<unknown>>();
-
-  t.expect(parser.toString()).toBe("i=>{i instanceof e[0]||e[1](i);return i}");
-
-  const data = new Set(["foo", "bar"]);
-  t.expect(parser(data)).toBe(data);
-
-  t.expect(() => parser(123)).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "Expected Set, received 123",
-    }),
-  );
-});
-
 test("Full Set schema", (t) => {
   const mySet = <T>(itemSchema: S.Schema<unknown, T>): S.Schema<unknown, Set<T>> =>
     S.instance(Set<unknown>)
@@ -1939,40 +828,6 @@ test("Full Set schema", (t) => {
       message: `At item 3 - Expected number, received "3"`,
     }),
   );
-});
-
-test("Coerce string to number", (t) => {
-  const schema = S.to(S.string, S.number);
-
-  t.expect(schema.to).toBe(S.number);
-
-  expectSchemaType(schema).toBe<string, number>();
-  expectTypeOf(schema.to).toEqualTypeOf<S.Schema<unknown> | undefined>();
-
-  t.expect(S.parser(schema)("123")).toEqual(123);
-  t.expect(S.parser(schema)("123.4")).toEqual(123.4);
-  t.expect(S.encoder(schema)(123)).toEqual("123");
-});
-
-test("Shape string to object", (t) => {
-  const schema = S.shape(S.string, (string) => ({ foo: string }));
-
-  t.expect(S.parser(schema)("bar")).toEqual({ foo: "bar" });
-  t.expect(S.encoder(schema)({ foo: "bar" })).toEqual("bar");
-});
-
-test("Tuple with transform to object", (t) => {
-  let pointSchema = S.tuple((s) => {
-    s.tag(0, "point");
-    return {
-      x: s.item(1, S.int32),
-      y: s.item(2, S.int32),
-    };
-  });
-
-  t.expect(S.parser(pointSchema)(["point", 1, -4])).toEqual({ x: 1, y: -4 });
-
-  expectSchemaType(pointSchema).toBe<unknown[], { x: number; y: number }>();
 });
 
 test("Assert throws with invalid data", (t) => {
@@ -2232,164 +1087,6 @@ test("Recursive with self as transform target", (t) => {
         "Can't decode string to Node[]. Use S.to to define a custom decoder",
     }),
   );
-});
-
-test("Port schema", (t) => {
-  const portSchema = S.port;
-  if (portSchema.type === "number") {
-    t.expect(portSchema.format).toEqual("port");
-  } else {
-    t.expect.fail("portSchema should be a number");
-  }
-
-  expectSchemaType(portSchema).toBe<number, number>();
-
-  t.expect(() => {
-    S.parser(portSchema)(10.2);
-  }).toThrow(
-    t.expect.objectContaining({
-      name: "SuryError",
-      message: "Expected port, received 10.2",
-    }),
-  );
-
-  const portCoercedFromString = S.string.with(S.to, S.port);
-  expectSchemaType(portCoercedFromString).toBe<string, number>();
-
-  if (portCoercedFromString.type === "string") {
-    t.expect(portCoercedFromString.format).toEqual(undefined);
-  } else {
-    t.expect.fail("portCoercedFromString should be a string");
-  }
-
-  if (S.reverse(portCoercedFromString).type === "number") {
-    t.expect(S.parser(portCoercedFromString)("10")).toEqual(10);
-    t.expect(() => {
-      S.parser(portCoercedFromString)(10.2);
-    }).toThrow(
-      t.expect.objectContaining({
-        name: "SuryError",
-        message: "Expected string, received 10.2",
-      }),
-    );
-    t.expect(() => {
-      S.parser(portCoercedFromString)("10.2");
-    }).toThrow(
-      t.expect.objectContaining({
-        name: "SuryError",
-        message: "Expected port, received 10.2",
-      }),
-    );
-    t.expect(S.encoder(portCoercedFromString)(10)).toEqual("10");
-  } else {
-    t.expect.fail("portCoercedFromString should be a number");
-  }
-});
-
-test("Example", (t) => {
-  // Create login schema with email and password
-  const loginSchema = S.schema({
-    email: S.email,
-    password: S.string.with(S.minLength, 8),
-  });
-
-  // Infer output TypeScript type of login schema
-  type LoginData = S.Output<typeof loginSchema>; // { email: string; password: string }
-
-  t.expect(() => {
-    // Throws the S.Error(`Failed at ["email"]: Expected email, received ""`)
-    S.parser(loginSchema)({ email: "", password: "" });
-  }).toThrow(
-    t.expect.objectContaining({
-      message: `Failed at ["email"]: Expected email, received ""`,
-    }),
-  );
-
-  // Returns data as { email: string; password: string }
-  const result = S.parser(loginSchema)({
-    email: "jane@example.com",
-    password: "12345678",
-  });
-
-  t.expect(result).toEqual({
-    email: "jane@example.com",
-    password: "12345678",
-  });
-
-  expectSchemaType(loginSchema).toBe<
-    { email: string; password: string },
-    { email: string; password: string }
-  >();
-  expectTypeOf<LoginData>().toEqualTypeOf<{
-    email: string;
-    password: string;
-  }>();
-});
-
-test("Decode from json", async (t) => {
-  t.expect(S.decoder(S.json, S.array(S.bigint))(["123"])).toEqual([123n]);
-  t.expect(S.decoder(S.array(S.bigint), S.json)([123n])).toEqual(["123"]);
-
-  const schema = S.string.with(S.nullable);
-
-  t.expect(S.decoder(S.json, schema)("hello")).toEqual("hello");
-  t.expect(S.decoder(S.json, schema)(null)).toEqual(null);
-
-  // Date fields should be encoded to ISO string when decoding to JSON
-  const dateSchema = S.schema({ field: S.date });
-  const dateToJson = S.decoder(dateSchema, S.json);
-  t.expect(dateToJson({ field: new Date("2024-01-01T00:00:00.000Z") })).toEqual(
-    {
-      field: "2024-01-01T00:00:00.000Z",
-    },
-  );
-  t.expect(dateToJson.toString()).toEqual(
-    `i=>{return {"field":i["field"].toISOString(),}}`,
-  );
-
-  // Date fields should work through the full jsonString pipeline
-  const dateToJsonString = S.decoder(dateSchema, S.jsonString);
-  t.expect(
-    dateToJsonString({ field: new Date("2024-01-01T00:00:00.000Z") }),
-  ).toEqual(`{"field":"2024-01-01T00:00:00.000Z"}`);
-
-  // JSON to Date: decode ISO string from JSON back to Date
-  const jsonToDate = S.decoder(S.json, dateSchema);
-  t.expect(jsonToDate({ field: "2024-01-01T00:00:00.000Z" })).toEqual({
-    field: new Date("2024-01-01T00:00:00.000Z"),
-  });
-  t.expect(jsonToDate.toString()).toEqual(
-    `i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[2](i);let v1=i["field"];typeof v1==="string"||e[1](v1);let v0=new Date(i["field"]);!Number.isNaN(v0.getTime())||e[0](v0);return {"field":v0,}}`,
-  );
-
-  // JSON string to Date: full round-trip through jsonString
-  const jsonStringToDate = S.decoder(S.jsonString, dateSchema);
-  t.expect(jsonStringToDate(`{"field":"2024-01-01T00:00:00.000Z"}`)).toEqual({
-    field: new Date("2024-01-01T00:00:00.000Z"),
-  });
-});
-
-test("Decode from json string", async (t) => {
-  const schema = S.nullable(S.string);
-
-  t.expect(S.decoder(S.jsonString, schema)(`"hello"`)).toEqual("hello");
-  t.expect(S.decoder(S.jsonString, schema)("null")).toEqual(null);
-});
-
-test("Decode from json string, convert to number", async (t) => {
-  const fn = S.decoder(S.jsonString, S.string, S.number);
-
-  expectTypeOf(fn).toEqualTypeOf<(data: string) => number>();
-
-  t.expect(fn(`"123"`)).toEqual(123);
-});
-
-test("Decode from json string to array of bigints", async (t) => {
-  const fn = S.decoder(S.jsonString, S.array(S.bigint));
-
-  expectTypeOf(fn).toEqualTypeOf<(data: string) => bigint[]>();
-
-  t.expect(fn(`["123"]`)).toEqual([123n]);
 });
 
 test("Parse to literal with no validation to emulate assert", async (t) => {
@@ -2985,24 +1682,6 @@ test("Error messages render through inputExpression, not toString", (t) => {
   t.expect(`${error!.expected}`).toBe("Schema<string>");
 });
 
-// FIXME: S.record takes no key schema, so keys are never validated. The
-// generated loop is `for (let v0 in i)`, which skips symbol keys entirely — a
-// value under one is never reached, whatever the value schema says. Lives here
-// rather than in specs/record.yaml because the spec harness cannot serialize an
-// object with symbol keys back to source (see CONTRIBUTING.md).
-test("S.record does not validate values under symbol keys", (t) => {
-  const key = Symbol.for("sury-test-symbol-key");
-  const input: Record<symbol, unknown> = { [key]: 123 };
-
-  const result = S.parser(S.record(S.string))(
-    input as unknown as Record<string, string>,
-  );
-
-  // 123 is not a string, yet this neither throws nor strips the property.
-  t.expect(result).toBe(input);
-  t.expect((result as unknown as Record<symbol, unknown>)[key]).toBe(123);
-});
-
 // Rendering the received value used to walk objects and arrays without a
 // limit, so a cyclic input overflowed the stack inside the error formatter — a
 // validation failure surfaced as a RangeError instead of a SuryError. One level
@@ -3071,4 +1750,21 @@ test("A received value is expanded one level", (t) => {
 test("A nan schema renders as NaN without a dedicated branch", (t) => {
   t.expect(S.inputExpression(S.schema(NaN))).toBe("NaN");
   t.expect(`${S.schema(NaN)}`).toBe("Schema<NaN>");
+});
+
+// The runtime tags a spec cannot record: specs snapshot codegen and types,
+// not the introspectable schema object itself.
+test("Schema introspection tags survive on coerced and instance schemas", (t) => {
+  t.expect(S.jsonString.type === "string" && S.jsonString.format === "json").toBe(true);
+
+  const coerced = S.to(S.string, S.number);
+  t.expect(coerced.to).toBe(S.number);
+
+  const portFromString = S.string.with(S.to, S.port);
+  t.expect(portFromString.type === "string" && portFromString.format === undefined).toBe(true);
+  const reversedPort = S.reverse(portFromString);
+  t.expect(reversedPort.type === "number" && (reversedPort as { format?: string }).format === "port").toBe(true);
+
+  const setSchema = S.instance(Set);
+  t.expect(setSchema.type === "instance" && setSchema.class === Set).toBe(true);
 });

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -55,7 +55,7 @@ test("stale golden (expression drifted from what the schema actually compiles to
     {
       "stderr": "✗ string
         goldens stale — run \`pnpm spec check string --write\` (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
-    @@ -11,7 +11,7 @@
+    @@ -13,7 +13,7 @@
         output: '{ type: "string" }'
       operations:
         parse:
@@ -63,7 +63,10 @@ test("stale golden (expression drifted from what the schema actually compiles to
     +     expression: i=>{typeof i==="string"||e[0](i);return i}
           examples:
             valid:
-              input: '"hello"'",
+              input: '"hello"'
+        ts.aliases["S.schema(S.string)"]: operations.parse.expression differs:
+    - i=>i /* stale */
+    + i=>{typeof i==="string"||e[0](i);return i}",
       "stdout": "",
     }
   `);
@@ -80,7 +83,7 @@ test("stale golden (recorded example output no longer matches live behavior)", a
     {
       "stderr": "✗ string
         goldens stale — run \`pnpm spec check string --write\` (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
-    @@ -15,7 +15,7 @@
+    @@ -17,7 +17,7 @@
           examples:
             valid:
               input: '"hello"'
@@ -187,7 +190,7 @@ test("not canonical (on-disk text doesn't match the canonical form)", async () =
     {
       "stderr": "✗ string
         not canonical — run \`pnpm spec format string\` (or \`pnpm spec check string --write\`, which also refreshes goldens):
-    @@ -4,7 +4,8 @@
+    @@ -6,7 +6,8 @@
         input: string
         output: string
         instantiations: 254
@@ -254,8 +257,8 @@ test("identity claimed but the operation doesn't actually compile to identity", 
         operations.decode: marked \`identity\` but does not compile to identity — use a full op block with examples
         operations.encode: marked \`identity\` but does not compile to identity — use a full op block with examples
         goldens stale — resolve the identity mismatch above first, then \`pnpm spec check string --write\` can fix it (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
-    @@ -3,28 +3,28 @@
-        schema: S.string.with(S.minLength, 3)
+    @@ -5,28 +5,28 @@
+          - S.schema(S.string)
         input: string
         output: string
     -   instantiations: 254
@@ -305,7 +308,7 @@ test("full op block claimed but the operation actually compiles to identity", as
         operations.decode: no examples — a compiled op block must run at least one input (add a named entry with just \`input\`, then \`--write\` fills the result)
         operations.decode: compiles to identity — use \`identity\` instead of an expression + examples
         goldens stale — resolve the identity mismatch above first, then \`pnpm spec check string --write\` can fix it (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
-    @@ -26,7 +26,10 @@
+    @@ -28,7 +28,10 @@
               input: "null"
               error: Expected string, received null
         decode:
@@ -316,7 +319,8 @@ test("full op block claimed but the operation actually compiles to identity", as
     +       }
           examples: {}
         encode: identity
-    ",
+
+        ts.aliases["S.schema(S.string)"]: operations.decode compiles to identity on this alias but not on schema",
       "stdout": "",
     }
   `);
@@ -457,7 +461,7 @@ test("multiple simultaneous problems all get their own guiding message", async (
       "stderr": "✗ string
         ts.instantiations: invalid _skip reason "nonsense-reason"
         goldens stale — run \`pnpm spec check string --write\` (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
-    @@ -12,7 +12,7 @@
+    @@ -14,7 +14,7 @@
         output: '{ type: "string" }'
       operations:
         parse:
@@ -465,7 +469,10 @@ test("multiple simultaneous problems all get their own guiding message", async (
     +     expression: i=>{typeof i==="string"||e[0](i);return i}
           examples:
             valid:
-              input: '"hello"'",
+              input: '"hello"'
+        ts.aliases["S.schema(S.string)"]: operations.parse.expression differs:
+    - i=>i /* stale */
+    + i=>{typeof i==="string"||e[0](i);return i}",
       "stdout": "",
     }
   `);


### PR DESCRIPTION
This change migrates test cases from `S_test.ts` into the spec system and adds comprehensive spec files for schema operations, following the project's convention that "every change under `packages/sury/src` goes through" the spec skill.

## Summary

The diff moves 78 test cases from the test file into dedicated spec YAML files, ensuring that generated code, bundle size, and type costs are properly tracked. This aligns with the project's guidance that "specs snapshot generated code, bundle size and type-cost; the printed metric summary is the deliverable."

## Key Changes

- **Removed from `S_test.ts`**: 78 test cases covering:
  - JSON string parsing and transformations
  - String refinements and transformations
  - Array and record operations
  - Object parsing with various features
  - Optional, nullable, and nullish schemas
  - Encoding/decoding operations
  - Custom transforms and refinements

- **Added spec files** (50+ new YAML specs):
  - Basic types: `string.yaml`, `array.yaml`, `json.yaml`, `jsonstring.yaml`
  - Transformations: `codec-string-number.yaml`, `codec-string-date.yaml`, `codec-array-bigint-string.yaml`, etc.
  - Refinements: `string-length-custom-message.yaml`, `string-refine.yaml`, `string-refine-path.yaml`
  - Modifiers: `optional.yaml`, `nullable.yaml`, `nullish.yaml`, `optional-default.yaml`, `nullable-default.yaml`
  - Objects: `object1.yaml`, `object-strict.yaml`, `object-deep-strict.yaml`, `object-advanced.yaml`, `object-quoted-keys.yaml`
  - Complex operations: `codec-jsonstring-extract-field.yaml`, `codec-jsonstring-bigint-array.yaml`, `compact-columns-*.yaml`
  - Unions: `union3-literals.yaml`, `union5-env-boolean.yaml`

- **Updated existing specs**:
  - `nullable.yaml`: Added alias for nested nullable flattening
  - `string.yaml`: Added alias for schema wrapping
  - `object1.yaml`: Added alias for strip/strict pattern
  - `object-proto-key.yaml`: Updated with implementation notes
  - `record.yaml`: Added FIXME comment about symbol key handling

- **Documentation updates**:
  - `CONTRIBUTING.md`: Removed outdated limitation note about JSON-target conversions
  - `spec/bench.ts`: Added clarification about JIT state and process-level confirmation

## Implementation Details

All removed tests are now captured in spec files with:
- TypeScript schema definitions
- Input/output type annotations
- Instantiation metrics
- Comparison with Zod equivalents (where applicable)
- JSON Schema representations
- Generated operation expressions with examples
- Error cases and edge cases

This ensures the generated code quality, performance characteristics, and type costs are continuously monitored through the spec system rather than relying on manual test assertions.

https://claude.ai/code/session_01JZN4fpyjwwSYD3ewo7cqwF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added broad coverage for arrays, objects, tuples, unions, optional and nullable values, dates, emails, ports, JSON, and common codecs.
  - Added examples for transforming strings, numbers, booleans, bigints, and structured data during parsing and encoding.
  - Added support for preserving enumerable symbol-keyed properties during serialization.

- **Bug Fixes**
  - Improved handling of prototype keys and nested validation errors.
  - Benchmark regression checks now require consistent results across multiple runs.

- **Tests**
  - Expanded validation, round-trip, error-message, and edge-case coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->