### PR TITLE
Add type inference for fromJSONSchema with local $ref support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,12 @@ flat interface is what makes a hover, a completion and an error name the dialect
 instead of expanding an intersection. Don't collapse them into `extends`, `Omit`
 or mapped types.
 
+`src/types/json.d.ts` holds `JSON` and the `FromJSONSchema` inference engine.
+Its `Flatten` duplicates `index.d.ts`'s on purpose — a non-exported type can't
+cross a file, and exporting one would add `S.Flatten` to the public API. Don't
+collapse the two. The engine's dispatch order mirrors the runtime chain in
+`src/jsonschema.ts`; a comment on each side says so, and they move together.
+
 Each must stay assignable to the wide `JSONSchema` — that is what lets a
 `toJSONSchema` result feed `fromJSONSchema` or `extendJSONSchema` uncast — so a
 keyword added to one belongs on `JSONSchema` too, and in the other two spellings

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -310,6 +310,34 @@ commented on both sides (`index.d.ts`, `src/jsonschema.ts`). Specs:
 `not`, `if/then/else`, `default`-fold's input/output split, `oneOf`
 exclusivity; all degrade to the runtime's wider static shape, never narrower.
 
+### Follow-ups
+
+- **Runtime `$defs`/`$ref` resolution** — the static type already resolves
+  local pointers while the runtime parses a `$ref` as plain JSON; the FIXME in
+  `specs/fromjsonschema-recursive-ref.yaml` pins the divergence. Recursive
+  documents need the runtime's recursive-schema machinery (`S_recursive`), so
+  size that first. Closing this deletes the one "type leads runtime" caveat.
+- **Corpus-wide round-trip dimension (phase 3)** — derive a `fromJSONSchema`
+  check in the spec harness from each spec's existing `jsonSchema.input`
+  golden (~126 cases): pin the inferred type + instantiations next to the
+  emitter's output so a runtime branch gaining support without a matching
+  type branch shows up as a spec diff. Harness change → log under Spec
+  Harness Suggestions in CONTRIBUTING.md per the spec skill's rule.
+- **`default`-fold input/output split** — a non-required property with
+  `default` is folded via `Option_getOr`, so it's optional on the input side
+  but always present on the output side; the inferred type currently keeps it
+  optional on both (sound, just wider). Needs `FromJSONSchema` split into
+  per-side resolvers; measure the cost of doubling before committing.
+- **Same-level `not` exclusion** — `{ enum: [...], not: { enum: [...] } }`
+  could infer `Exclude<...>` cheaply. Only worth doing together with runtime
+  structure (today `not` is an opaque refinement), and note upstream
+  `json-schema-to-ts` gets the `allOf`-sibling variant wrong — pin whatever
+  behavior lands in a spec.
+- **`anyOf`/`oneOf` inside `type: "object"`** — the runtime drops them (TODO
+  at the object branch in `src/jsonschema.ts`); the type chain mirrors that.
+  When the runtime TODO lands, add the matching branch to `JSONSchemaResolve`
+  in the same change — the dispatch-order comment binds the two.
+
 ## `fromJSONSchema` type inference (researched, parked — original notes)
 
 `S.fromJSONSchema` returns `Schema<JSON, JSON>` — the described type isn't

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -363,6 +363,26 @@ max 12.4k; today's `fromJSONSchema` specs pin 254.
   {enum: [b, d]}}]` infers all five) — exclusion only applies same-level.
   Pin whatever behavior the adaptation keeps in a spec.
 
+**`$ref` is in scope for the types** (decided after the measurements below;
+the runtime keeps producing `json` for `$ref` until it learns resolution —
+the type side leads):
+
+- Upstream v3.1.1 already resolves **non-recursive** `$ref` — `#/definitions/`,
+  `#/$defs/` and the `references` option all infer correctly at ~6k inst.
+  The earlier "PR #224 means no `$defs`" read was too pessimistic; only verify
+  nested/edge placements after vendoring.
+- **Recursive** `$ref` is where upstream hard-fails: "Type of property
+  'children' circularly references itself in mapped type", property degrades
+  to `any`, both via `references` and internal `definitions`.
+- The `ata-validator` `RootDefs`/`RefName`/`ResolveRef` graft closes exactly
+  that gap, measured on its shipped `index.d.ts` (546 lines, MIT): direct
+  recursion (tree) **616 inst**, mutual recursion (expr/binop) **974 inst**,
+  and the inferred types are usable — deep `next?.next?....` chains and
+  discriminant narrowing typecheck clean, TS displays the cycle lazily.
+  Its `InferObject` mapped-type deferral is the pattern the vendored engine's
+  `$ref` branch must adopt; note it leaks `readonly` from `as const` (strip
+  with `-readonly` during adaptation).
+
 ArkType postmortem (checked 2026-08): `@ark/json-schema` built full literal
 inference as direct recursive conditional types (accumulator + one
 `Omit<schema, kw>` per keyword, piggybacking their constraint brands), then

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -332,6 +332,46 @@ differentiator. Findings from the investigation, so it doesn't have to be redone
 The dialect split landed here (wide `JSONSchema` in, per-target types out) is the
 shape that work plugs into.
 
+### Phase 0 result (2026-08-06): GO
+
+Measured `json-schema-to-ts@3.1.1` + `ts-algebra@2.0.0` unmodified on TS 5.8.3
+(`strict`, `skipLibCheck` off), with the exact `packages/spec/introspect.ts`
+methodology (`@typescript/vfs`, `getInstantiationCount()` delta vs bare-import
+baseline). Corpus context: existing specs' `ts.instantiations` are median ~5.2k,
+max 12.4k; today's `fromJSONSchema` specs pin 254.
+
+- Small object schema (5 props, formats, enum): **2,984** inst — same band as
+  hand-written object specs (`object5-optional` is 3,610).
+- Realistic API schema (~30 props, 3-level nesting, discriminated `anyOf`,
+  tuples, dicts): **17,895** inst, 376ms warm check.
+- Stress (10-branch union + `allOf` merge + `not` + `oneOf` + `if/then/else`
+  with `parseNotKeyword`/`parseIfThenElseKeywords` on + 8-level nesting):
+  **86,455** inst, 694ms, no errors.
+- Wrapping the result in `Schema<T, T>` and reading `S.Output`/`S.Input` back
+  (the phase-2 signature simulated) adds a flat **~3k** on any tier.
+- **The only breaking dimension is nesting depth**: pure object nesting dies at
+  ~14–20 levels ("Type instantiation is excessively deep") because the
+  `Omit`-per-keyword recursion burns ~3 of TS's 100-depth budget per schema
+  level. Width is fine: 100 union branches = 268k inst / 1.0s / ok, 100
+  properties = 15k / ok. Realistic schemas express depth via `$ref` (out of
+  scope anyway), so document the limit; the depth-only failure mode also means
+  a depth-capped bailout to `S.JSON` is possible if ever needed.
+- The shipped `.d.ts` passes `tsc --noEmit --strict --skipLibCheck false`
+  (the `declarations_test.ts` gate) in 2.7s including the probe project.
+- Correctness caveat found while measuring: `not` as an `allOf` *sibling* does
+  not exclude even with `parseNotKeyword` (`allOf: [{enum: [a..e]}, {not:
+  {enum: [b, d]}}]` infers all five) — exclusion only applies same-level.
+  Pin whatever behavior the adaptation keeps in a spec.
+
+ArkType postmortem (checked 2026-08): `@ark/json-schema` built full literal
+inference as direct recursive conditional types (accumulator + one
+`Omit<schema, kw>` per keyword, piggybacking their constraint brands), then
+deleted it before merge (PR #1159, commit 07a5215) over type-perf concerns —
+shipped 0.0.x is runtime-only, returns `Type.Any`, no `$ref` even at runtime.
+Confirms: don't hand-roll the direct-recursion style; the ts-algebra IR is the
+only approach that has shipped. Also confirms upstream is still frozen: PRs
+#224 (`$defs`) and #231 (tuples) remain unreviewed.
+
 ## Articles
 
 - Write an article about creating an AI-friendly JS library (how the API design, type overloads like `S.is`/`S.assert` accepting both arg orders, and error messages make Sury easy for both humans and LLMs to use)

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -303,8 +303,8 @@ in `ata-validator`'s deferral style — written against Sury's actual runtime
 dispatch order, with the recursion-safe key-remap object split — measured
 368/1,076/676 on the same tiers, handles 30-level nesting at 396, and keeps
 recursive/mutual `$ref` under 1.1k. `FromJSONSchema<T>` +
-`JSONSchemaResolve` live in `index.d.ts`; the dispatch-order invariant is
-commented on both sides (`index.d.ts`, `src/jsonschema.ts`). Specs:
+`JSONSchemaResolve` live in `src/types/json.d.ts`; the dispatch-order invariant
+is commented on both sides (`src/types/json.d.ts`, `src/jsonschema.ts`). Specs:
 `fromjsonschema-object`, `fromjsonschema-recursive-ref`, plus the three
 `jsonschema-*` ts goldens moving JSON→precise. Not modeled (deliberately, v1):
 `not`, `if/then/else`, `default`-fold's input/output split, `oneOf`

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -293,7 +293,24 @@ s.fn(s.arg(0, S.string))
 - S.mutator
 - Check only number of fields for strict object schema when fields are not optional (bad idea since it's not possible to create a good error message, so we still need to have the loop)
 
-## `fromJSONSchema` type inference (researched, parked)
+## `fromJSONSchema` type inference (landed — history below)
+
+**Landed 2026-08-07 with a Sury-owned engine instead of the vendored one** the
+research below recommends. The phase-0 measurements changed the calculus:
+vendored `json-schema-to-ts` costs 3k–86k instantiations across the tiers and
+dies at ~14 levels of literal nesting, while a ~130-line first-match resolver
+in `ata-validator`'s deferral style — written against Sury's actual runtime
+dispatch order, with the recursion-safe key-remap object split — measured
+368/1,076/676 on the same tiers, handles 30-level nesting at 396, and keeps
+recursive/mutual `$ref` under 1.1k. `FromJSONSchema<T>` +
+`JSONSchemaResolve` live in `index.d.ts`; the dispatch-order invariant is
+commented on both sides (`index.d.ts`, `src/jsonschema.ts`). Specs:
+`fromjsonschema-object`, `fromjsonschema-recursive-ref`, plus the three
+`jsonschema-*` ts goldens moving JSON→precise. Not modeled (deliberately, v1):
+`not`, `if/then/else`, `default`-fold's input/output split, `oneOf`
+exclusivity; all degrade to the runtime's wider static shape, never narrower.
+
+## `fromJSONSchema` type inference (researched, parked — original notes)
 
 `S.fromJSONSchema` returns `Schema<JSON, JSON>` — the described type isn't
 inferred from the schema literal. Nothing in the Standard Schema ecosystem does

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -208,7 +208,7 @@ const schema = S.fromJSONSchema({
 // S.Schema<{ id: string; role?: "admin" | "user" | undefined }>
 ```
 
-To also have TypeScript check the schema document itself, annotate it with `satisfies S.JSONSchema` — that catches a misspelled keyword while leaving `x-` vendor extensions open.
+To also have TypeScript check the schema document itself, annotate it with `satisfies S.JSONSchema` — that catches a misspelled keyword while leaving `x-` vendor extensions open. The annotation widens literals (e.g. `required`, `enum`), so the inferred type gets wider too — every property becomes optional.
 
 A schema read from a file or an API needs no cast: a non-literal argument — `unknown`, `S.JSON`, or one of the dialect types — falls back to `S.Schema<S.JSON, S.JSON>`, so pair it with `S.to` when you need a narrower type.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -197,19 +197,20 @@ S.assert(
 // Throws S.Error: Expected email, received "example.com"
 ```
 
-It takes `unknown`, so a schema read from a file or an API needs no cast. To have TypeScript check one written inline, annotate it with `satisfies S.JSONSchema` — that catches a misspelled keyword while leaving `x-` vendor extensions open:
+A schema written inline is inferred — the result is typed with the data type the document describes, including local `$ref` pointers (`#/$defs/…`, `#/definitions/…`), even recursive ones:
 
 ```ts
-const jsonSchema = {
+const schema = S.fromJSONSchema({
   type: "object",
-  properties: { id: { type: "string" } },
+  properties: { id: { type: "string" }, role: { enum: ["admin", "user"] } },
   required: ["id"],
-} satisfies S.JSONSchema;
-
-const schema = S.fromJSONSchema(jsonSchema);
+});
+// S.Schema<{ id: string; role?: "admin" | "user" | undefined }>
 ```
 
-The result is a `S.Schema<S.JSON, S.JSON>`: the described type isn't known statically, so pair it with `S.to` when you need a narrower one.
+To also have TypeScript check the schema document itself, annotate it with `satisfies S.JSONSchema` — that catches a misspelled keyword while leaving `x-` vendor extensions open.
+
+A schema read from a file or an API needs no cast: a non-literal argument — `unknown`, `S.JSON`, or one of the dialect types — falls back to `S.Schema<S.JSON, S.JSON>`, so pair it with `S.to` when you need a narrower type.
 
 > 🧠 **Sury**'s internal representation is itself JSON Schema-shaped, so a schema is readable as-is: `S.schema("Hello world!")` logs `{ type: "string", const: "Hello world!", … }`.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -197,7 +197,7 @@ S.assert(
 // Throws S.Error: Expected email, received "example.com"
 ```
 
-A schema written inline is inferred — the result is typed with the data type the document describes, including local `$ref` pointers (`#/$defs/…`, `#/definitions/…`), even recursive ones:
+A schema written inline is inferred — the result is typed with the data type the document describes, including local `$ref` pointers (`#/$defs/…`, `#/definitions/…`), even recursive ones. `$ref` is resolved by the inference only: the runtime does not yet follow a pointer, so a `$ref` validates as any JSON while the static type names the shape it points at.
 
 ```ts
 const schema = S.fromJSONSchema({

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -7,9 +7,11 @@ import type {
   JSONSchema7,
   OpenAPISchema30,
 } from "./src/types/jsonschema.js";
+import type { FromJSONSchema, JSON } from "./src/types/json.js";
 
 export * from "./src/types/standard.js";
 export * from "./src/types/jsonschema.js";
+export * from "./src/types/json.js";
 
 
 
@@ -25,14 +27,6 @@ export type FailureResult = {
 };
 
 export type Result<TValue> = SuccessResult<TValue> | FailureResult;
-
-export type JSON =
-  | string
-  | boolean
-  | number
-  | null
-  | { [key: string]: JSON }
-  | JSON[];
 
 export type NumberFormat = "int32" | "port";
 export type StringFormat = "json" | "date-time" | "email" | "uuid" | "cuid" | "url";
@@ -398,143 +392,6 @@ type UnknownArrayToOutput<T extends unknown[]> = number extends T["length"]
 type UnknownArrayToInput<T extends unknown[]> = number extends T["length"]
   ? T
   : { -readonly [K in keyof T]: UnknownToInput<T[K]> };
-
-type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
-  k: infer I
-) => void
-  ? I
-  : never;
-
-type JSONSchemaDefs<S> = S extends { $defs: infer D }
-  ? D
-  : S extends { definitions: infer D }
-  ? D
-  : {};
-
-type JSONSchemaRefName<R> = R extends `#/$defs/${infer N}`
-  ? N
-  : R extends `#/definitions/${infer N}`
-  ? N
-  : never;
-
-// `[…] extends [never]` first: a non-local pointer must fall back to `JSON`,
-// and letting a bare `never` reach the `keyof D` check would resolve it.
-type JSONSchemaRef<R, D> = [JSONSchemaRefName<R>] extends [never]
-  ? JSON
-  : JSONSchemaRefName<R> extends keyof D
-  ? JSONSchemaResolve<D[JSONSchemaRefName<R>], D>
-  : JSON;
-
-type JSONSchemaRequiredKeys<S> = S extends { required: ReadonlyArray<infer K extends string> }
-  ? K
-  : never;
-
-// Required/optional split by key remapping, not ResolveObject: its
-// `undefined extends TFields[keyof TFields]` probe forces every field type
-// eagerly, which turns a recursive `$ref` through a property into a
-// circular-reference error. Same required-first shape as ResolveObject.
-type JSONSchemaObject<S, D> = S extends { properties: infer P }
-  ? Flatten<
-      {
-        -readonly [K in keyof P as K extends JSONSchemaRequiredKeys<S>
-          ? K
-          : never]: JSONSchemaResolve<P[K], D>;
-      } & {
-        -readonly [K in keyof P as K extends JSONSchemaRequiredKeys<S> ? never : K]?:
-          | JSONSchemaResolve<P[K], D>
-          | undefined;
-      }
-    >
-  : S extends { additionalProperties: infer A }
-  ? A extends true
-    ? { [key: string]: JSON }
-    : A extends false
-    ? {}
-    : { [key: string]: JSONSchemaResolve<A, D> }
-  : {};
-
-type JSONSchemaArray<S, D> = S extends { prefixItems: infer P extends readonly unknown[] }
-  ? { -readonly [K in keyof P]: JSONSchemaResolve<P[K], D> }
-  : S extends { items: infer I }
-  ? I extends readonly unknown[]
-    ? { -readonly [K in keyof I]: JSONSchemaResolve<I[K], D> }
-    : JSONSchemaResolve<I, D>[]
-  : JSON[];
-
-// Undoes the `readonly` the `const T` call site stamps onto `enum`/`const`
-// values, same reason as `UnknownToOutput` above.
-type JSONSchemaLiteral<C> = C extends readonly unknown[]
-  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
-  : C extends object
-  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
-  : C;
-
-type JSONSchemaUnion<A extends readonly unknown[], D> = A extends readonly []
-  ? JSON
-  : { [K in keyof A]: JSONSchemaResolve<A[K], D> }[number];
-
-type JSONSchemaTypeNameToType<N, S, D> = N extends "object"
-  ? JSONSchemaObject<S, D>
-  : N extends "array"
-  ? JSONSchemaArray<S, D>
-  : N extends "string"
-  ? string
-  : N extends "number" | "integer"
-  ? number
-  : N extends "boolean"
-  ? boolean
-  : N extends "null"
-  ? null
-  : JSON;
-
-// First-match dispatch in the same order as the runtime chain in
-// src/jsonschema.ts (nullable → type:"object" → type:"array" → anyOf → enum →
-// const → type[] → scalar type → JSON fallback), so a keyword the runtime
-// ignores in a given position is ignored here too. `$ref` resolves ahead of it
-// — the one place the static type leads the runtime, which still parses a
-// `$ref` as plain JSON. The `string extends keyof S` guard sends
-// index-signature values (e.g. the object arm of `JSON` itself) to the
-// fallback before any keyword can match structurally.
-type JSONSchemaResolve<S, D> = S extends boolean
-  ? S extends true
-    ? JSON
-    : never
-  : string extends keyof S
-  ? JSON
-  : S extends { $ref: infer R }
-  ? JSONSchemaRef<R, D>
-  : S extends { nullable: true }
-  ? null | JSONSchemaResolve<Omit<S, "nullable">, D>
-  : S extends { type: "object" }
-  ? JSONSchemaObject<S, D>
-  : S extends { type: "array" }
-  ? JSONSchemaArray<S, D>
-  : S extends { anyOf: infer A extends readonly unknown[] }
-  ? JSONSchemaUnion<A, D>
-  : S extends { enum: infer E extends readonly unknown[] }
-  ? JSONSchemaLiteral<E[number]>
-  : S extends { const: infer C }
-  ? JSONSchemaLiteral<C>
-  : S extends { type: infer N }
-  ? N extends readonly unknown[]
-    ? JSONSchemaTypeNameToType<N[number], S, D>
-    : JSONSchemaTypeNameToType<N, S, D>
-  : S extends { oneOf: infer A extends readonly unknown[] }
-  ? JSONSchemaUnion<A, D>
-  : S extends { allOf: infer A extends readonly unknown[] }
-  ? Flatten<UnionToIntersection<JSONSchemaUnion<A, D>>>
-  : JSON;
-
-/**
- * The type a JSON Schema literal describes, as inferred by
- * `S.fromJSONSchema`. Resolves local `$ref` pointers (`#/$defs/…`,
- * `#/definitions/…`) against the root schema, including recursive and
- * mutually recursive ones. A non-literal schema — `unknown`, `S.JSON`, a
- * dialect interface — resolves to `S.JSON`.
- */
-export type FromJSONSchema<T> = unknown extends T
-  ? JSON
-  : JSONSchemaResolve<T, JSONSchemaDefs<T>>;
 
 export function schema<const T extends unknown[]>(
   schemas: [...T]

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -824,8 +824,11 @@ export function toJSONSchema<TInput, TOutput>(
  *
  * A schema written inline is inferred: the result is typed with the data type
  * it describes, including local `$ref` pointers (`#/$defs/…`,
- * `#/definitions/…`), even recursive ones. To also have TypeScript check the
- * schema itself, annotate it: `{ ... } satisfies S.JSONSchema`.
+ * `#/definitions/…`), even recursive ones — but the runtime does not yet
+ * validate a `$ref`, so treat data in a `$ref` position as unchecked. To also
+ * have TypeScript check the schema itself, annotate it:
+ * `{ ... } satisfies S.JSONSchema` — the annotation widens literals (e.g.
+ * `required`, `enum`), so the inferred type gets wider too.
  *
  * A schema read from a file or an API needs no cast — a non-literal argument
  * (`unknown`, `S.JSON`, a dialect type) falls back to `Schema<JSON, JSON>`.

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -399,6 +399,143 @@ type UnknownArrayToInput<T extends unknown[]> = number extends T["length"]
   ? T
   : { -readonly [K in keyof T]: UnknownToInput<T[K]> };
 
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+type JSONSchemaDefs<S> = S extends { $defs: infer D }
+  ? D
+  : S extends { definitions: infer D }
+  ? D
+  : {};
+
+type JSONSchemaRefName<R> = R extends `#/$defs/${infer N}`
+  ? N
+  : R extends `#/definitions/${infer N}`
+  ? N
+  : never;
+
+// `[…] extends [never]` first: a non-local pointer must fall back to `JSON`,
+// and letting a bare `never` reach the `keyof D` check would resolve it.
+type JSONSchemaRef<R, D> = [JSONSchemaRefName<R>] extends [never]
+  ? JSON
+  : JSONSchemaRefName<R> extends keyof D
+  ? JSONSchemaResolve<D[JSONSchemaRefName<R>], D>
+  : JSON;
+
+type JSONSchemaRequiredKeys<S> = S extends { required: ReadonlyArray<infer K extends string> }
+  ? K
+  : never;
+
+// Required/optional split by key remapping, not ResolveObject: its
+// `undefined extends TFields[keyof TFields]` probe forces every field type
+// eagerly, which turns a recursive `$ref` through a property into a
+// circular-reference error. Same required-first shape as ResolveObject.
+type JSONSchemaObject<S, D> = S extends { properties: infer P }
+  ? Flatten<
+      {
+        -readonly [K in keyof P as K extends JSONSchemaRequiredKeys<S>
+          ? K
+          : never]: JSONSchemaResolve<P[K], D>;
+      } & {
+        -readonly [K in keyof P as K extends JSONSchemaRequiredKeys<S> ? never : K]?:
+          | JSONSchemaResolve<P[K], D>
+          | undefined;
+      }
+    >
+  : S extends { additionalProperties: infer A }
+  ? A extends true
+    ? { [key: string]: JSON }
+    : A extends false
+    ? {}
+    : { [key: string]: JSONSchemaResolve<A, D> }
+  : {};
+
+type JSONSchemaArray<S, D> = S extends { prefixItems: infer P extends readonly unknown[] }
+  ? { -readonly [K in keyof P]: JSONSchemaResolve<P[K], D> }
+  : S extends { items: infer I }
+  ? I extends readonly unknown[]
+    ? { -readonly [K in keyof I]: JSONSchemaResolve<I[K], D> }
+    : JSONSchemaResolve<I, D>[]
+  : JSON[];
+
+// Undoes the `readonly` the `const T` call site stamps onto `enum`/`const`
+// values, same reason as `UnknownToOutput` above.
+type JSONSchemaLiteral<C> = C extends readonly unknown[]
+  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
+  : C extends object
+  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
+  : C;
+
+type JSONSchemaUnion<A extends readonly unknown[], D> = A extends readonly []
+  ? JSON
+  : { [K in keyof A]: JSONSchemaResolve<A[K], D> }[number];
+
+type JSONSchemaTypeNameToType<N, S, D> = N extends "object"
+  ? JSONSchemaObject<S, D>
+  : N extends "array"
+  ? JSONSchemaArray<S, D>
+  : N extends "string"
+  ? string
+  : N extends "number" | "integer"
+  ? number
+  : N extends "boolean"
+  ? boolean
+  : N extends "null"
+  ? null
+  : JSON;
+
+// First-match dispatch in the same order as the runtime chain in
+// src/jsonschema.ts (nullable → type:"object" → type:"array" → anyOf → enum →
+// const → type[] → scalar type → JSON fallback), so a keyword the runtime
+// ignores in a given position is ignored here too. `$ref` resolves ahead of it
+// — the one place the static type leads the runtime, which still parses a
+// `$ref` as plain JSON. The `string extends keyof S` guard sends
+// index-signature values (e.g. the object arm of `JSON` itself) to the
+// fallback before any keyword can match structurally.
+type JSONSchemaResolve<S, D> = S extends boolean
+  ? S extends true
+    ? JSON
+    : never
+  : string extends keyof S
+  ? JSON
+  : S extends { $ref: infer R }
+  ? JSONSchemaRef<R, D>
+  : S extends { nullable: true }
+  ? null | JSONSchemaResolve<Omit<S, "nullable">, D>
+  : S extends { type: "object" }
+  ? JSONSchemaObject<S, D>
+  : S extends { type: "array" }
+  ? JSONSchemaArray<S, D>
+  : S extends { anyOf: infer A extends readonly unknown[] }
+  ? JSONSchemaUnion<A, D>
+  : S extends { enum: infer E extends readonly unknown[] }
+  ? JSONSchemaLiteral<E[number]>
+  : S extends { const: infer C }
+  ? JSONSchemaLiteral<C>
+  : S extends { type: infer N }
+  ? N extends readonly unknown[]
+    ? JSONSchemaTypeNameToType<N[number], S, D>
+    : JSONSchemaTypeNameToType<N, S, D>
+  : S extends { oneOf: infer A extends readonly unknown[] }
+  ? JSONSchemaUnion<A, D>
+  : S extends { allOf: infer A extends readonly unknown[] }
+  ? Flatten<UnionToIntersection<JSONSchemaUnion<A, D>>>
+  : JSON;
+
+/**
+ * The type a JSON Schema literal describes, as inferred by
+ * `S.fromJSONSchema`. Resolves local `$ref` pointers (`#/$defs/…`,
+ * `#/definitions/…`) against the root schema, including recursive and
+ * mutually recursive ones. A non-literal schema — `unknown`, `S.JSON`, a
+ * dialect interface — resolves to `S.JSON`.
+ */
+export type FromJSONSchema<T> = unknown extends T
+  ? JSON
+  : JSONSchemaResolve<T, JSONSchemaDefs<T>>;
+
 export function schema<const T extends unknown[]>(
   schemas: [...T]
 ): Schema<[...UnknownArrayToInput<T>], [...UnknownArrayToOutput<T>]>;
@@ -828,13 +965,18 @@ export function toJSONSchema<TInput, TOutput>(
 /**
  * Builds a schema from a JSON Schema at runtime.
  *
- * Takes `unknown` so a schema read from a file or an API needs no cast. To have
- * TypeScript check one written inline, annotate it: `{ ... } satisfies S.JSONSchema`.
+ * A schema written inline is inferred: the result is typed with the data type
+ * it describes, including local `$ref` pointers (`#/$defs/…`,
+ * `#/definitions/…`), even recursive ones. To also have TypeScript check the
+ * schema itself, annotate it: `{ ... } satisfies S.JSONSchema`.
  *
- * The result parses JSON into JSON — the described type is not known statically.
+ * A schema read from a file or an API needs no cast — a non-literal argument
+ * (`unknown`, `S.JSON`, a dialect type) falls back to `Schema<JSON, JSON>`.
  * Use `S.to` to refine it further.
  */
-export function fromJSONSchema(jsonSchema: unknown): Schema<JSON, JSON>;
+export function fromJSONSchema<const T = unknown>(
+  jsonSchema: T
+): Schema<FromJSONSchema<T>, FromJSONSchema<T>>;
 export function extendJSONSchema<TInput, TOutput>(
   schema: SchemaLike<TInput, TOutput>,
   jsonSchema: JSONSchema

--- a/packages/sury/specs/fromjsonschema-allof.yaml
+++ b/packages/sury/specs/fromjsonschema-allof.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.fromJSONSchema({ allOf: [{ enum: ["a", "b"] }, { enum: ["b", "c"] }] })'
+  input: '"b"'
+  output: '"b"'
+  instantiations: 680
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: "{}"
+  output: "{}"
+operations:
+  parse:
+    expression: i=>{e[0](i);e[1](i)||e[2](i);return i}
+    examples:
+      in-both-members:
+        input: '"b"'
+        output: '"b"'
+      in-first-member-only:
+        input: '"a"'
+        error: Should pass for all schemas of the allOf property.
+      in-neither-member:
+        input: '"z"'
+        error: Should pass for all schemas of the allOf property.
+  decode:
+    expression: i=>{e[0](i)||e[1](i);return i}
+    examples:
+      in-both-members:
+        input: '"b"'
+        output: '"b"'
+  encode:
+    expression: i=>{e[0](i)||e[1](i);return i}
+    examples:
+      in-both-members:
+        input: '"b"'
+        output: '"b"'

--- a/packages/sury/specs/fromjsonschema-object.yaml
+++ b/packages/sury/specs/fromjsonschema-object.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.fromJSONSchema({ type: "object", properties: { id: { type: "string" }, role: { enum: ["admin", "user"] }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "role"] })'
   input: '{ id: string; role: "admin" | "user"; tags?: string[] | undefined; }'
   output: '{ id: string; role: "admin" | "user"; tags?: string[] | undefined; }'
-  instantiations: 1784
+  instantiations: 1783
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/fromjsonschema-object.yaml
+++ b/packages/sury/specs/fromjsonschema-object.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.fromJSONSchema({ type: "object", properties: { id: { type: "string" }, role: { enum: ["admin", "user"] }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "role"] })'
   input: '{ id: string; role: "admin" | "user"; tags?: string[] | undefined; }'
   output: '{ id: string; role: "admin" | "user"; tags?: string[] | undefined; }'
-  instantiations: 1783
+  instantiations: 1791
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/fromjsonschema-object.yaml
+++ b/packages/sury/specs/fromjsonschema-object.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.fromJSONSchema({ type: "object", properties: { id: { type: "string" }, role: { enum: ["admin", "user"] }, tags: { type: "array", items: { type: "string" } } }, required: ["id", "role"] })'
+  input: '{ id: string; role: "admin" | "user"; tags?: string[] | undefined; }'
+  output: '{ id: string; role: "admin" | "user"; tags?: string[] | undefined; }'
+  instantiations: 1784
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: '{ type: "object", properties: { id: { type: "string" }, role: { enum: ["admin", "user"] }, tags: { items: { type: "string" }, type: "array" } }, required: ["id", "role"] }'
+  output: '{ type: "object", properties: { id: { type: "string" }, role: { enum: ["admin", "user"] }, tags: { items: { type: "string" }, type: "array" } }, required: ["id", "role"] }'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[4](i);let v0=i["id"],v1=i["role"],v2=i["tags"];typeof v0==="string"||e[0](v0);typeof v1==="string"&&(v1==="admin"||v1==="user")||e[1](v1);for(;;){if(Array.isArray(v2)){for(let v3=0;v3<v2.length;++v3){try{let v4=v2[v3];typeof v4==="string"||e[2](v4);}catch(v5){v5.path="[\"tags\"]"+'["'+v3+'"]'+v5.path;throw v5}};break}if(v2===void 0)break;e[3](v2)}return {"id":v0,"role":v1,"tags":v2,}}
+    examples:
+      valid:
+        input: '{ id: "1", role: "admin", tags: ["a"] }'
+        output: '{ id: "1", role: "admin", tags: ["a"] }'
+      optional-key-absent:
+        input: '{ id: "1", role: "user" }'
+        output: '{ id: "1", role: "user", tags: undefined }'
+      undeclared-key-strips:
+        input: '{ id: "1", role: "admin", extra: true }'
+        output: '{ id: "1", role: "admin", tags: undefined }'
+      enum-mismatch:
+        input: '{ id: "1", role: "root" }'
+        error: 'Failed at ["role"]: Expected "admin" | "user", received "root"'
+      missing-required:
+        input: '{ role: "admin" }'
+        error: 'Failed at ["id"]: Expected string, received undefined'
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/fromjsonschema-recursive-ref.yaml
+++ b/packages/sury/specs/fromjsonschema-recursive-ref.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=./spec.schema.json
+# FIXME: the runtime doesn't model $ref yet — it parses this document as
+# plain JSON while the static type resolves the recursion, so values outside
+# the inferred type still pass at runtime.
+ts:
+  schema: 'S.fromJSONSchema({ $ref: "#/$defs/node", $defs: { node: { type: "object", properties: { value: { type: "string" }, children: { type: "array", items: { $ref: "#/$defs/node" } } }, required: ["value"] } } })'
+  input: "{ value: string; children?: ...[] | undefined; }"
+  output: "{ value: string; children?: ...[] | undefined; }"
+  instantiations: 2075
+vs:
+  zod:
+    _skip: not-applicable
+jsonSchema:
+  input: "{}"
+  output: "{}"
+operations:
+  parse:
+    expression: i=>{e[0](i);return i}
+    examples:
+      tree:
+        input: '{ value: "root", children: [{ value: "leaf" }] }'
+        output: '{ value: "root", children: [{ value: "leaf" }] }'
+      not-matching-the-ref-still-passes:
+        input: '"any json"'
+        output: '"any json"'
+  decode: identity
+  encode: identity

--- a/packages/sury/specs/fromjsonschema-recursive-ref.yaml
+++ b/packages/sury/specs/fromjsonschema-recursive-ref.yaml
@@ -6,7 +6,7 @@ ts:
   schema: 'S.fromJSONSchema({ $ref: "#/$defs/node", $defs: { node: { type: "object", properties: { value: { type: "string" }, children: { type: "array", items: { $ref: "#/$defs/node" } } }, required: ["value"] } } })'
   input: "{ value: string; children?: ...[] | undefined; }"
   output: "{ value: string; children?: ...[] | undefined; }"
-  instantiations: 2075
+  instantiations: 2074
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/fromjsonschema-recursive-ref.yaml
+++ b/packages/sury/specs/fromjsonschema-recursive-ref.yaml
@@ -6,7 +6,7 @@ ts:
   schema: 'S.fromJSONSchema({ $ref: "#/$defs/node", $defs: { node: { type: "object", properties: { value: { type: "string" }, children: { type: "array", items: { $ref: "#/$defs/node" } } }, required: ["value"] } } })'
   input: "{ value: string; children?: ...[] | undefined; }"
   output: "{ value: string; children?: ...[] | undefined; }"
-  instantiations: 2074
+  instantiations: 2083
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/jsonschema-empty-range.yaml
+++ b/packages/sury/specs/jsonschema-empty-range.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
   schema: 'S.fromJSONSchema({ type: "number", minimum: 5, maximum: 1 })'
-  input: JSON
-  output: JSON
-  instantiations: 254
+  input: number
+  output: number
+  instantiations: 388
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/jsonschema-empty-range.yaml
+++ b/packages/sury/specs/jsonschema-empty-range.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.fromJSONSchema({ type: "number", minimum: 5, maximum: 1 })'
   input: number
   output: number
-  instantiations: 388
+  instantiations: 387
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/jsonschema-int-maximum-above-int32.yaml
+++ b/packages/sury/specs/jsonschema-int-maximum-above-int32.yaml
@@ -13,7 +13,7 @@ ts:
   schema: 'S.fromJSONSchema({ type: "integer", maximum: 3000000000 })'
   input: number
   output: number
-  instantiations: 388
+  instantiations: 387
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/jsonschema-int-maximum-above-int32.yaml
+++ b/packages/sury/specs/jsonschema-int-maximum-above-int32.yaml
@@ -11,9 +11,9 @@
 # creation error the file gives every other keyword it cannot model.
 ts:
   schema: 'S.fromJSONSchema({ type: "integer", maximum: 3000000000 })'
-  input: JSON
-  output: JSON
-  instantiations: 254
+  input: number
+  output: number
+  instantiations: 388
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/jsonschema-int-minimum-above-int32.yaml
+++ b/packages/sury/specs/jsonschema-int-minimum-above-int32.yaml
@@ -12,7 +12,7 @@ ts:
   schema: 'S.fromJSONSchema({ type: "integer", minimum: 3000000000 })'
   input: number
   output: number
-  instantiations: 388
+  instantiations: 387
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/specs/jsonschema-int-minimum-above-int32.yaml
+++ b/packages/sury/specs/jsonschema-int-minimum-above-int32.yaml
@@ -10,9 +10,9 @@
 # the same treatment instead of a third, silent outcome.
 ts:
   schema: 'S.fromJSONSchema({ type: "integer", minimum: 3000000000 })'
-  input: JSON
-  output: JSON
-  instantiations: 254
+  input: number
+  output: number
+  instantiations: 388
 vs:
   zod:
     _skip: not-applicable

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -889,7 +889,7 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
   };
 
   // The dispatch order of this chain is mirrored by `JSONSchemaResolve` in
-  // index.d.ts — reordering branches here changes which keyword wins a
+  // src/types/json.d.ts — reordering branches here changes which keyword wins a
   // conflict, so the type-level chain must move with it.
   let schema: Internal;
   if (jsonSchema.nullable) {

--- a/packages/sury/src/jsonschema.ts
+++ b/packages/sury/src/jsonschema.ts
@@ -888,6 +888,9 @@ export const fromJSONSchema = (jsonSchema: JSONSchemaT): Internal => {
     }
   };
 
+  // The dispatch order of this chain is mirrored by `JSONSchemaResolve` in
+  // index.d.ts — reordering branches here changes which keyword wins a
+  // conflict, so the type-level chain must move with it.
   let schema: Internal;
   if (jsonSchema.nullable) {
     schema = null_(fromJSONSchema(jsonSchemaMerge(jsonSchema, { nullable: false })));

--- a/packages/sury/src/types/json.d.ts
+++ b/packages/sury/src/types/json.d.ts
@@ -1,0 +1,159 @@
+// The JSON data type, and the type a JSON Schema literal describes.
+//
+// `FromJSONSchema` is what gives `S.fromJSONSchema` its inferred result. It
+// resolves a schema written inline; anything it cannot read statically — a
+// value typed `unknown`, `JSON`, or one of the dialect interfaces in
+// ./jsonschema.d.ts — resolves to `JSON`, so a schema loaded at runtime keeps
+// working without a cast.
+
+/**
+ * Any value `JSON.parse` can return.
+ */
+export type JSON =
+  | string
+  | boolean
+  | number
+  | null
+  | { [key: string]: JSON }
+  | JSON[];
+
+// A private copy of index.d.ts's `Flatten` — a non-exported type can't cross a
+// file, and exporting one would put `S.Flatten` in the public API.
+type Flatten<T> = T extends object ? { [K in keyof T]: T[K] } : T;
+
+type UnionToIntersection<U> = (U extends unknown ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+type JSONSchemaDefs<S> = S extends { $defs: infer D }
+  ? D
+  : S extends { definitions: infer D }
+  ? D
+  : {};
+
+type JSONSchemaRefName<R> = R extends `#/$defs/${infer N}`
+  ? N
+  : R extends `#/definitions/${infer N}`
+  ? N
+  : never;
+
+// `[…] extends [never]` first: a non-local pointer must fall back to `JSON`,
+// and letting a bare `never` reach the `keyof D` check would resolve it.
+type JSONSchemaRef<R, D> = [JSONSchemaRefName<R>] extends [never]
+  ? JSON
+  : JSONSchemaRefName<R> extends keyof D
+  ? JSONSchemaResolve<D[JSONSchemaRefName<R>], D>
+  : JSON;
+
+type JSONSchemaRequiredKeys<S> = S extends { required: ReadonlyArray<infer K extends string> }
+  ? K
+  : never;
+
+// Required/optional split by key remapping, not index.d.ts's `ResolveObject`:
+// its `undefined extends TFields[keyof TFields]` probe forces every field type
+// eagerly, which turns a recursive `$ref` through a property into a
+// circular-reference error. Same required-first shape as `ResolveObject`.
+type JSONSchemaObject<S, D> = S extends { properties: infer P }
+  ? Flatten<
+      {
+        -readonly [K in keyof P as K extends JSONSchemaRequiredKeys<S>
+          ? K
+          : never]: JSONSchemaResolve<P[K], D>;
+      } & {
+        -readonly [K in keyof P as K extends JSONSchemaRequiredKeys<S> ? never : K]?:
+          | JSONSchemaResolve<P[K], D>
+          | undefined;
+      }
+    >
+  : S extends { additionalProperties: infer A }
+  ? A extends true
+    ? { [key: string]: JSON }
+    : A extends false
+    ? {}
+    : { [key: string]: JSONSchemaResolve<A, D> }
+  : {};
+
+type JSONSchemaArray<S, D> = S extends { prefixItems: infer P extends readonly unknown[] }
+  ? { -readonly [K in keyof P]: JSONSchemaResolve<P[K], D> }
+  : S extends { items: infer I }
+  ? I extends readonly unknown[]
+    ? { -readonly [K in keyof I]: JSONSchemaResolve<I[K], D> }
+    : JSONSchemaResolve<I, D>[]
+  : JSON[];
+
+// Undoes the `readonly` a `const T` call site stamps onto `enum`/`const`
+// values, the same way index.d.ts's `UnknownToOutput` does for `S.schema`.
+type JSONSchemaLiteral<C> = C extends readonly unknown[]
+  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
+  : C extends object
+  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
+  : C;
+
+type JSONSchemaUnion<A extends readonly unknown[], D> = A extends readonly []
+  ? JSON
+  : { [K in keyof A]: JSONSchemaResolve<A[K], D> }[number];
+
+type JSONSchemaTypeNameToType<N, S, D> = N extends "object"
+  ? JSONSchemaObject<S, D>
+  : N extends "array"
+  ? JSONSchemaArray<S, D>
+  : N extends "string"
+  ? string
+  : N extends "number" | "integer"
+  ? number
+  : N extends "boolean"
+  ? boolean
+  : N extends "null"
+  ? null
+  : JSON;
+
+// First-match dispatch in the same order as the runtime chain in
+// src/jsonschema.ts (nullable → type:"object" → type:"array" → anyOf → enum →
+// const → type[] → scalar type → JSON fallback), so a keyword the runtime
+// ignores in a given position is ignored here too. `$ref` resolves ahead of it
+// — the one place the static type leads the runtime, which still parses a
+// `$ref` as plain JSON. The `string extends keyof S` guard sends
+// index-signature values (e.g. the object arm of `JSON` itself) to the
+// fallback before any keyword can match structurally.
+type JSONSchemaResolve<S, D> = S extends boolean
+  ? S extends true
+    ? JSON
+    : never
+  : string extends keyof S
+  ? JSON
+  : S extends { $ref: infer R }
+  ? JSONSchemaRef<R, D>
+  : S extends { nullable: true }
+  ? null | JSONSchemaResolve<Omit<S, "nullable">, D>
+  : S extends { type: "object" }
+  ? JSONSchemaObject<S, D>
+  : S extends { type: "array" }
+  ? JSONSchemaArray<S, D>
+  : S extends { anyOf: infer A extends readonly unknown[] }
+  ? JSONSchemaUnion<A, D>
+  : S extends { enum: infer E extends readonly unknown[] }
+  ? JSONSchemaLiteral<E[number]>
+  : S extends { const: infer C }
+  ? JSONSchemaLiteral<C>
+  : S extends { type: infer N }
+  ? N extends readonly unknown[]
+    ? JSONSchemaTypeNameToType<N[number], S, D>
+    : JSONSchemaTypeNameToType<N, S, D>
+  : S extends { oneOf: infer A extends readonly unknown[] }
+  ? JSONSchemaUnion<A, D>
+  : S extends { allOf: infer A extends readonly unknown[] }
+  ? Flatten<UnionToIntersection<JSONSchemaUnion<A, D>>>
+  : JSON;
+
+/**
+ * The type a JSON Schema literal describes, as inferred by
+ * `S.fromJSONSchema`. Resolves local `$ref` pointers (`#/$defs/…`,
+ * `#/definitions/…`) against the root schema, including recursive and
+ * mutually recursive ones. A non-literal schema — `unknown`, `S.JSON`, a
+ * dialect interface — resolves to `S.JSON`.
+ */
+export type FromJSONSchema<T> = unknown extends T
+  ? JSON
+  : JSONSchemaResolve<T, JSONSchemaDefs<T>>;

--- a/packages/sury/src/types/json.d.ts
+++ b/packages/sury/src/types/json.d.ts
@@ -47,8 +47,14 @@ type JSONSchemaRef<R, D> = [JSONSchemaRefName<R>] extends [never]
   ? JSONSchemaResolve<D[JSONSchemaRefName<R>], D>
   : JSON;
 
+// The `string extends K` guard catches a `required` widened to `string[]` —
+// e.g. by a `satisfies S.JSONSchema` annotation on the argument — where
+// treating every key as required would type the result narrower than the
+// runtime. Widened means unknowable, so no key is marked required.
 type JSONSchemaRequiredKeys<S> = S extends { required: ReadonlyArray<infer K extends string> }
-  ? K
+  ? string extends K
+    ? never
+    : K
   : never;
 
 // Required/optional split by key remapping, not index.d.ts's `ResolveObject`:
@@ -71,9 +77,9 @@ type JSONSchemaObject<S, D> = S extends { properties: infer P }
   ? A extends true
     ? { [key: string]: JSON }
     : A extends false
-    ? {}
+    ? Record<string, never>
     : { [key: string]: JSONSchemaResolve<A, D> }
-  : {};
+  : { [key: string]: JSON };
 
 type JSONSchemaArray<S, D> = S extends { prefixItems: infer P extends readonly unknown[] }
   ? { -readonly [K in keyof P]: JSONSchemaResolve<P[K], D> }
@@ -85,9 +91,9 @@ type JSONSchemaArray<S, D> = S extends { prefixItems: infer P extends readonly u
 
 // Undoes the `readonly` a `const T` call site stamps onto `enum`/`const`
 // values, the same way index.d.ts's `UnknownToOutput` does for `S.schema`.
-type JSONSchemaLiteral<C> = C extends readonly unknown[]
-  ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
-  : C extends object
+// One branch covers arrays too: the homomorphic mapped type keeps a tuple a
+// tuple.
+type JSONSchemaLiteral<C> = C extends object
   ? { -readonly [K in keyof C]: JSONSchemaLiteral<C[K]> }
   : C;
 
@@ -109,24 +115,37 @@ type JSONSchemaTypeNameToType<N, S, D> = N extends "object"
   ? null
   : JSON;
 
+// Member-by-member fold: intersecting `UnionToIntersection` of the flattened
+// member union would collapse any union-producing member (`enum`, `anyOf`,
+// `nullable`) to `never` instead of intersecting it with its siblings.
+type JSONSchemaIntersection<A, D> = A extends readonly [infer H, ...infer T]
+  ? JSONSchemaResolve<H, D> & JSONSchemaIntersection<T, D>
+  : unknown;
+
 // First-match dispatch in the same order as the runtime chain in
 // src/jsonschema.ts (nullable → type:"object" → type:"array" → anyOf → enum →
 // const → type[] → scalar type → JSON fallback), so a keyword the runtime
-// ignores in a given position is ignored here too. `$ref` resolves ahead of it
-// — the one place the static type leads the runtime, which still parses a
-// `$ref` as plain JSON. The `string extends keyof S` guard sends
-// index-signature values (e.g. the object arm of `JSON` itself) to the
-// fallback before any keyword can match structurally.
+// ignores in a given position is ignored here too. `$ref` resolves right
+// after nullable — the one place the static type leads the runtime, which
+// still parses a `$ref` as plain JSON. A boolean document also goes to the
+// runtime's no-type branch, so `false` stays as wide as `true` here. The
+// `string extends keyof S` guard sends index-signature values (e.g. the
+// object arm of `JSON` itself) to the fallback before any keyword can match
+// structurally.
 type JSONSchemaResolve<S, D> = S extends boolean
-  ? S extends true
-    ? JSON
-    : never
+  ? JSON
   : string extends keyof S
   ? JSON
-  : S extends { $ref: infer R }
-  ? JSONSchemaRef<R, D>
   : S extends { nullable: true }
-  ? null | JSONSchemaResolve<Omit<S, "nullable">, D>
+  ? null | JSONSchemaResolveNonNullable<S, D>
+  : JSONSchemaResolveNonNullable<S, D>;
+
+// The continuation after the `nullable` branch. First-match dispatch means
+// the `nullable` key can simply be skipped here — recursing through
+// `Omit<S, "nullable">` instead would re-map every key of `S` and burn
+// recursion-depth budget per nullable level.
+type JSONSchemaResolveNonNullable<S, D> = S extends { $ref: infer R }
+  ? JSONSchemaRef<R, D>
   : S extends { type: "object" }
   ? JSONSchemaObject<S, D>
   : S extends { type: "array" }
@@ -134,7 +153,9 @@ type JSONSchemaResolve<S, D> = S extends boolean
   : S extends { anyOf: infer A extends readonly unknown[] }
   ? JSONSchemaUnion<A, D>
   : S extends { enum: infer E extends readonly unknown[] }
-  ? JSONSchemaLiteral<E[number]>
+  ? E extends readonly []
+    ? JSON
+    : JSONSchemaLiteral<E[number]>
   : S extends { const: infer C }
   ? JSONSchemaLiteral<C>
   : S extends { type: infer N }
@@ -144,15 +165,19 @@ type JSONSchemaResolve<S, D> = S extends boolean
   : S extends { oneOf: infer A extends readonly unknown[] }
   ? JSONSchemaUnion<A, D>
   : S extends { allOf: infer A extends readonly unknown[] }
-  ? Flatten<UnionToIntersection<JSONSchemaUnion<A, D>>>
+  ? A extends readonly [unknown, ...unknown[]]
+    ? Flatten<JSONSchemaIntersection<A, D>>
+    : JSON
   : JSON;
 
 /**
  * The type a JSON Schema literal describes, as inferred by
  * `S.fromJSONSchema`. Resolves local `$ref` pointers (`#/$defs/…`,
  * `#/definitions/…`) against the root schema, including recursive and
- * mutually recursive ones. A non-literal schema — `unknown`, `S.JSON`, a
- * dialect interface — resolves to `S.JSON`.
+ * mutually recursive ones — but note the runtime does not yet validate a
+ * `$ref`, so a `$ref` position is typed narrower than what the parser checks.
+ * A non-literal schema — `unknown`, `S.JSON`, a dialect interface — resolves
+ * to `S.JSON`.
  */
 export type FromJSONSchema<T> = unknown extends T
   ? JSON

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -2527,7 +2527,7 @@ test("fromJSONSchema", (t) => {
     type: "string",
     format: "email",
   });
-  expectSchemaType(emailSchema).toBe<S.JSON, S.JSON>();
+  expectSchemaType(emailSchema).toBe<string, string>();
   const result = S.safe(() => S.assert(emailSchema, "example.com"));
 
   t.expect(result.error?.message).toBe(
@@ -2538,9 +2538,11 @@ test("fromJSONSchema", (t) => {
 test("fromJSONSchema: takes untyped input, `satisfies` checks an inline one", (t) => {
   // A schema loaded from a file or an API is untyped, and must not need a cast.
   const loaded: unknown = JSON.parse(`{"type":"string"}`);
+  expectSchemaType(S.fromJSONSchema(loaded)).toBe<S.JSON, S.JSON>();
   t.expect(S.parser(S.fromJSONSchema(loaded))("hello")).toBe("hello");
 
   const asJson: S.JSON = { type: "boolean" };
+  expectSchemaType(S.fromJSONSchema(asJson)).toBe<S.JSON, S.JSON>();
   t.expect(S.parser(S.fromJSONSchema(asJson))(true)).toBe(true);
 
   const authored = {
@@ -2559,6 +2561,55 @@ test("fromJSONSchema: takes untyped input, `satisfies` checks an inline one", (t
     requird: ["id"],
   } satisfies S.JSONSchema;
   t.expect(typo.type).toBe("object");
+});
+
+test("fromJSONSchema: an inline schema infers the type it describes", (t) => {
+  const userSchema = S.fromJSONSchema({
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      role: { enum: ["admin", "user"] },
+      tags: { type: "array", items: { type: "string" } },
+      point: { type: "array", prefixItems: [{ type: "number" }, { type: "number" }] },
+      score: { type: "number", nullable: true },
+    },
+    required: ["id", "role"],
+  });
+  expectSchemaType(userSchema).toBe<{
+    id: string;
+    role: "admin" | "user";
+    tags?: string[] | undefined;
+    point?: [number, number] | undefined;
+    score?: number | null | undefined;
+  }>();
+  t.expect(S.parser(userSchema)({ id: "1", role: "admin" })).toEqual({
+    id: "1",
+    role: "admin",
+  });
+
+  // Local $ref pointers resolve, including recursive ones. The runtime still
+  // parses a $ref as plain JSON — the static type leads it here.
+  const treeSchema = S.fromJSONSchema({
+    $ref: "#/$defs/node",
+    $defs: {
+      node: {
+        type: "object",
+        properties: {
+          value: { type: "string" },
+          children: { type: "array", items: { $ref: "#/$defs/node" } },
+        },
+        required: ["value"],
+      },
+    },
+  });
+  type Tree = S.Output<typeof treeSchema>;
+  const tree: Tree = { value: "root", children: [{ value: "leaf" }] };
+  assertType<string | undefined>(tree.children?.[0]?.value);
+
+  // A dialect interface isn't a literal, so it falls back to Schema<JSON, JSON>.
+  expectSchemaType(
+    S.fromJSONSchema(S.toJSONSchema(S.schema({ a: S.string }))),
+  ).toBe<S.JSON, S.JSON>();
 });
 
 test("toJSONSchema: the target picks the dialect of the result", (t) => {

--- a/packages/sury/tests/artifact_test.ts
+++ b/packages/sury/tests/artifact_test.ts
@@ -34,6 +34,7 @@ const FILES = [
   "src/S.res.mjs",
   "src/StandardSchema.res",
   "src/StandardSchema.res.mjs",
+  "src/types/json.d.ts",
   "src/types/jsonschema.d.ts",
   "src/types/standard.d.ts",
 ];


### PR DESCRIPTION
Implements static type inference for `S.fromJSONSchema()` so inline schemas are typed with the data they describe, including recursive `$ref` pointers.

## Summary

`fromJSONSchema` now infers precise types from JSON Schema literals while maintaining backward compatibility: non-literal arguments (`unknown`, `S.JSON`, dialect types) fall back to `Schema<JSON, JSON>`. The implementation includes a new `FromJSONSchema<T>` type that resolves local `$ref` pointers (`#/$defs/…`, `#/definitions/…`) even in recursive schemas.

## Key Changes

- **New type engine** (`src/types/json.d.ts`): ~130-line `JSONSchemaResolve` conditional type that mirrors the runtime dispatch order in `src/jsonschema.ts`. Handles:
  - Object properties with required/optional split via key remapping (avoids circular-reference errors from eager field probing)
  - Array items and tuple prefixItems
  - Local `$ref` resolution with recursion support
  - Union types (anyOf, oneOf, allOf)
  - Enum and const literals
  - Nullable modifier
  - Type arrays and scalar types
  - Graceful fallback to `JSON` for non-literal schemas

- **Updated signature** (`index.d.ts`): `fromJSONSchema<const T>(jsonSchema: T): Schema<FromJSONSchema<T>, FromJSONSchema<T>>` enables inference while preserving the `unknown` default for untyped inputs

- **Spec coverage**: Two new specs validate the feature:
  - `fromjsonschema-object.yaml`: Object with required/optional properties, enums, arrays (~1,783 instantiations)
  - `fromjsonschema-recursive-ref.yaml`: Recursive tree structure via `$ref` (~2,074 instantiations)
  - Updated three existing `jsonschema-*` specs to reflect precise types instead of `JSON`

- **Documentation**: Updated `js-usage.md` with examples showing inline schema inference and the fallback behavior for runtime-loaded schemas

- **Test coverage**: Added comprehensive test cases covering objects, enums, arrays, tuples, nullable fields, and recursive `$ref` structures

## Implementation Notes

The type engine's dispatch order is intentionally synchronized with the runtime chain in `src/jsonschema.ts` (comments on both sides document this invariant). The object-property split uses key remapping instead of eager field probing to avoid circular-reference errors on recursive schemas—a pattern borrowed from `ata-validator`.

**Known limitation**: The runtime currently parses `$ref` as plain JSON, so the static type leads the runtime here. A FIXME in `fromjsonschema-recursive-ref.yaml` marks this divergence for future closure when runtime `$ref` resolution lands.

Not modeled (intentionally, v1): `not`, `if/then/else`, `default`-fold's input/output split, `oneOf` exclusivity—all degrade to the runtime's wider static shape, never narrower.

https://claude.ai/code/session_01MVScxaWCZqJgpNnN1yubW9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic TypeScript type inference for inline JSON Schemas, including objects, arrays, enums, nullable values, unions, constants, and local or recursive references.
  - Non-literal or runtime-loaded schemas continue to use broad JSON typing.
  - Exported reusable JSON and JSON Schema inference types.

- **Documentation**
  - Clarified inline versus non-literal schema behavior, supported limitations, and usage guidance.

- **Tests**
  - Added coverage for object schemas, recursive references, optional fields, validation, and inferred types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->