### PR TITLE
Support async operations in schema specs

### DIFF
--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -15,8 +15,6 @@ pnpm spec check [id]           # gate
 
 Add a case: a named entry with just `input` under an op's `examples`, then `--write`. Follow the CLI's error messages — op shorthands (`identity`, `eq-to-parse`), `_skip` reasons, and the `vs.zod` divergence form all report the fix in the message.
 
-An async direction (a schema with an async transform or refine) is the one thing about an operation you declare rather than derive: put `isAsync: true` on the op block, and `check` builds it with `S.asyncParser`/`asyncDecoder`/`asyncEncoder` and awaits every example. It errors when a direction is async and unmarked, or marked and synchronous — asyncness is per direction, so `S.asyncDecoderAssert` marks decode/parse while encode stays sync.
-
 **Examples are where findings live.** Cover every edge case the schema turns up — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corners, each generated-check branch. A bug report or review finding becomes an example, not a test file and not a commit message.
 
 ## Metrics ratchet

--- a/.claude/skills/spec/SKILL.md
+++ b/.claude/skills/spec/SKILL.md
@@ -15,6 +15,8 @@ pnpm spec check [id]           # gate
 
 Add a case: a named entry with just `input` under an op's `examples`, then `--write`. Follow the CLI's error messages — op shorthands (`identity`, `eq-to-parse`), `_skip` reasons, and the `vs.zod` divergence form all report the fix in the message.
 
+An async direction (a schema with an async transform or refine) is the one thing about an operation you declare rather than derive: put `isAsync: true` on the op block, and `check` builds it with `S.asyncParser`/`asyncDecoder`/`asyncEncoder` and awaits every example. It errors when a direction is async and unmarked, or marked and synchronous — asyncness is per direction, so `S.asyncDecoderAssert` marks decode/parse while encode stays sync.
+
 **Examples are where findings live.** Cover every edge case the schema turns up — boundary values, IEEE-754 oddities (`-0`, `NaN`, `Infinity`), coercion corners, each generated-check branch. A bug report or review finding becomes an example, not a test file and not a commit message.
 
 ## Metrics ratchet

--- a/packages/spec/bench.ts
+++ b/packages/spec/bench.ts
@@ -72,6 +72,8 @@ export type Target = {
   specId: string;
   phase: Phase;
   op?: OpName;
+  /** Build the operation with the async builder — the only way an async schema compiles. */
+  isAsync?: boolean;
   /** Type-stripped already: the child has no TypeScript to strip it with. */
   schemaSrc?: string;
   inputSrc?: string;
@@ -110,6 +112,7 @@ export type Perf = {
   unchanged: number;
   added: string[];
   skippedConstants: number;
+  skippedAsync: number;
   errors: { name: string; error: string }[];
   // Targets whose accept/reject outcome moved. Not timings — a behavior change
   // that a percentage would misreport as an enormous slowdown.
@@ -210,9 +213,10 @@ const isConstantSchema = (src: string): boolean => evalSchema(src) === evalSchem
 export const deriveTargets = (
   files: string[],
   scenarioIds?: string[],
-): { targets: Target[]; skippedConstants: number } => {
+): { targets: Target[]; skippedConstants: number; skippedAsync: number } => {
   const targets: Target[] = [];
   let skippedConstants = 0;
+  let skippedAsync = 0;
 
   for (const [id, scenario] of Object.entries(readScenarios())) {
     if (scenarioIds && !scenarioIds.includes(id)) continue;
@@ -251,8 +255,17 @@ export const deriveTargets = (
       // and no examples to run. Timing how fast it throws would measure error
       // construction, not the schema.
       if (isCreationError(block)) continue;
+      const isAsync = block.isAsync === true;
       if (!constant)
-        targets.push({ ...base, name: `${id}${SEP}create+compile${SEP}${op}`, phase: "create+compile", op });
+        targets.push({ ...base, name: `${id}${SEP}create+compile${SEP}${op}`, phase: "create+compile", op, isAsync });
+      // Compiling an async operation is ordinary synchronous work (above), but
+      // running one is not: the batch loop can only start the promises, so the
+      // resolution it is supposed to be timing lands in microtasks after the
+      // clock is read. Counted, not silently dropped — the report says how many.
+      if (isAsync) {
+        skippedAsync += Object.keys(block.examples).length;
+        continue;
+      }
       for (const [example, ex] of Object.entries(block.examples))
         targets.push({
           ...base,
@@ -275,7 +288,7 @@ export const deriveTargets = (
       controls.push({ ...inPhase[i]!, name: `control${SEP}${inPhase[i]!.name}`, control: true });
   }
 
-  return { targets: [...targets, ...controls], skippedConstants };
+  return { targets: [...targets, ...controls], skippedConstants, skippedAsync };
 };
 
 // ---- statistics ------------------------------------------------------------
@@ -342,7 +355,7 @@ export const runPerf = async (
     buildChild(),
   ]);
 
-  const { targets, skippedConstants } = deriveTargets(files, scenarioIds);
+  const { targets, skippedConstants, skippedAsync } = deriveTargets(files, scenarioIds);
   const childPath = join(CACHE, "child.mjs");
   const payloadFor = (list: Target[]): ChildPayload => ({
     baseline: pathToFileURL(baselinePath).href,
@@ -484,6 +497,7 @@ export const runPerf = async (
     unchanged: real.length - changed.length,
     added: [...new Set(added)],
     skippedConstants,
+    skippedAsync,
     // Deduped by name like outcomeChanged: collect runs over the screening pass
     // plus every confirm pass, so one target can report the same failure twice.
     errors: [...new Map(errors.map((e) => [e.name, e])).values()],

--- a/packages/spec/benchChild.ts
+++ b/packages/spec/benchChild.ts
@@ -14,6 +14,10 @@ import type { ChildPayload, ChildResult, Target } from "./bench";
 import { buildScenarioRunner } from "./scenario";
 
 const OP_BUILDER = { parse: "parser", decode: "decoder", encode: "encoder" } as const;
+// An async schema compiles only through these, so a `create+compile` target for
+// one has to name the builder its spec's `isAsync` declares. (There are no
+// async `run` targets — see deriveTargets.)
+const ASYNC_OP_BUILDER = { parse: "asyncParser", decode: "asyncDecoder", encode: "asyncEncoder" } as const;
 
 // Every measured value is stored into a box so V8 can't delete the work as
 // dead. The boxes are kept alive here (and read at exit) so escape analysis
@@ -57,7 +61,7 @@ const buildRunner = (
       )(factory, S, box),
     };
 
-  const builder = S[OP_BUILDER[target.op!]];
+  const builder = S[(target.isAsync ? ASYNC_OP_BUILDER : OP_BUILDER)[target.op!]];
 
   if (target.phase === "create+compile")
     return {

--- a/packages/spec/format.ts
+++ b/packages/spec/format.ts
@@ -72,6 +72,17 @@ export type Example = S.Output<typeof example>;
 // Examples are addressed by name, not array index, so identity survives
 // insertion/removal.
 const operationExpression = S.schema({
+  // Declared, not refreshed: an async operation is compiled by a different
+  // builder and returns a Promise — a different API for every consumer — so
+  // `--write` never adds or removes the marker in place. A schema that turns
+  // async fails the check instead of quietly rewriting the spec to say so.
+  // Absent means sync; `false` is never written, so there's one spelling per state.
+  isAsync: S.optional(S.schema(true)).with(S.meta, {
+    description:
+      "`true` if this direction is async (built with S.asyncParser/asyncDecoder/asyncEncoder, " +
+      "examples awaited). Written when the block is first created; `spec check` errors when it " +
+      "disagrees with the schema. Omit when sync.",
+  }),
   expression: orSkip(S.string).with(S.meta, {
     description: "Compiled function source (`.toString()`). Filled by `spec check --write`.",
   }),
@@ -81,6 +92,7 @@ const operationExpression = S.schema({
 })
   .with(S.strict)
   .with(S.meta, { description: "Compiled codegen plus its runnable examples." });
+export type OperationExpression = S.Output<typeof operationExpression>;
 
 // The operation analogue of a thrown `jsonSchema` string: some conversions are
 // rejected when the operation is compiled (an unsupported or ambiguous `.to`),
@@ -235,6 +247,11 @@ export const TS_KEY_ORDER = keyOrder<Spec["ts"]>({
   instantiations: true,
 });
 export const OP_ORDER = keyOrder<Spec["operations"]>({ parse: true, decode: true, encode: true });
+export const OP_BLOCK_KEY_ORDER = keyOrder<OperationExpression>({
+  isAsync: true,
+  expression: true,
+  examples: true,
+});
 
 export const isSkip = (v: unknown): v is Skip => S.is(skip, v);
 

--- a/packages/spec/harness.ts
+++ b/packages/spec/harness.ts
@@ -22,6 +22,7 @@ import {
   VS_KEY_ORDER,
   VS_ZOD_KEY_ORDER,
   OP_ORDER,
+  OP_BLOCK_KEY_ORDER,
   BUNDLE_SIZE_KEY_ORDER,
   SKIP_REASONS,
   isSkip,
@@ -68,6 +69,27 @@ const OP_BUILDER: Record<OpName, (schema: any) => (input: any) => any> = {
   decode: S.decoder,
   encode: S.encoder,
 };
+
+// A schema carrying an async transform or refine compiles only through these:
+// the sync builders reject it at operation creation ("Encountered unexpected
+// async transform or refine"), and they wrap a sync direction in
+// `Promise.resolve(...)`, so which builder an op uses is part of its codegen —
+// hence a declared `isAsync`, checked against the schema, rather than a guess.
+const ASYNC_OP_BUILDER: Record<OpName, (schema: any) => (input: any) => Promise<any>> = {
+  parse: S.asyncParser,
+  decode: S.asyncDecoder,
+  encode: S.asyncEncoder,
+};
+
+// `S.isAsync` is exported by the runtime entry but declared only for ReScript
+// (docs/rescript-usage.md), so index.d.ts has no signature to import.
+const schemaIsAsync = (S as unknown as { isAsync: (schema: any) => boolean }).isAsync;
+
+// Asked per direction, not per schema: `S.asyncDecoderAssert` makes the decode
+// side async while the encode side stays a plain sync pass, and encode runs the
+// reversed schema.
+const opIsAsync = (opName: OpName, schema: any): boolean =>
+  schemaIsAsync(opName === "encode" ? S.reverse(schema) : schema);
 
 const SKIP_REASON_SET = new Set<string>(SKIP_REASONS);
 export const isValidSkipReason = (r: unknown): boolean =>
@@ -220,6 +242,40 @@ export const identityViolations = (schema: any, spec: Spec): string[] => {
   return out;
 };
 
+// The `isAsync` marker checked both ways, like identityViolations: an async
+// direction must declare it (the operation returns a Promise — a different API
+// for every consumer, and different codegen), and a declared one must hold.
+// Only full op blocks carry the marker: `identity` can't be async (an async op
+// never compiles to Sury's noop, so identityViolations already reports it),
+// `eq-to-parse` inherits parse's block, and a `{creationError}` block has no
+// compiled operation to be async.
+export const asyncViolations = (schema: any, spec: Spec): string[] => {
+  const out: string[] = [];
+  for (const opName of OP_ORDER) {
+    const op = spec.operations[opName];
+    if (typeof op === "string" || isCreationError(op)) continue;
+    let isAsync: boolean;
+    try {
+      isAsync = opIsAsync(opName, schema);
+    } catch {
+      // Not a usable schema — reported by checkSpec's own evaluation, and by
+      // the creationError golden if the operation is what fails.
+      continue;
+    }
+    if (isAsync && op.isAsync !== true)
+      out.push(
+        `operations.${opName}: is async (the schema has an async transform or refine) — add \`isAsync: true\`, ` +
+          "which builds it with S.asyncParser/asyncDecoder/asyncEncoder and awaits every example",
+      );
+    else if (!isAsync && op.isAsync === true)
+      out.push(
+        `operations.${opName}: marked \`isAsync: true\` but the operation is synchronous — remove the marker ` +
+          "(the async builders would only wrap the result in `Promise.resolve`)",
+      );
+  }
+  return out;
+};
+
 // JSON Schema has no representation for bigint or symbol, so `S.toJSONSchema`
 // throws for any schema containing one (at any nesting depth) — a real "this
 // concept doesn't apply" case, not a bug to work around. Recorded per
@@ -252,10 +308,11 @@ export const scaffoldJsonSchema = (schema: any): Spec["jsonSchema"] => deriveJso
 // so a bug stays visibly distinct in the golden — and flips back to compiled
 // code once a fix turns the crash into a real operation — rather than silently
 // masquerading as a normal rejection.
-type BuiltOp = { fn: (input: any) => any } | { creationError: string };
+type BuiltOp = { fn: (input: any) => any; isAsync: boolean } | { creationError: string };
 const buildOp = (opName: OpName, schema: any): BuiltOp => {
   try {
-    return { fn: OP_BUILDER[opName](schema) };
+    const isAsync = opIsAsync(opName, schema);
+    return { fn: (isAsync ? ASYNC_OP_BUILDER : OP_BUILDER)[opName](schema), isAsync };
   } catch (e) {
     const err = e as Error;
     return { creationError: `${err.constructor.name}: ${err.message}` };
@@ -284,7 +341,7 @@ const opForm = (opName: OpName, built: BuiltOp, parseBuilt: BuiltOp): Operation 
     ? "identity"
     : opName !== "parse" && parseCode !== undefined && built.fn.toString() === parseCode
       ? "eq-to-parse"
-      : { expression: built.fn.toString(), examples: {} };
+      : clean({ isAsync: built.isAsync ? (true as const) : undefined, expression: built.fn.toString(), examples: {} });
 };
 
 // Can throw if `schema` isn't actually a usable schema (e.g. `--ts` evaluated
@@ -331,7 +388,7 @@ const canonExample = (ex: Example): Example => {
 const canonOp = (op: Operation): Operation => {
   if (typeof op === "string") return op;
   if (isCreationError(op)) return order(op, ["creationError"]);
-  const o = order(op, ["expression", "examples"]);
+  const o = order(op, OP_BLOCK_KEY_ORDER as string[]);
   if (o.examples && typeof o.examples === "object") {
     const ex: Record<string, Example> = {};
     for (const [name, v] of Object.entries(o.examples)) ex[name] = canonExample(v);
@@ -584,7 +641,12 @@ export const recomputeGoldens = async (obj: Spec): Promise<Spec> => {
       const bench = ex.bench;
       try {
         const value = evalSchema(ex.input);
-        const out = fn(value);
+        // `await` on a sync operation's result is a no-op, so both kinds run
+        // through one path. An async operation can still throw synchronously
+        // (the top-level type check runs before the first await), which the
+        // same catch handles — a rejection and a synchronous throw are one
+        // outcome to the author.
+        const out = await fn(value);
         // An operation that hands its input straight back records the input's
         // own source rather than a re-derived spelling of the same value. It
         // reads better, and it's the only way a value the serializer can't
@@ -717,6 +779,13 @@ export const checkAliases = async (spec: Spec): Promise<string[]> => {
             errs.push(
               `${label}: operations.${opName} is \`eq-to-parse\` on schema but does not compile to the same code as parse on this alias`,
             );
+        } else if (built.isAsync !== (op.isAsync === true)) {
+          // Reported instead of the expression diff below: the two are built by
+          // different builders, so their code differs everywhere and the diff
+          // would bury the one fact that explains it.
+          errs.push(
+            `${label}: operations.${opName} is ${built.isAsync ? "async on this alias but not on schema" : "async on schema but not on this alias"}`,
+          );
         } else if (!isSkip(op.expression) && fn.toString() !== op.expression) {
           errs.push(`${label}: operations.${opName}.expression differs:\n${diffText(op.expression, fn.toString())}`);
         }
@@ -844,6 +913,11 @@ export const checkSpec = async (
     try {
       const violations = identityViolations(schema, spec);
       for (const violation of violations) errs.push(violation);
+      // Not part of `violations`: a wrong `isAsync` doesn't block `--write`
+      // (which builder a direction uses is derived from the schema, so the
+      // recomputed goldens are right either way) — only the marker needs the
+      // author's hand.
+      errs.push(...asyncViolations(schema, spec));
       const fresh = knownFresh ?? serialize(await recomputeGoldens(spec), comments);
       if (fresh !== canon)
         errs.push(

--- a/packages/spec/summary.ts
+++ b/packages/spec/summary.ts
@@ -210,7 +210,9 @@ export const renderPerformance = (perf: Perf): string => {
     lines.push(`  behavior changed, not timed — ${o.name}: ${o.note}`);
   for (const e of perf.errors) lines.push(`  could not measure ${e.name}: ${e.error}`);
   lines.push(
-    `  ${perf.unchanged} unchanged · ${perf.skippedConstants} constant-schema targets skipped · advisory only`,
+    `  ${perf.unchanged} unchanged · ${perf.skippedConstants} constant-schema targets skipped · ` +
+      (perf.skippedAsync ? `${perf.skippedAsync} async examples skipped · ` : "") +
+      "advisory only",
     `  ${perf.meta}`,
   );
   return lines.join("\n");

--- a/packages/sury/specs/async-assert.yaml
+++ b/packages/sury/specs/async-assert.yaml
@@ -1,0 +1,41 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: S.string.with(S.asyncDecoderAssert, async (value) => { if (value === "bad") throw new Error("rejected"); })
+  input: string
+  output: string
+  instantiations: 5245
+vs:
+  zod: z.string().refine(async (value) => value !== "bad")
+jsonSchema:
+  input: '{ type: "string" }'
+  output: Expected JSON, received unknown
+operations:
+  parse:
+    isAsync: true
+    expression: i=>{typeof i==="string"||e[2](i);let v0;try{v0=e[0](i).catch(x=>e[1](x))}catch(x){e[1](x)}return v0}
+    examples:
+      valid:
+        input: '"hello"'
+        output: '"hello"'
+      rejected-by-assert:
+        input: '"bad"'
+        error: rejected
+      invalid-type:
+        input: "42"
+        error: Expected string, received 42
+  decode:
+    isAsync: true
+    expression: i=>{let v0;try{v0=e[0](i).catch(x=>e[1](x))}catch(x){e[1](x)}return v0}
+    examples:
+      valid:
+        input: '"hello"'
+        output: '"hello"'
+      rejected-by-assert:
+        input: '"bad"'
+        error: rejected
+  encode:
+    expression: i=>{let v0;try{v0=e[0](i)}catch(x){e[1](x)}typeof v0==="string"||e[2](v0);return v0}
+    examples:
+      valid:
+        input: '"hello"'
+        output: '"hello"'

--- a/packages/sury/specs/spec.schema.json
+++ b/packages/sury/specs/spec.schema.json
@@ -179,6 +179,11 @@
             {
               "type": "object",
               "properties": {
+                "isAsync": {
+                  "type": "boolean",
+                  "const": true,
+                  "description": "`true` if this direction is async (built with S.asyncParser/asyncDecoder/asyncEncoder, examples awaited). Written when the block is first created; `spec check` errors when it disagrees with the schema. Omit when sync."
+                },
                 "expression": {
                   "anyOf": [
                     {
@@ -292,6 +297,11 @@
             {
               "type": "object",
               "properties": {
+                "isAsync": {
+                  "type": "boolean",
+                  "const": true,
+                  "description": "`true` if this direction is async (built with S.asyncParser/asyncDecoder/asyncEncoder, examples awaited). Written when the block is first created; `spec check` errors when it disagrees with the schema. Omit when sync."
+                },
                 "expression": {
                   "anyOf": [
                     {
@@ -405,6 +415,11 @@
             {
               "type": "object",
               "properties": {
+                "isAsync": {
+                  "type": "boolean",
+                  "const": true,
+                  "description": "`true` if this direction is async (built with S.asyncParser/asyncDecoder/asyncEncoder, examples awaited). Written when the block is first created; `spec check` errors when it disagrees with the schema. Omit when sync."
+                },
                 "expression": {
                   "anyOf": [
                     {

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -410,6 +410,47 @@ test("eq-to-parse claimed but parse itself is identity — identity wins", async
   `);
 });
 
+// An async direction is compiled by a different builder and its examples are
+// awaited, so the marker is the author's acknowledgment that the operation's
+// whole shape changed — the two directions of getting it wrong are checked
+// against a spec that really is async on one side and sync on the other.
+const asyncBaseline = readSpec(listSpecFiles().find((f) => specId(f) === "async-assert")!);
+
+const mutateAsync = (patch: (spec: Spec) => void): Spec => {
+  const spec = structuredClone(asyncBaseline);
+  patch(spec);
+  return spec;
+};
+
+test("an async operation left unmarked", async () => {
+  const spec = mutateAsync((s) => {
+    if (s.operations.parse !== "identity" && !isCreationError(s.operations.parse))
+      delete s.operations.parse.isAsync;
+  });
+  await expect(runCheck("async-assert", serialize(spec))).resolves.toMatchInlineSnapshot(`
+    {
+      "stderr": "✗ async-assert
+        operations.parse: is async (the schema has an async transform or refine) — add \`isAsync: true\`, which builds it with S.asyncParser/asyncDecoder/asyncEncoder and awaits every example",
+      "stdout": "",
+    }
+  `);
+});
+
+test("`isAsync: true` on an operation that is synchronous", async () => {
+  const spec = mutateAsync((s) => {
+    // async-assert's encode side runs the assert's sync `s: noop` half.
+    if (typeof s.operations.encode !== "string" && !isCreationError(s.operations.encode))
+      s.operations.encode.isAsync = true;
+  });
+  await expect(runCheck("async-assert", serialize(spec))).resolves.toMatchInlineSnapshot(`
+    {
+      "stderr": "✗ async-assert
+        operations.encode: marked \`isAsync: true\` but the operation is synchronous — remove the marker (the async builders would only wrap the result in \`Promise.resolve\`)",
+      "stdout": "",
+    }
+  `);
+});
+
 test("format validation failure (unrecognized key)", async () => {
   const spec = mutate((s) => {
     (s as unknown as Record<string, unknown>).notAField = true;

--- a/packages/sury/tests/spec_perf_test.ts
+++ b/packages/sury/tests/spec_perf_test.ts
@@ -81,6 +81,27 @@ test("a scenario contributes one target built from its own prepare and run", () 
   expect(real[0]!.runSrc).toBe('(schema["~standard"].validate(data))');
 });
 
+// Compiling an async operation is ordinary sync work and is measured (with the
+// async builder, the only one that accepts the schema); running one can't be —
+// a batch loop only starts the promises. The skipped examples are counted so
+// the report doesn't read as if they were timed and found unchanged.
+test("an async op contributes its compilation target but none of its examples", () => {
+  const { targets, skippedAsync } = targetsFor("async-assert");
+  const real = targets.filter((t) => !t.control);
+  expect(real.map((t) => t.name)).toEqual([
+    "async-assert · create",
+    "async-assert · create+compile · parse",
+    "async-assert · create+compile · decode",
+    "async-assert · create+compile · encode",
+    "async-assert · encode · valid",
+  ]);
+  expect(real.filter((t) => t.isAsync).map((t) => t.name)).toEqual([
+    "async-assert · create+compile · parse",
+    "async-assert · create+compile · decode",
+  ]);
+  expect(skippedAsync).toBe(5);
+});
+
 test("scenarios are selected by name, so narrowing to a spec picks up none of them", () => {
   expect(targetsFor("string").targets.some((t) => t.phase === "scenario")).toBe(false);
   expect(deriveTargets([], []).targets.length).toBe(0);
@@ -126,6 +147,7 @@ const perf = (changed: Perf["changed"], over: Partial<Perf> = {}): Perf => ({
   unchanged: 137,
   added: [],
   skippedConstants: 13,
+  skippedAsync: 0,
   errors: [],
   outcomeChanged: [],
   meta: "node 24.16.0 · linux x64 · 4 cores · 8×2 rounds · confirmed",
@@ -157,6 +179,14 @@ test("renderPerformance ranks worst regression first and states the floor per ph
       137 unchanged · 13 constant-schema targets skipped · advisory only
       node 24.16.0 · linux x64 · 4 cores · 8×2 rounds · confirmed"
   `);
+});
+
+// Only when there are any: a "0 async examples skipped" on every run of a
+// suite that has none is noise in the one line that summarizes coverage.
+test("renderPerformance reports skipped async examples alongside the constant-schema ones", () => {
+  expect(renderPerformance(perf([], { skippedAsync: 5 }))).toContain(
+    "137 unchanged · 13 constant-schema targets skipped · 5 async examples skipped · advisory only",
+  );
 });
 
 test("renderPerformance says so plainly when nothing cleared the floor", () => {

--- a/packages/sury/tests/spec_test.ts
+++ b/packages/sury/tests/spec_test.ts
@@ -14,6 +14,7 @@ import {
   recomputeGoldens,
   evalSchema,
   identityViolations,
+  asyncViolations,
   checkAliases,
   collectComments,
   lintComments,
@@ -221,6 +222,11 @@ describe.each(specs)("spec: $id", ({ file }) => {
   test("has no identity-invariant violations (run `pnpm spec check`)", () => {
     const schema = evalSchema(spec.ts.schema);
     const violations = identityViolations(schema, spec);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  test("every `isAsync` marker matches the schema (run `pnpm spec check`)", () => {
+    const violations = asyncViolations(evalSchema(spec.ts.schema), spec);
     expect(violations, violations.join("\n")).toEqual([]);
   });
 


### PR DESCRIPTION
Add support for async transforms and refines in schema specifications. Async operations are compiled with different builders (`asyncParser`, `asyncDecoder`, `asyncEncoder`) and return Promises, requiring explicit declaration via an `isAsync: true` marker in operation blocks.

## Key changes

- **New `asyncViolations` check**: Validates that `isAsync` markers match the schema's actual async state. An operation with async transforms/refines must declare `isAsync: true`; conversely, a declared async operation must actually be async. This check runs alongside `identityViolations` in `checkSpec`.

- **Async operation detection**: Added `opIsAsync` helper that uses `S.isAsync` (exported by runtime but only documented for ReScript) to determine if a direction compiles to an async operation. For encode, checks the reversed schema since encode runs the reversed direction.

- **Dual builder system**: Introduced `ASYNC_OP_BUILDER` alongside existing `OP_BUILDER`. The `buildOp` function now selects the appropriate builder based on schema analysis and includes the `isAsync` boolean in its return type.

- **Operation expression schema update**: Added optional `isAsync: true` field to `operationExpression` schema. The marker is declared once at creation and never auto-refreshed—`--write` errors if it disagrees with the schema rather than silently rewriting it.

- **Example handling**: Examples in async operation blocks are awaited during execution (via `await fn(value)` in `recomputeGoldens`). Sync operations' results are also awaited, which is a no-op.

- **Alias checking**: Extended `checkAliases` to detect when an operation's async state differs between schema and alias, reporting this before expression diffs since different builders produce entirely different code.

- **Performance tracking**: Updated `deriveTargets` to skip async operation examples from timing (they can't be measured in a batch loop that only starts promises). Async examples are counted in `skippedAsync` and reported in performance summaries.

- **New spec**: Added `async-assert.yaml` demonstrating an async operation using `S.asyncDecoderAssert` with an async refine, covering parse/decode (async) and encode (sync) directions.

- **Tests**: Added validation tests for unmarked async operations and incorrectly marked sync operations, plus performance test coverage for async target derivation.

## Implementation notes

- The `isAsync` marker is author-declared, not inferred by `--write`, because it represents a significant API change (Promise return type) that requires conscious acknowledgment.
- Async detection checks the schema direction-specifically: encode checks the reversed schema since it runs the reversed direction.
- Sync operations awaited in examples is harmless and allows one code path for both kinds.
- Async examples are excluded from performance measurement because the batch loop can only start promises; their resolution happens in microtasks after timing stops.

https://claude.ai/code/session_01GQGXqapvY1q5WMkcz5eiJp