### PR TITLE
Add schema compiler fuzz engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "res": "pnpm --filter=sury exec rescript watch",
     "spec": "tsx packages/spec/cli.ts",
+    "fuzz": "pnpm --filter=fuzz fuzz",
+    "test:fuzz": "pnpm --filter=fuzz test",
     "compliance": "pnpm --filter=sury build:entry && tsx packages/json-schema-test-suite/cli.ts",
     "test": "pnpm --filter=sury test && pnpm --filter=e2e test",
     "build": "pnpm --filter=sury build",

--- a/packages/fuzz/.gitignore
+++ b/packages/fuzz/.gitignore
@@ -1,0 +1,1 @@
+artifacts/

--- a/packages/fuzz/README.md
+++ b/packages/fuzz/README.md
@@ -1,0 +1,35 @@
+# Sury schema compiler fuzzer
+
+This is one deterministic engine for the public, compiler-facing runtime schema API. It varies schema trees, decoder/encoder pipelines, and compilation modes; it intentionally does not spend most of its budget mutating arbitrary input values.
+
+The engine covers:
+
+- the complete compiler-facing schema constructor, refinement, modifier, transformation, recursion, list, compact-column, instance, merge, shape, and reverse surface (aliases share their canonical implementation);
+- `parser`, `decoder`, `encoder`, and their async variants;
+- one-to-three-schema compiler pipelines;
+- unions, recursion, refinements, objects, tuples, records, and transformations;
+- `S.to(source, target)`, `S.to(source, target, decoder)`, and `S.to(source, target, decoder, encoder)`;
+- generated-function syntax, sync/async contracts, cache behavior, and a canonical witness value;
+- deterministic failure replay and structural shrinking.
+
+PPX is out of scope. It has a separate compilation surface and should get its own focused harness if it is fuzzed later. JSON Schema conversion, global configuration, and result-wrapper helpers are also outside this schema-to-generated-function engine because they do not add decoder/encoder compiler combinations.
+
+## Run
+
+From the repository root:
+
+```sh
+pnpm fuzz
+```
+
+The command deliberately has no tuning flags. It always runs the checked-in reliability profile: four deterministic seeds, 2,000 cases per seed, schema depth four, canonical witness execution, a one-second async timeout, and structural shrinking. Keeping this profile in source makes local and CI runs comparable and prevents important checks from being disabled accidentally.
+
+A compiler crash, invalid generated function, unexpected runtime exception, timeout, or sync/async contract violation writes a JSON artifact under `packages/fuzz/artifacts/` and prints a replay command. `SuryError` and explicit `[Sury]` configuration errors are treated as controlled rejections because many randomly composed API combinations are intentionally incompatible.
+
+To replay a saved failure:
+
+```sh
+pnpm fuzz -- replay packages/fuzz/artifacts/<artifact>.json
+```
+
+The report lists operation, public API, pipeline-category, and outcome counters. It explicitly reports any compiler API not reached by the run; the fixed corpus reaches the full catalog before seeded generation begins.

--- a/packages/fuzz/catalog.ts
+++ b/packages/fuzz/catalog.ts
@@ -1,0 +1,113 @@
+import type { CodecFunctionName, ValueAst } from "./types";
+
+export const CODEC_FUNCTION_NAMES: readonly CodecFunctionName[] = [
+  "identity",
+  "to-string",
+  "to-number",
+  "to-boolean",
+  "length",
+  "first",
+  "wrap-array",
+  "constant-string",
+  "constant-number",
+  "constant-boolean",
+  "constant-null",
+  "constant-undefined",
+  "empty-array",
+  "empty-object",
+];
+
+export const codecFunction = (name: CodecFunctionName): ((value: unknown) => unknown) => {
+  switch (name) {
+    case "identity":
+      return (value) => value;
+    case "to-string":
+      return (value) => String(value);
+    case "to-number":
+      return (value) => Number(value);
+    case "to-boolean":
+      return (value) => Boolean(value);
+    case "length":
+      return (value) =>
+        typeof value === "string" || Array.isArray(value) ? value.length : 0;
+    case "first":
+      return (value) => (Array.isArray(value) ? value[0] : value);
+    case "wrap-array":
+      return (value) => [value];
+    case "constant-string":
+      return () => "fuzz";
+    case "constant-number":
+      return () => 1;
+    case "constant-boolean":
+      return () => true;
+    case "constant-null":
+      return () => null;
+    case "constant-undefined":
+      return () => undefined;
+    case "empty-array":
+      return () => [];
+    case "empty-object":
+      return () => ({});
+  }
+};
+
+export const valueFromAst = (value: ValueAst): unknown => {
+  switch (value.kind) {
+    case "string":
+    case "boolean":
+      return value.value;
+    case "number":
+      switch (value.value.kind) {
+        case "finite":
+          return value.value.value;
+        case "nan":
+          return NaN;
+        case "infinity":
+          return value.value.negative ? -Infinity : Infinity;
+        case "negative-zero":
+          return -0;
+      }
+    case "bigint":
+      return BigInt(value.value);
+    case "null":
+      return null;
+    case "undefined":
+      return undefined;
+    case "array":
+      return value.items.map(valueFromAst);
+    case "object":
+      return Object.fromEntries(value.entries.map(([key, item]) => [key, valueFromAst(item)]));
+  }
+};
+
+export const renderValue = (value: ValueAst): string => {
+  switch (value.kind) {
+    case "string":
+      return JSON.stringify(value.value);
+    case "boolean":
+      return String(value.value);
+    case "number":
+      switch (value.value.kind) {
+        case "finite":
+          return String(value.value.value);
+        case "nan":
+          return "NaN";
+        case "infinity":
+          return value.value.negative ? "-Infinity" : "Infinity";
+        case "negative-zero":
+          return "-0";
+      }
+    case "bigint":
+      return `${value.value}n`;
+    case "null":
+      return "null";
+    case "undefined":
+      return "undefined";
+    case "array":
+      return `[${value.items.map(renderValue).join(", ")}]`;
+    case "object":
+      return `{ ${value.entries
+        .map(([key, item]) => `${JSON.stringify(key)}: ${renderValue(item)}`)
+        .join(", ")} }`;
+  }
+};

--- a/packages/fuzz/cli.ts
+++ b/packages/fuzz/cli.ts
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync } from "node:fs";
+import { isAbsolute, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  artifactFor,
+  renderCase,
+  renderCoverage,
+  runCase,
+  shrinkFailure,
+  writeFailureArtifact,
+} from "./engine";
+import { generateCases } from "./generate";
+import { Coverage, type SuryApi } from "./schema";
+import { CASE_VERSION, type CompilerCase, type FailureArtifact } from "./types";
+
+type Command =
+  | { kind: "check" }
+  | { kind: "replay"; file: string }
+  | { kind: "help" };
+
+const CAMPAIGN_SEEDS = [1, 0x5eed, 0x51a7, 0x5a17c0de] as const;
+const CASES_PER_SEED = 2_000;
+const MAX_SCHEMA_DEPTH = 4;
+const ASYNC_TIMEOUT_MS = 1_000;
+const MAX_SHRINK_ATTEMPTS = 250;
+const MAX_TIMEOUT_SHRINK_ATTEMPTS = 20;
+
+const fuzzDirectory = fileURLToPath(new URL(".", import.meta.url));
+const repositoryDirectory = resolve(fuzzDirectory, "../..");
+const artifactDirectory = resolve(fuzzDirectory, "artifacts");
+
+const usage = `Sury schema compiler fuzzer
+
+Usage:
+  pnpm fuzz
+  pnpm fuzz -- replay <artifact.json>
+
+The campaign is intentionally zero-configuration. It always runs the checked-in,
+deterministic reliability profile with canonical witnesses and failure shrinking.
+PPX is deliberately outside this engine's scope.`;
+
+const parseCommand = (args: string[]): Command => {
+  const values = args.filter((argument) => argument !== "--");
+  if (values.length === 0 || (values.length === 1 && values[0] === "check")) {
+    return { kind: "check" };
+  }
+  if (values.length === 1 && ["help", "--help", "-h"].includes(values[0]!)) {
+    return { kind: "help" };
+  }
+  if (values.length === 2 && values[0] === "replay") {
+    return { kind: "replay", file: values[1]! };
+  }
+  throw new Error("The fuzz campaign does not accept configuration. Run `pnpm fuzz`.");
+};
+
+const loadSury = async (): Promise<SuryApi> => (await import("sury")) as SuryApi;
+
+const validateCase = (value: unknown): CompilerCase => {
+  if (!value || typeof value !== "object") throw new Error("Invalid replay file");
+  const candidate = value as Partial<CompilerCase>;
+  if (
+    candidate.version !== CASE_VERSION ||
+    typeof candidate.id !== "string" ||
+    typeof candidate.operation !== "string" ||
+    !Array.isArray(candidate.schemas) ||
+    typeof candidate.runWitness !== "boolean"
+  ) {
+    throw new Error(`Replay case must use case version ${CASE_VERSION}`);
+  }
+  return candidate as CompilerCase;
+};
+
+const readReplay = (path: string): { testCase: CompilerCase; expectedSignature?: string } => {
+  const fromWorkingDirectory = resolve(path);
+  const resolvedPath =
+    isAbsolute(path) || existsSync(fromWorkingDirectory)
+      ? fromWorkingDirectory
+      : resolve(repositoryDirectory, path);
+  const value = JSON.parse(readFileSync(resolvedPath, "utf8")) as unknown;
+  if (value && typeof value === "object" && "artifactVersion" in value) {
+    const artifact = value as FailureArtifact;
+    return {
+      testCase: validateCase(artifact.minimized),
+      expectedSignature: artifact.failure?.signature,
+    };
+  }
+  return { testCase: validateCase(value) };
+};
+
+const check = async (S: SuryApi): Promise<number> => {
+  const coverage = new Coverage();
+  const counts = { compiled: 0, expectedError: 0 };
+  const totalCases = CAMPAIGN_SEEDS.length * CASES_PER_SEED;
+  let completedCases = 0;
+
+  for (const seed of CAMPAIGN_SEEDS) {
+    const cases = generateCases(seed, CASES_PER_SEED, MAX_SCHEMA_DEPTH);
+    for (const testCase of cases) {
+      completedCases++;
+      const result = await runCase(testCase, S, coverage, ASYNC_TIMEOUT_MS);
+      if (result.status === "compiled") {
+        counts.compiled++;
+        continue;
+      }
+      if (result.status === "expected-error") {
+        counts.expectedError++;
+        continue;
+      }
+
+      const maxShrinkAttempts =
+        result.failure.phase === "timeout"
+          ? MAX_TIMEOUT_SHRINK_ATTEMPTS
+          : MAX_SHRINK_ATTEMPTS;
+      const minimized = await shrinkFailure(
+        testCase,
+        result.failure.signature,
+        S,
+        ASYNC_TIMEOUT_MS,
+        maxShrinkAttempts,
+      );
+      const minimizedResult = await runCase(
+        minimized,
+        S,
+        new Coverage(),
+        ASYNC_TIMEOUT_MS,
+      );
+      const finalFailure =
+        minimizedResult.status === "bug" ? minimizedResult.failure : result.failure;
+      const artifact = artifactFor(seed, testCase, minimized, finalFailure);
+      const artifactPath = writeFailureArtifact(artifactDirectory, artifact);
+      console.error(
+        `BUG after ${completedCases}/${totalCases} cases: ${finalFailure.signature}`,
+      );
+      console.error(finalFailure.message);
+      console.error(`Original:  ${renderCase(testCase)}`);
+      console.error(`Minimized: ${renderCase(minimized)}`);
+      console.error(`Replay: pnpm fuzz -- replay ${artifactPath}`);
+      console.log(`\n${renderCoverage(coverage)}`);
+      return 1;
+    }
+  }
+
+  console.log(
+    `OK: ${totalCases} cases across ${CAMPAIGN_SEEDS.length} deterministic seeds ` +
+      `(compiled ${counts.compiled}, controlled errors ${counts.expectedError})`,
+  );
+  console.log(`\n${renderCoverage(coverage)}`);
+  return 0;
+};
+
+const replay = async (file: string, S: SuryApi): Promise<number> => {
+  const replayValue = readReplay(file);
+  const result = await runCase(
+    replayValue.testCase,
+    S,
+    new Coverage(),
+    ASYNC_TIMEOUT_MS,
+  );
+  console.log(renderCase(replayValue.testCase));
+  if (result.status === "bug") {
+    const matches =
+      replayValue.expectedSignature === undefined ||
+      replayValue.expectedSignature === result.failure.signature;
+    console.log(`${matches ? "REPRODUCED" : "CHANGED"}: ${result.failure.signature}`);
+    console.log(result.failure.message);
+    return matches ? 1 : 2;
+  }
+  console.log(`NOT REPRODUCED: ${result.status}`);
+  return 2;
+};
+
+const main = async (): Promise<void> => {
+  const command = parseCommand(process.argv.slice(2));
+  if (command.kind === "help") {
+    console.log(usage);
+    return;
+  }
+  const S = await loadSury();
+  process.exitCode =
+    command.kind === "replay" ? await replay(command.file, S) : await check(S);
+};
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 2;
+});

--- a/packages/fuzz/engine.ts
+++ b/packages/fuzz/engine.ts
@@ -1,0 +1,396 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  COMPILER_API_NAMES,
+  Coverage,
+  NO_WITNESS,
+  compileSchema,
+  renderSchema,
+  schemaCategory,
+  schemaWitness,
+  type SuryApi,
+} from "./schema";
+import {
+  CASE_VERSION,
+  type CaseResult,
+  type CompilerCase,
+  type Failure,
+  type FailureArtifact,
+  type OperationKind,
+  type SchemaAst,
+} from "./types";
+
+const ASYNC_OPERATIONS = new Set<OperationKind>([
+  "asyncParser",
+  "asyncDecoder",
+  "asyncEncoder",
+]);
+
+const isSuryError = (error: unknown, S: SuryApi): boolean =>
+  !!error &&
+  ((typeof S.Error === "function" && error instanceof S.Error) ||
+    (error as { name?: unknown }).name === "SuryError");
+
+const isControlledError = (error: unknown, S: SuryApi): boolean =>
+  isSuryError(error, S) ||
+  (error instanceof Error && error.message.startsWith("[Sury]"));
+
+const errorInfo = (error: unknown): { name: string; message: string } => {
+  if (error && typeof error === "object") {
+    const value = error as { name?: unknown; message?: unknown; constructor?: { name?: unknown } };
+    return {
+      name:
+        typeof value.name === "string"
+          ? value.name
+          : typeof value.constructor?.name === "string"
+            ? value.constructor.name
+            : "Error",
+      message: typeof value.message === "string" ? value.message : String(error),
+    };
+  }
+  return { name: typeof error, message: String(error) };
+};
+
+const failure = (
+  phase: Failure["phase"],
+  error: unknown,
+  overrideName?: string,
+): Failure => {
+  const info = errorInfo(error);
+  const name = overrideName ?? info.name;
+  return {
+    phase,
+    name,
+    message: info.message,
+    signature: `${phase}:${name}`,
+  };
+};
+
+const operationFactory = (
+  kind: OperationKind,
+  schemas: unknown[],
+  S: SuryApi,
+): unknown => {
+  const operation = S[kind];
+  if (typeof operation !== "function") throw new Error(`Missing public Sury API S.${kind}`);
+  return operation(...schemas);
+};
+
+const withTimeout = async <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+};
+
+const witnessFor = (testCase: CompilerCase): unknown => {
+  const first = testCase.schemas[0]!;
+  return schemaWitness(
+    first,
+    testCase.operation === "encoder" || testCase.operation === "asyncEncoder"
+      ? "output"
+      : "input",
+  );
+};
+
+const recordCombination = (testCase: CompilerCase, coverage: Coverage): void => {
+  const first = testCase.schemas[0]!;
+  const last = testCase.schemas[testCase.schemas.length - 1]!;
+  const encode = testCase.operation === "encoder" || testCase.operation === "asyncEncoder";
+  const from = schemaCategory(first, encode ? "output" : "input");
+  const to = schemaCategory(last, encode ? "input" : "output");
+  coverage.hit(
+    coverage.combinations,
+    `${testCase.operation}:${testCase.schemas.length}:${from}->${to}`,
+  );
+};
+
+export const runCase = async (
+  testCase: CompilerCase,
+  S: SuryApi,
+  coverage: Coverage,
+  timeoutMs: number,
+): Promise<CaseResult> => {
+  coverage.hit(coverage.operations, `${testCase.operation}:${testCase.schemas.length}`);
+  recordCombination(testCase, coverage);
+
+  let schemas: unknown[];
+  try {
+    schemas = testCase.schemas.map((schema) => compileSchema(schema, S, coverage));
+  } catch (error) {
+    if (isControlledError(error, S)) {
+      const info = errorInfo(error);
+      coverage.hit(coverage.outcomes, "expected-error:schema");
+      return { status: "expected-error", ...info };
+    }
+    coverage.hit(coverage.outcomes, "bug:schema");
+    return { status: "bug", failure: failure("schema", error) };
+  }
+
+  let operation: unknown;
+  let cacheHit = false;
+  try {
+    operation = operationFactory(testCase.operation, schemas, S);
+    const second = operationFactory(testCase.operation, schemas, S);
+    cacheHit = operation === second;
+  } catch (error) {
+    if (isControlledError(error, S)) {
+      const info = errorInfo(error);
+      coverage.hit(coverage.outcomes, "expected-error:compile");
+      return { status: "expected-error", ...info };
+    }
+    coverage.hit(coverage.outcomes, "bug:compile");
+    return { status: "bug", failure: failure("compile", error) };
+  }
+
+  if (typeof operation !== "function") {
+    const result = failure("compile", `S.${testCase.operation} returned ${typeof operation}`, "NonFunction");
+    coverage.hit(coverage.outcomes, "bug:compile");
+    return { status: "bug", failure: result };
+  }
+
+  const callable = operation as (input: unknown) => unknown;
+
+  try {
+    const source = Function.prototype.toString.call(callable);
+    new Function(`return (${source})`);
+  } catch (error) {
+    coverage.hit(coverage.outcomes, "bug:source");
+    return { status: "bug", failure: failure("source", error) };
+  }
+
+  if (!testCase.runWitness) {
+    coverage.hit(coverage.outcomes, "compiled:skipped");
+    return { status: "compiled", cacheHit, witness: "skipped" };
+  }
+
+  const witness = witnessFor(testCase);
+  if (witness === NO_WITNESS) {
+    coverage.hit(coverage.outcomes, "compiled:skipped");
+    return { status: "compiled", cacheHit, witness: "skipped" };
+  }
+
+  try {
+    const output = callable(witness);
+    if (ASYNC_OPERATIONS.has(testCase.operation)) {
+      if (!output || typeof (output as { then?: unknown }).then !== "function") {
+        const result = failure(
+          "runtime",
+          `S.${testCase.operation} returned a non-Promise`,
+          "NonPromise",
+        );
+        coverage.hit(coverage.outcomes, "bug:runtime");
+        return { status: "bug", failure: result };
+      }
+      await withTimeout(Promise.resolve(output), timeoutMs);
+    } else if (output && typeof (output as { then?: unknown }).then === "function") {
+      const result = failure(
+        "runtime",
+        `S.${testCase.operation} unexpectedly returned a Promise`,
+        "UnexpectedPromise",
+      );
+      coverage.hit(coverage.outcomes, "bug:runtime");
+      return { status: "bug", failure: result };
+    }
+  } catch (error) {
+    if (isControlledError(error, S)) {
+      coverage.hit(coverage.outcomes, "compiled:sury-error");
+      return { status: "compiled", cacheHit, witness: "sury-error" };
+    }
+    const info = errorInfo(error);
+    const timedOut = info.message.startsWith("Timed out after ");
+    coverage.hit(coverage.outcomes, timedOut ? "bug:timeout" : "bug:runtime");
+    return {
+      status: "bug",
+      failure: failure(timedOut ? "timeout" : "runtime", error),
+    };
+  }
+
+  coverage.hit(coverage.outcomes, "compiled:passed");
+  return { status: "compiled", cacheHit, witness: "passed" };
+};
+
+const schemaShrinks = (schema: SchemaAst): SchemaAst[] => {
+  const simplest: SchemaAst[] = [
+    { kind: "primitive", name: "string" },
+    { kind: "primitive", name: "unknown" },
+  ];
+  switch (schema.kind) {
+    case "primitive":
+      return schema.name === "string" ? [] : simplest;
+    case "literal":
+    case "enum":
+    case "instance":
+      return simplest;
+    case "array":
+      return [
+        schema.item,
+        ...schemaShrinks(schema.item).map((item): SchemaAst => ({ ...schema, item })),
+      ];
+    case "record":
+      return [
+        schema.value,
+        ...schemaShrinks(schema.value).map((value): SchemaAst => ({ ...schema, value })),
+      ];
+    case "tuple":
+      return [
+        ...simplest,
+        ...(schema.items.length > 1 ? [{ ...schema, items: schema.items.slice(0, 1) } as SchemaAst] : []),
+        ...schema.items.flatMap((item, index) =>
+          schemaShrinks(item).map((next) => ({
+            ...schema,
+            items: schema.items.map((current, itemIndex) => (itemIndex === index ? next : current)),
+          })),
+        ),
+      ];
+    case "object":
+      return [
+        ...simplest,
+        ...(schema.fields.length > 1 ? [{ ...schema, fields: schema.fields.slice(0, 1) } as SchemaAst] : []),
+        ...schema.fields.flatMap(([key, field], index) =>
+          schemaShrinks(field).map((next) => ({
+            ...schema,
+            fields: schema.fields.map((current, fieldIndex) =>
+              fieldIndex === index ? ([key, next] as [string, SchemaAst]) : current,
+            ),
+          })),
+        ),
+      ];
+    case "union":
+      return [
+        ...schema.members,
+        ...(schema.members.length > 2
+          ? [{ ...schema, members: schema.members.slice(0, 2) } as SchemaAst]
+          : []),
+      ];
+    case "optional":
+    case "nullable":
+    case "nullish":
+    case "refine":
+    case "modifier":
+      return [schema.inner, ...schemaShrinks(schema.inner).map((inner) => ({ ...schema, inner }))];
+    case "unary":
+      return [
+        schema.inner,
+        ...schemaShrinks(schema.inner).map((inner): SchemaAst => ({ ...schema, inner })),
+      ];
+    case "merge":
+      return [
+        schema.left,
+        schema.right,
+        ...schemaShrinks(schema.left).map((left): SchemaAst => ({ ...schema, left })),
+        ...schemaShrinks(schema.right).map((right): SchemaAst => ({ ...schema, right })),
+      ];
+    case "to":
+      return [
+        schema.source,
+        schema.target,
+        ...schemaShrinks(schema.source).map((source) => ({ ...schema, source })),
+        ...schemaShrinks(schema.target).map((target) => ({ ...schema, target })),
+        ...(schema.codec.kind === "custom-bidirectional"
+          ? [
+              {
+                ...schema,
+                codec: { kind: "custom-decoder" as const, decoder: schema.codec.decoder },
+              },
+            ]
+          : []),
+      ];
+    case "recursive":
+      return [schema.leaf, ...schemaShrinks(schema.leaf).map((leaf) => ({ ...schema, leaf }))];
+  }
+};
+
+const caseShrinks = (testCase: CompilerCase): CompilerCase[] => {
+  const cases: CompilerCase[] = [];
+  if (testCase.schemas.length > 1) {
+    cases.push({ ...testCase, schemas: [testCase.schemas[0]!] });
+    cases.push({ ...testCase, schemas: testCase.schemas.slice(0, -1) });
+  }
+  for (let index = 0; index < testCase.schemas.length; index++) {
+    for (const schema of schemaShrinks(testCase.schemas[index]!)) {
+      cases.push({
+        ...testCase,
+        schemas: testCase.schemas.map((current, schemaIndex) =>
+          schemaIndex === index ? schema : current,
+        ),
+      });
+    }
+  }
+  return cases;
+};
+
+export const shrinkFailure = async (
+  original: CompilerCase,
+  targetSignature: string,
+  S: SuryApi,
+  timeoutMs: number,
+  maxAttempts = 250,
+): Promise<CompilerCase> => {
+  let current = original;
+  let attempts = 0;
+  let changed = true;
+  while (changed && attempts < maxAttempts) {
+    changed = false;
+    for (const candidate of caseShrinks(current)) {
+      if (attempts++ >= maxAttempts) break;
+      const result = await runCase(candidate, S, new Coverage(), timeoutMs);
+      if (result.status === "bug" && result.failure.signature === targetSignature) {
+        current = candidate;
+        changed = true;
+        break;
+      }
+    }
+  }
+  return current;
+};
+
+export const writeFailureArtifact = (
+  directory: string,
+  artifact: FailureArtifact,
+): string => {
+  mkdirSync(directory, { recursive: true });
+  const safeId = artifact.minimized.id.replace(/[^a-zA-Z0-9_.-]+/g, "-");
+  const path = join(directory, `${safeId}-${artifact.failure.signature.replace(":", "-")}.json`);
+  writeFileSync(path, `${JSON.stringify(artifact, null, 2)}\n`);
+  return path;
+};
+
+const printMap = (title: string, map: Map<string, number>): string[] => {
+  const lines = [`${title}:`];
+  for (const [key, count] of [...map].sort(([left], [right]) => left.localeCompare(right))) {
+    lines.push(`  ${key.padEnd(48)} ${count}`);
+  }
+  return lines;
+};
+
+export const renderCoverage = (coverage: Coverage): string =>
+  [
+    `missing compiler APIs: ${COMPILER_API_NAMES.filter((name) => !coverage.api.has(name)).join(", ") || "none"}`,
+    ...printMap("operations", coverage.operations),
+    ...printMap("outcomes", coverage.outcomes),
+    ...printMap("api", coverage.api),
+    ...printMap("combinations", coverage.combinations),
+  ].join("\n");
+
+export const renderCase = (testCase: CompilerCase): string =>
+  `S.${testCase.operation}(${testCase.schemas.map(renderSchema).join(", ")})`;
+
+export const artifactFor = (
+  seed: number | undefined,
+  original: CompilerCase,
+  minimized: CompilerCase,
+  failureValue: Failure,
+): FailureArtifact => ({
+  artifactVersion: 1,
+  createdAt: new Date().toISOString(),
+  seed,
+  original,
+  minimized: { ...minimized, version: CASE_VERSION },
+  failure: failureValue,
+});

--- a/packages/fuzz/engine_test.ts
+++ b/packages/fuzz/engine_test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { compileSchema, Coverage, renderSchema } from "./schema";
+import { baselineCases, generateCases } from "./generate";
+import type { SchemaAst } from "./types";
+
+const generatedCount = baselineCases().length + 20;
+const first = generateCases(42, generatedCount, 3);
+const second = generateCases(42, generatedCount, 3);
+assert.deepEqual(first, second, "the same seed must produce the same compiler cases");
+assert.notDeepEqual(
+  first,
+  generateCases(43, generatedCount, 3),
+  "different seeds should vary the corpus",
+);
+
+const modes = baselineCases()
+  .flatMap((testCase) => testCase.schemas)
+  .filter((schema): schema is Extract<SchemaAst, { kind: "to" }> => schema.kind === "to")
+  .map((schema) => schema.codec.kind);
+assert.ok(modes.includes("builtin"));
+assert.ok(modes.includes("custom-decoder"));
+assert.ok(modes.includes("custom-bidirectional"));
+
+const custom: SchemaAst = {
+  kind: "to",
+  source: { kind: "primitive", name: "string" },
+  target: { kind: "primitive", name: "number" },
+  codec: {
+    kind: "custom-bidirectional",
+    decoder: "to-number",
+    encoder: "to-string",
+  },
+};
+let argumentsSeen: unknown[] | undefined;
+const stub = {
+  string: { name: "string" },
+  number: { name: "number" },
+  to: (...args: unknown[]) => {
+    argumentsSeen = args;
+    return { args };
+  },
+};
+compileSchema(custom, stub, new Coverage());
+assert.equal(argumentsSeen?.length, 4);
+assert.equal((argumentsSeen?.[2] as (value: unknown) => unknown)("12"), 12);
+assert.equal((argumentsSeen?.[3] as (value: unknown) => unknown)(12), "12");
+assert.match(renderSchema(custom), /S\.to\(.+<to-number>, <to-string>\)/);
+
+console.log("fuzz engine tests passed");

--- a/packages/fuzz/generate.ts
+++ b/packages/fuzz/generate.ts
@@ -1,0 +1,565 @@
+import { CODEC_FUNCTION_NAMES } from "./catalog";
+import { Random } from "./random";
+import { schemaCategory } from "./schema";
+import {
+  CASE_VERSION,
+  type CompilerCase,
+  type OperationKind,
+  type PrimitiveName,
+  type SchemaAst,
+  type ValueAst,
+} from "./types";
+
+const PRIMITIVES: readonly PrimitiveName[] = [
+  "string",
+  "any",
+  "boolean",
+  "int32",
+  "number",
+  "nan",
+  "bigint",
+  "symbol",
+  "void",
+  "never",
+  "unknown",
+  "json",
+  "jsonString",
+  "jsonStringWithSpace",
+  "uint8Array",
+  "isoDateTime",
+  "port",
+  "email",
+  "uuid",
+  "cuid",
+  "url",
+  "date",
+];
+
+const OPERATIONS: readonly OperationKind[] = [
+  "parser",
+  "decoder",
+  "encoder",
+  "asyncParser",
+  "asyncDecoder",
+  "asyncEncoder",
+];
+
+const FIELD_NAMES = ["value", "kind", "id", "constructor", 'quoted"key'] as const;
+
+const literalValue = (random: Random): ValueAst =>
+  random.pick<ValueAst>([
+    { kind: "string", value: "fuzz" },
+    { kind: "string", value: "" },
+    { kind: "number", value: { kind: "finite", value: 0 } },
+    { kind: "number", value: { kind: "negative-zero" } },
+    { kind: "number", value: { kind: "nan" } },
+    { kind: "bigint", value: "1" },
+    { kind: "boolean", value: true },
+    { kind: "null" },
+    { kind: "undefined" },
+  ]);
+
+const leaf = (random: Random): SchemaAst =>
+  random.bool(0.75)
+    ? { kind: "primitive", name: random.pick(PRIMITIVES) }
+    : { kind: "literal", value: literalValue(random) };
+
+const genericRefinement = (random: Random, inner: SchemaAst): SchemaAst => ({
+  kind: "refine",
+  refinement: random.pick(["always", "never", "non-empty", "non-negative"] as const),
+  inner,
+});
+
+const refined = (random: Random, inner: SchemaAst): SchemaAst => {
+  const category = schemaCategory(inner, "output");
+  if (category === "string" || category === "array") {
+    const refinement = random.pick([
+      "min-length",
+      "max-length",
+      "length",
+      "empty",
+      "nonEmpty",
+      ...(category === "string" ? (["pattern"] as const) : []),
+    ] as const);
+    return {
+      kind: "refine",
+      refinement,
+      argument:
+        refinement === "empty" || refinement === "nonEmpty" || refinement === "pattern"
+          ? undefined
+          : random.int(0, 4),
+      inner,
+    };
+  }
+  if (category === "number" || category === "bigint") {
+    return {
+      kind: "refine",
+      refinement: random.pick(["gte", "lte", "gt", "lt"] as const),
+      argument: random.int(-2, 2),
+      inner,
+    };
+  }
+  return genericRefinement(random, inner);
+};
+
+const modified = (random: Random, inner: SchemaAst): SchemaAst => {
+  const supportsObjectPolicy = inner.kind === "object" || inner.kind === "record";
+  const modifier =
+    supportsObjectPolicy
+      ? random.pick(["strict", "strip", "deepStrict", "deepStrip", "noValidation", "meta"] as const)
+      : random.pick(["noValidation", "meta"] as const);
+  return { kind: "modifier", modifier, inner };
+};
+
+const transformed = (random: Random, depth: number): SchemaAst => {
+  const source = generateSchema(random, Math.max(0, depth - 1));
+  const target = generateSchema(random, Math.max(0, depth - 1));
+  const mode = random.weighted([
+    { value: "builtin" as const, weight: 4 },
+    { value: "custom-decoder" as const, weight: 3 },
+    { value: "custom-bidirectional" as const, weight: 3 },
+  ]);
+  if (mode === "builtin") return { kind: "to", source, target, codec: { kind: mode } };
+  const decoder = random.pick(CODEC_FUNCTION_NAMES);
+  if (mode === "custom-decoder") {
+    return { kind: "to", source, target, codec: { kind: mode, decoder } };
+  }
+  return {
+    kind: "to",
+    source,
+    target,
+    codec: {
+      kind: mode,
+      decoder,
+      encoder: random.pick(CODEC_FUNCTION_NAMES),
+    },
+  };
+};
+
+const unary = (random: Random, depth: number): SchemaAst => {
+  const api = random.pick([
+    "compactColumns",
+    "list",
+    "trim",
+    "brand",
+    "shape",
+    "asyncDecoderAssert",
+    "reverse",
+  ] as const);
+  const inner =
+    api === "trim"
+      ? ({ kind: "primitive", name: "string" } as const)
+      : api === "compactColumns"
+        ? objectSchema(random, depth, "column")
+        : generateSchema(random, depth - 1);
+  return {
+    kind: "unary",
+    api,
+    inner,
+    ...(api === "shape" ? { codec: random.pick(CODEC_FUNCTION_NAMES) } : {}),
+  };
+};
+
+const objectSchema = (random: Random, depth: number, field: string): SchemaAst => ({
+  kind: "object",
+  factory: random.pick(["schema", "object"] as const),
+  fields: [[field, generateSchema(random, Math.max(0, depth - 1))]],
+});
+
+export const generateSchema = (random: Random, depth: number): SchemaAst => {
+  if (depth <= 0) return leaf(random);
+
+  const kind = random.weighted([
+    { value: "leaf" as const, weight: 20 },
+    { value: "enum" as const, weight: 3 },
+    { value: "instance" as const, weight: 2 },
+    { value: "array" as const, weight: 8 },
+    { value: "tuple" as const, weight: 8 },
+    { value: "record" as const, weight: 6 },
+    { value: "object" as const, weight: 10 },
+    { value: "union" as const, weight: 12 },
+    { value: "optional" as const, weight: 5 },
+    { value: "nullable" as const, weight: 5 },
+    { value: "nullish" as const, weight: 3 },
+    { value: "refine" as const, weight: 7 },
+    { value: "modifier" as const, weight: 6 },
+    { value: "to" as const, weight: 16 },
+    { value: "unary" as const, weight: 8 },
+    { value: "merge" as const, weight: 2 },
+    { value: "recursive" as const, weight: 2 },
+  ]);
+
+  switch (kind) {
+    case "leaf":
+      return leaf(random);
+    case "enum":
+      return {
+        kind,
+        values: Array.from({ length: random.int(1, 3) }, () => literalValue(random)),
+      };
+    case "instance":
+      return { kind };
+    case "array":
+      return { kind, item: generateSchema(random, depth - 1) };
+    case "tuple":
+      return {
+        kind,
+        items: Array.from({ length: random.int(1, 3) }, () =>
+          generateSchema(random, depth - 1),
+        ),
+      };
+    case "record":
+      return { kind, value: generateSchema(random, depth - 1) };
+    case "object": {
+      const names = [...FIELD_NAMES];
+      const fields: [string, SchemaAst][] = [];
+      for (let index = 0; index < random.int(1, 3); index++) {
+        const nameIndex = random.int(0, names.length - 1);
+        const name = names.splice(nameIndex, 1)[0]!;
+        fields.push([name, generateSchema(random, depth - 1)]);
+      }
+      return { kind, factory: random.pick(["schema", "object"] as const), fields };
+    }
+    case "union":
+      return {
+        kind,
+        members: Array.from({ length: random.int(2, 4) }, () =>
+          generateSchema(random, depth - 1),
+        ),
+      };
+    case "optional":
+    case "nullable":
+    case "nullish":
+      return { kind, inner: generateSchema(random, depth - 1) };
+    case "refine":
+      return refined(random, generateSchema(random, depth - 1));
+    case "modifier":
+      return modified(random, generateSchema(random, depth - 1));
+    case "to":
+      return transformed(random, depth);
+    case "unary":
+      return unary(random, depth);
+    case "merge":
+      return {
+        kind,
+        left: objectSchema(random, depth, "left"),
+        right: objectSchema(random, depth, "right"),
+      };
+    case "recursive":
+      return {
+        kind,
+        name: `FuzzRecursive${random.int(0, 0x7fffffff)}`,
+        leaf: leaf(random),
+      };
+  }
+};
+
+const primitiveSchema = (name: PrimitiveName): SchemaAst => ({ kind: "primitive", name });
+
+export const baselineCases = (): CompilerCase[] => {
+  const string = primitiveSchema("string");
+  const number = primitiveSchema("number");
+  const json = primitiveSchema("json");
+  const bigint = primitiveSchema("bigint");
+  const baseline = (
+    id: string,
+    operation: OperationKind,
+    schema: SchemaAst,
+  ): CompilerCase => ({
+    version: CASE_VERSION,
+    id: `baseline:${id}`,
+    operation,
+    schemas: [schema],
+    runWitness: true,
+  });
+  return [
+    {
+      version: CASE_VERSION,
+      id: "baseline:primitive-parser",
+      operation: "parser",
+      schemas: [string],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:builtin-to",
+      operation: "parser",
+      schemas: [{ kind: "to", source: string, target: number, codec: { kind: "builtin" } }],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:custom-decoder",
+      operation: "decoder",
+      schemas: [
+        {
+          kind: "to",
+          source: string,
+          target: number,
+          codec: { kind: "custom-decoder", decoder: "to-number" },
+        },
+      ],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:custom-bidirectional-parser",
+      operation: "parser",
+      schemas: [
+        {
+          kind: "to",
+          source: string,
+          target: number,
+          codec: {
+            kind: "custom-bidirectional",
+            decoder: "to-number",
+            encoder: "to-string",
+          },
+        },
+      ],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:custom-bidirectional-encoder",
+      operation: "encoder",
+      schemas: [
+        {
+          kind: "to",
+          source: string,
+          target: number,
+          codec: {
+            kind: "custom-bidirectional",
+            decoder: "to-number",
+            encoder: "to-string",
+          },
+        },
+      ],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:custom-bidirectional-async-encoder",
+      operation: "asyncEncoder",
+      schemas: [
+        {
+          kind: "to",
+          source: string,
+          target: number,
+          codec: {
+            kind: "custom-bidirectional",
+            decoder: "to-number",
+            encoder: "to-string",
+          },
+        },
+      ],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:union-codec",
+      operation: "decoder",
+      schemas: [
+        { kind: "union", members: [string, number] },
+        { kind: "union", members: [number, string] },
+      ],
+      runWitness: true,
+    },
+    {
+      version: CASE_VERSION,
+      id: "baseline:json-bigint-async",
+      operation: "asyncDecoder",
+      schemas: [json, bigint],
+      runWitness: true,
+    },
+    baseline("any", "parser", primitiveSchema("any")),
+    baseline("nan", "parser", primitiveSchema("nan")),
+    baseline("json-string-space", "parser", primitiveSchema("jsonStringWithSpace")),
+    baseline("enum", "parser", {
+      kind: "enum",
+      values: [
+        { kind: "string", value: "one" },
+        { kind: "number", value: { kind: "finite", value: 2 } },
+      ],
+    }),
+    baseline("instance", "parser", { kind: "instance" }),
+    {
+      version: CASE_VERSION,
+      id: "baseline:compact-columns",
+      operation: "parser",
+      schemas: [
+        { kind: "unary", api: "compactColumns", inner: primitiveSchema("unknown") },
+        {
+          kind: "array",
+          item: { kind: "object", factory: "object", fields: [["value", string]] },
+        },
+      ],
+      runWitness: true,
+    },
+    baseline("list", "parser", { kind: "unary", api: "list", inner: string }),
+    baseline("trim", "parser", { kind: "unary", api: "trim", inner: string }),
+    baseline("brand", "parser", { kind: "unary", api: "brand", inner: string }),
+    baseline("shape", "parser", {
+      kind: "unary",
+      api: "shape",
+      codec: "identity",
+      inner: string,
+    }),
+    baseline("async-assert", "asyncParser", {
+      kind: "unary",
+      api: "asyncDecoderAssert",
+      inner: string,
+    }),
+    baseline("reverse", "parser", {
+      kind: "unary",
+      api: "reverse",
+      inner: {
+        kind: "to",
+        source: string,
+        target: number,
+        codec: {
+          kind: "custom-bidirectional",
+          decoder: "to-number",
+          encoder: "to-string",
+        },
+      },
+    }),
+    baseline("merge", "parser", {
+      kind: "merge",
+      left: { kind: "object", factory: "object", fields: [["left", string]] },
+      right: { kind: "object", factory: "schema", fields: [["right", number]] },
+    }),
+    baseline("string-refinements", "parser", {
+      kind: "refine",
+      refinement: "pattern",
+      inner: {
+        kind: "refine",
+        refinement: "nonEmpty",
+        inner: {
+          kind: "refine",
+          refinement: "length",
+          argument: 4,
+          inner: {
+            kind: "refine",
+            refinement: "max-length",
+            argument: 8,
+            inner: { kind: "refine", refinement: "min-length", argument: 1, inner: string },
+          },
+        },
+      },
+    }),
+    baseline("empty", "parser", { kind: "refine", refinement: "empty", inner: string }),
+    baseline("number-refinements", "parser", {
+      kind: "refine",
+      refinement: "lt",
+      argument: 10,
+      inner: {
+        kind: "refine",
+        refinement: "gt",
+        argument: -10,
+        inner: {
+          kind: "refine",
+          refinement: "lte",
+          argument: 10,
+          inner: { kind: "refine", refinement: "gte", argument: -10, inner: number },
+        },
+      },
+    }),
+    baseline("object-policies", "parser", {
+      kind: "modifier",
+      modifier: "deepStrict",
+      inner: {
+        kind: "modifier",
+        modifier: "strict",
+        inner: { kind: "object", factory: "object", fields: [["value", string]] },
+      },
+    }),
+    baseline("strip-policies", "parser", {
+      kind: "modifier",
+      modifier: "deepStrip",
+      inner: {
+        kind: "modifier",
+        modifier: "strip",
+        inner: { kind: "object", factory: "schema", fields: [["value", string]] },
+      },
+    }),
+    baseline("metadata", "parser", {
+      kind: "modifier",
+      modifier: "noValidation",
+      inner: { kind: "modifier", modifier: "meta", inner: string },
+    }),
+    baseline("primitive-surface", "parser", {
+      kind: "tuple",
+      items: [
+        primitiveSchema("boolean"),
+        primitiveSchema("int32"),
+        primitiveSchema("bigint"),
+        primitiveSchema("symbol"),
+        primitiveSchema("void"),
+        primitiveSchema("never"),
+        primitiveSchema("unknown"),
+        primitiveSchema("jsonString"),
+        primitiveSchema("uint8Array"),
+        primitiveSchema("isoDateTime"),
+        primitiveSchema("port"),
+        primitiveSchema("email"),
+        primitiveSchema("uuid"),
+        primitiveSchema("cuid"),
+        primitiveSchema("url"),
+        primitiveSchema("date"),
+      ],
+    }),
+    baseline("composite-surface", "parser", {
+      kind: "record",
+      value: {
+        kind: "array",
+        item: {
+          kind: "nullish",
+          inner: { kind: "nullable", inner: { kind: "optional", inner: string } },
+        },
+      },
+    }),
+    baseline("literal-refine", "parser", {
+      kind: "refine",
+      refinement: "always",
+      inner: { kind: "literal", value: { kind: "string", value: "fuzz" } },
+    }),
+    baseline("recursive", "parser", {
+      kind: "recursive",
+      name: "FuzzBaseline",
+      leaf: string,
+    }),
+  ];
+};
+
+export const generateCompilerCase = (
+  random: Random,
+  index: number,
+  maxDepth: number,
+): CompilerCase => {
+  const operation = random.pick(OPERATIONS);
+  const schemaCount =
+    operation === "parser" || operation === "asyncParser"
+      ? random.int(1, 3)
+      : random.int(1, 3);
+  return {
+    version: CASE_VERSION,
+    id: `${random.initialSeed}:${index}`,
+    operation,
+    schemas: Array.from({ length: schemaCount }, () => generateSchema(random, maxDepth)),
+    runWitness: true,
+  };
+};
+
+export const generateCases = (
+  seed: number,
+  count: number,
+  maxDepth: number,
+): CompilerCase[] => {
+  const baselines = baselineCases();
+  const random = new Random(seed);
+  const generated = Array.from({ length: Math.max(0, count - baselines.length) }, (_, index) =>
+    generateCompilerCase(random, index, maxDepth),
+  );
+  return [...baselines.slice(0, count), ...generated];
+};

--- a/packages/fuzz/package.json
+++ b/packages/fuzz/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fuzz",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Schema compiler fuzzing for Sury's public decoder and encoder API",
+  "scripts": {
+    "fuzz": "pnpm --filter=sury build:entry && tsx ./cli.ts",
+    "test": "tsx ./engine_test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "sury": "file:../sury"
+  },
+  "devDependencies": {
+    "@types/node": "20.19.41",
+    "tsx": "4.22.4",
+    "typescript": "5.8.3"
+  }
+}

--- a/packages/fuzz/random.ts
+++ b/packages/fuzz/random.ts
@@ -1,0 +1,41 @@
+export class Random {
+  readonly initialSeed: number;
+  #state: number;
+
+  constructor(seed: number) {
+    this.initialSeed = seed | 0;
+    this.#state = this.initialSeed;
+  }
+
+  next(): number {
+    this.#state = (this.#state + 0x6d2b79f5) | 0;
+    let value = this.#state;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  }
+
+  int(min: number, max: number): number {
+    return min + Math.floor(this.next() * (max - min + 1));
+  }
+
+  bool(chance = 0.5): boolean {
+    return this.next() < chance;
+  }
+
+  pick<T>(values: readonly T[]): T {
+    const value = values[Math.floor(this.next() * values.length)];
+    if (value === undefined) throw new Error("Cannot pick from an empty list");
+    return value;
+  }
+
+  weighted<T>(values: readonly { value: T; weight: number }[]): T {
+    const total = values.reduce((sum, item) => sum + item.weight, 0);
+    let cursor = this.next() * total;
+    for (const item of values) {
+      cursor -= item.weight;
+      if (cursor < 0) return item.value;
+    }
+    return values[values.length - 1]!.value;
+  }
+}

--- a/packages/fuzz/schema.ts
+++ b/packages/fuzz/schema.ts
@@ -1,0 +1,478 @@
+import { codecFunction, renderValue, valueFromAst } from "./catalog";
+import type { PrimitiveName, SchemaAst, ValueAst } from "./types";
+
+export type SuryApi = Record<string, any>;
+
+export const COMPILER_API_NAMES = [
+  "string", "any", "boolean", "int32", "number", "nan", "bigint", "symbol", "void",
+  "never", "unknown", "json", "jsonString", "jsonStringWithSpace", "uint8Array",
+  "isoDateTime", "port", "email", "uuid", "cuid", "url", "date", "literal", "enum",
+  "instance", "array", "tuple", "record", "schema", "object", "union", "optional",
+  "nullable", "nullish", "recursive", "strict", "deepStrict", "strip", "deepStrip",
+  "noValidation", "meta", "brand", "refine", "gt", "gte", "lt", "lte", "minLength",
+  "maxLength", "length", "empty", "nonEmpty", "pattern", "trim", "compactColumns",
+  "list", "shape", "asyncDecoderAssert", "reverse", "merge", "to", "to:builtin",
+  "to:custom-decoder", "to:custom-bidirectional",
+] as const;
+
+export class Coverage {
+  readonly api = new Map<string, number>();
+  readonly operations = new Map<string, number>();
+  readonly combinations = new Map<string, number>();
+  readonly outcomes = new Map<string, number>();
+
+  hit(map: Map<string, number>, key: string): void {
+    map.set(key, (map.get(key) ?? 0) + 1);
+  }
+
+  hitApi(key: string): void {
+    this.hit(this.api, key);
+  }
+}
+
+const primitive = (S: SuryApi, name: PrimitiveName): unknown => {
+  if (name === "void") return S.void;
+  if (name === "jsonStringWithSpace") return S.jsonStringWithSpace(2);
+  return S[name];
+};
+
+class FuzzInstance {
+  readonly value = "fuzz";
+}
+
+const refinementPredicate = (
+  name: Extract<SchemaAst, { kind: "refine" }>["refinement"],
+): ((value: unknown) => boolean) => {
+  switch (name) {
+    case "always":
+      return () => true;
+    case "never":
+      return () => false;
+    case "non-empty":
+      return (value) =>
+        (typeof value === "string" || Array.isArray(value)) && value.length > 0;
+    case "non-negative":
+      return (value) =>
+        (typeof value === "number" || typeof value === "bigint") && value >= 0;
+    case "min-length":
+    case "max-length":
+    case "gte":
+    case "lte":
+    case "gt":
+    case "lt":
+    case "length":
+    case "empty":
+    case "nonEmpty":
+    case "pattern":
+      return () => true;
+  }
+};
+
+export const compileSchema = (ast: SchemaAst, S: SuryApi, coverage: Coverage): any => {
+  switch (ast.kind) {
+    case "primitive": {
+      coverage.hitApi(ast.name);
+      const schema = primitive(S, ast.name);
+      if (schema === undefined) throw new Error(`Missing public Sury API S.${ast.name}`);
+      return schema;
+    }
+    case "literal":
+      coverage.hitApi("literal");
+      return S.literal(valueFromAst(ast.value));
+    case "enum":
+      coverage.hitApi("enum");
+      return S.enum(ast.values.map(valueFromAst));
+    case "instance":
+      coverage.hitApi("instance");
+      return S.instance(FuzzInstance);
+    case "array":
+      coverage.hitApi("array");
+      return S.array(compileSchema(ast.item, S, coverage));
+    case "tuple":
+      coverage.hitApi("tuple");
+      return S.tuple(ast.items.map((item) => compileSchema(item, S, coverage)));
+    case "record":
+      coverage.hitApi("record");
+      return S.record(compileSchema(ast.value, S, coverage));
+    case "object": {
+      coverage.hitApi(ast.factory);
+      const definition = Object.fromEntries(
+        ast.fields.map(([key, field]) => [key, compileSchema(field, S, coverage)]),
+      );
+      return S[ast.factory](definition);
+    }
+    case "union":
+      coverage.hitApi("union");
+      return S.union(ast.members.map((member) => compileSchema(member, S, coverage)));
+    case "optional":
+    case "nullable":
+    case "nullish":
+      coverage.hitApi(ast.kind);
+      return S[ast.kind](compileSchema(ast.inner, S, coverage));
+    case "refine": {
+      const schema = compileSchema(ast.inner, S, coverage);
+      switch (ast.refinement) {
+        case "min-length":
+          coverage.hitApi("minLength");
+          return S.minLength(schema, ast.argument ?? 1);
+        case "max-length":
+          coverage.hitApi("maxLength");
+          return S.maxLength(schema, ast.argument ?? 1);
+        case "gte":
+        case "lte":
+        case "gt":
+        case "lt":
+        case "length":
+          coverage.hitApi(ast.refinement);
+          return S[ast.refinement](schema, ast.argument ?? 0);
+        case "empty":
+        case "nonEmpty":
+          coverage.hitApi(ast.refinement);
+          return S[ast.refinement](schema);
+        case "pattern":
+          coverage.hitApi("pattern");
+          return S.pattern(schema, /^fuzz/);
+        default:
+          coverage.hitApi("refine");
+          return S.refine(schema, refinementPredicate(ast.refinement), {
+            error: `fuzz:${ast.refinement}`,
+          });
+      }
+    }
+    case "modifier": {
+      coverage.hitApi(ast.modifier);
+      const schema = compileSchema(ast.inner, S, coverage);
+      if (ast.modifier === "noValidation") return S.noValidation(schema, true);
+      if (ast.modifier === "meta")
+        return S.meta(schema, { description: "compiler fuzz metadata" });
+      return S[ast.modifier](schema);
+    }
+    case "unary": {
+      coverage.hitApi(ast.api);
+      const schema = compileSchema(ast.inner, S, coverage);
+      switch (ast.api) {
+        case "brand":
+          return S.brand(schema, "FuzzBrand");
+        case "shape":
+          return S.shape(schema, codecFunction(ast.codec ?? "identity"));
+        case "asyncDecoderAssert":
+          return S.asyncDecoderAssert(schema, async () => undefined);
+        default:
+          return S[ast.api](schema);
+      }
+    }
+    case "merge":
+      coverage.hitApi("merge");
+      return S.merge(
+        compileSchema(ast.left, S, coverage),
+        compileSchema(ast.right, S, coverage),
+      );
+    case "to": {
+      coverage.hitApi("to");
+      const source = compileSchema(ast.source, S, coverage);
+      const target = compileSchema(ast.target, S, coverage);
+      switch (ast.codec.kind) {
+        case "builtin":
+          coverage.hitApi("to:builtin");
+          return S.to(source, target);
+        case "custom-decoder":
+          coverage.hitApi("to:custom-decoder");
+          return S.to(source, target, codecFunction(ast.codec.decoder));
+        case "custom-bidirectional":
+          coverage.hitApi("to:custom-bidirectional");
+          return S.to(
+            source,
+            target,
+            codecFunction(ast.codec.decoder),
+            codecFunction(ast.codec.encoder),
+          );
+      }
+    }
+    case "recursive":
+      coverage.hitApi("recursive");
+      return S.recursive(ast.name, (self: unknown) =>
+        S.union([compileSchema(ast.leaf, S, coverage), S.array(self)]),
+      );
+  }
+};
+
+export type SchemaCategory =
+  | "string"
+  | "number"
+  | "bigint"
+  | "boolean"
+  | "symbol"
+  | "undefined"
+  | "object"
+  | "array"
+  | "date"
+  | "unknown"
+  | "never"
+  | "union";
+
+const primitiveCategory = (name: PrimitiveName): SchemaCategory => {
+  switch (name) {
+    case "string":
+    case "jsonString":
+    case "jsonStringWithSpace":
+    case "isoDateTime":
+    case "email":
+    case "uuid":
+    case "cuid":
+    case "url":
+      return "string";
+    case "number":
+    case "int32":
+    case "port":
+    case "nan":
+      return "number";
+    case "bigint":
+      return "bigint";
+    case "boolean":
+      return "boolean";
+    case "symbol":
+      return "symbol";
+    case "void":
+      return "undefined";
+    case "date":
+      return "date";
+    case "uint8Array":
+      return "object";
+    case "json":
+    case "unknown":
+    case "any":
+      return "unknown";
+    case "never":
+      return "never";
+  }
+};
+
+export const schemaCategory = (
+  ast: SchemaAst,
+  side: "input" | "output",
+): SchemaCategory => {
+  switch (ast.kind) {
+    case "primitive":
+      return primitiveCategory(ast.name);
+    case "literal":
+      switch (ast.value.kind) {
+        case "string":
+          return "string";
+        case "number":
+          return "number";
+        case "bigint":
+          return "bigint";
+        case "boolean":
+          return "boolean";
+        case "undefined":
+          return "undefined";
+        case "array":
+          return "array";
+        case "object":
+        case "null":
+          return "object";
+      }
+    case "enum":
+      return "union";
+    case "instance":
+      return "object";
+    case "array":
+    case "tuple":
+      return "array";
+    case "record":
+    case "object":
+      return "object";
+    case "union":
+    case "optional":
+    case "nullable":
+    case "nullish":
+    case "recursive":
+      return "union";
+    case "refine":
+    case "modifier":
+      return schemaCategory(ast.inner, side);
+    case "unary":
+      if (ast.api === "reverse") {
+        return schemaCategory(ast.inner, side === "input" ? "output" : "input");
+      }
+      if (ast.api === "compactColumns") return "array";
+      if (ast.api === "list") return side === "input" ? "array" : "object";
+      if (ast.api === "shape" && side === "output") return "unknown";
+      return schemaCategory(ast.inner, side);
+    case "merge":
+      return "object";
+    case "to":
+      return schemaCategory(side === "input" ? ast.source : ast.target, side);
+  }
+};
+
+const literalWitness = (value: ValueAst): unknown => valueFromAst(value);
+
+const primitiveWitness = (name: PrimitiveName): unknown => {
+  switch (name) {
+    case "string":
+      return "fuzz";
+    case "any":
+      return null;
+    case "boolean":
+      return true;
+    case "number":
+    case "int32":
+      return 1;
+    case "port":
+      return 80;
+    case "nan":
+      return NaN;
+    case "bigint":
+      return 1n;
+    case "symbol":
+      return Symbol.for("sury-fuzz");
+    case "void":
+      return undefined;
+    case "never":
+      return NO_WITNESS;
+    case "unknown":
+    case "json":
+      return null;
+    case "jsonString":
+    case "jsonStringWithSpace":
+      return "null";
+    case "uint8Array":
+      return new Uint8Array();
+    case "isoDateTime":
+      return "2024-01-01T00:00:00.000Z";
+    case "email":
+      return "fuzz@example.com";
+    case "uuid":
+      return "00000000-0000-4000-8000-000000000000";
+    case "cuid":
+      return "clh7q8x9y0000qzrmn831i7rn";
+    case "url":
+      return "https://example.com";
+    case "date":
+      return new Date(0);
+  }
+};
+
+export const NO_WITNESS = Symbol("no-witness");
+
+export const schemaWitness = (ast: SchemaAst, side: "input" | "output"): unknown => {
+  switch (ast.kind) {
+    case "primitive":
+      return primitiveWitness(ast.name);
+    case "literal":
+      return literalWitness(ast.value);
+    case "enum":
+      return ast.values.length ? literalWitness(ast.values[0]!) : NO_WITNESS;
+    case "instance":
+      return new FuzzInstance();
+    case "array":
+    case "record":
+      return ast.kind === "array" ? [] : {};
+    case "tuple": {
+      const values = ast.items.map((item) => schemaWitness(item, side));
+      return values.some((value) => value === NO_WITNESS) ? NO_WITNESS : values;
+    }
+    case "object": {
+      const values = ast.fields.map(([key, field]) => [key, schemaWitness(field, side)] as const);
+      if (values.some(([, value]) => value === NO_WITNESS)) return NO_WITNESS;
+      return Object.fromEntries(values);
+    }
+    case "union":
+      for (const member of ast.members) {
+        const value = schemaWitness(member, side);
+        if (value !== NO_WITNESS) return value;
+      }
+      return NO_WITNESS;
+    case "optional":
+    case "nullable":
+    case "nullish":
+    case "refine":
+    case "modifier":
+      return schemaWitness(ast.inner, side);
+    case "unary":
+      if (ast.api === "reverse") {
+        return schemaWitness(ast.inner, side === "input" ? "output" : "input");
+      }
+      if (ast.api === "compactColumns") return [];
+      if (ast.api === "list") return side === "input" ? [] : 0;
+      if (ast.api === "shape" && side === "output") return NO_WITNESS;
+      return schemaWitness(ast.inner, side);
+    case "merge": {
+      const left = schemaWitness(ast.left, side);
+      const right = schemaWitness(ast.right, side);
+      return left && right && typeof left === "object" && typeof right === "object"
+        ? { ...left, ...right }
+        : NO_WITNESS;
+    }
+    case "to":
+      return schemaWitness(side === "input" ? ast.source : ast.target, side);
+    case "recursive":
+      return schemaWitness(ast.leaf, side);
+  }
+};
+
+export const renderSchema = (ast: SchemaAst): string => {
+  switch (ast.kind) {
+    case "primitive":
+      return `S.${ast.name}`;
+    case "literal":
+      return `S.literal(${renderValue(ast.value)})`;
+    case "enum":
+      return `S.enum([${ast.values.map(renderValue).join(", ")}])`;
+    case "instance":
+      return "S.instance(FuzzInstance)";
+    case "array":
+      return `S.array(${renderSchema(ast.item)})`;
+    case "tuple":
+      return `S.tuple([${ast.items.map(renderSchema).join(", ")}])`;
+    case "record":
+      return `S.record(${renderSchema(ast.value)})`;
+    case "object":
+      return `S.${ast.factory}({${ast.fields
+        .map(([key, field]) => `${JSON.stringify(key)}: ${renderSchema(field)}`)
+        .join(", ")}})`;
+    case "union":
+      return `S.union([${ast.members.map(renderSchema).join(", ")}])`;
+    case "optional":
+    case "nullable":
+    case "nullish":
+      return `S.${ast.kind}(${renderSchema(ast.inner)})`;
+    case "refine":
+      return ast.refinement === "min-length"
+        ? `S.minLength(${renderSchema(ast.inner)}, ${ast.argument})`
+        : ast.refinement === "max-length"
+          ? `S.maxLength(${renderSchema(ast.inner)}, ${ast.argument})`
+          : ["gte", "lte", "gt", "lt", "length"].includes(ast.refinement)
+            ? `S.${ast.refinement}(${renderSchema(ast.inner)}, ${ast.argument})`
+            : ast.refinement === "empty" || ast.refinement === "nonEmpty"
+              ? `S.${ast.refinement}(${renderSchema(ast.inner)})`
+              : ast.refinement === "pattern"
+                ? `S.pattern(${renderSchema(ast.inner)}, /^fuzz/)`
+                : `S.refine(${renderSchema(ast.inner)}, <${ast.refinement}>)`;
+    case "modifier":
+      return ast.modifier === "noValidation"
+        ? `S.noValidation(${renderSchema(ast.inner)}, true)`
+        : ast.modifier === "meta"
+          ? `S.meta(${renderSchema(ast.inner)}, {description: "compiler fuzz metadata"})`
+          : `S.${ast.modifier}(${renderSchema(ast.inner)})`;
+    case "unary":
+      return ast.api === "brand"
+        ? `S.brand(${renderSchema(ast.inner)}, "FuzzBrand")`
+        : ast.api === "shape"
+          ? `S.shape(${renderSchema(ast.inner)}, <${ast.codec ?? "identity"}>)`
+          : ast.api === "asyncDecoderAssert"
+            ? `S.asyncDecoderAssert(${renderSchema(ast.inner)}, <async-assert>)`
+            : `S.${ast.api}(${renderSchema(ast.inner)})`;
+    case "merge":
+      return `S.merge(${renderSchema(ast.left)}, ${renderSchema(ast.right)})`;
+    case "to":
+      return ast.codec.kind === "builtin"
+        ? `S.to(${renderSchema(ast.source)}, ${renderSchema(ast.target)})`
+        : ast.codec.kind === "custom-decoder"
+          ? `S.to(${renderSchema(ast.source)}, ${renderSchema(ast.target)}, <${ast.codec.decoder}>)`
+          : `S.to(${renderSchema(ast.source)}, ${renderSchema(ast.target)}, <${ast.codec.decoder}>, <${ast.codec.encoder}>)`;
+    case "recursive":
+      return `S.recursive(${JSON.stringify(ast.name)}, self => S.union([${renderSchema(ast.leaf)}, S.array(self)]))`;
+  }
+};

--- a/packages/fuzz/tsconfig.json
+++ b/packages/fuzz/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
+  "include": ["*.ts"]
+}

--- a/packages/fuzz/types.ts
+++ b/packages/fuzz/types.ts
@@ -1,0 +1,162 @@
+export const CASE_VERSION = 1;
+
+export type PrimitiveName =
+  | "string"
+  | "any"
+  | "boolean"
+  | "int32"
+  | "number"
+  | "nan"
+  | "bigint"
+  | "symbol"
+  | "void"
+  | "never"
+  | "unknown"
+  | "json"
+  | "jsonString"
+  | "jsonStringWithSpace"
+  | "uint8Array"
+  | "isoDateTime"
+  | "port"
+  | "email"
+  | "uuid"
+  | "cuid"
+  | "url"
+  | "date";
+
+export type NumberValue =
+  | { kind: "finite"; value: number }
+  | { kind: "nan" }
+  | { kind: "infinity"; negative: boolean }
+  | { kind: "negative-zero" };
+
+export type ValueAst =
+  | { kind: "string"; value: string }
+  | { kind: "number"; value: NumberValue }
+  | { kind: "bigint"; value: string }
+  | { kind: "boolean"; value: boolean }
+  | { kind: "null" }
+  | { kind: "undefined" }
+  | { kind: "array"; items: ValueAst[] }
+  | { kind: "object"; entries: [string, ValueAst][] };
+
+export type CodecFunctionName =
+  | "identity"
+  | "to-string"
+  | "to-number"
+  | "to-boolean"
+  | "length"
+  | "first"
+  | "wrap-array"
+  | "constant-string"
+  | "constant-number"
+  | "constant-boolean"
+  | "constant-null"
+  | "constant-undefined"
+  | "empty-array"
+  | "empty-object";
+
+export type ToCodec =
+  | { kind: "builtin" }
+  | { kind: "custom-decoder"; decoder: CodecFunctionName }
+  | {
+      kind: "custom-bidirectional";
+      decoder: CodecFunctionName;
+      encoder: CodecFunctionName;
+    };
+
+export type SchemaAst =
+  | { kind: "primitive"; name: PrimitiveName }
+  | { kind: "literal"; value: ValueAst }
+  | { kind: "enum"; values: ValueAst[] }
+  | { kind: "instance" }
+  | { kind: "array"; item: SchemaAst }
+  | { kind: "tuple"; items: SchemaAst[] }
+  | { kind: "record"; value: SchemaAst }
+  | {
+      kind: "object";
+      factory: "schema" | "object";
+      fields: [string, SchemaAst][];
+    }
+  | { kind: "union"; members: SchemaAst[] }
+  | { kind: "optional" | "nullable" | "nullish"; inner: SchemaAst }
+  | {
+      kind: "refine";
+      refinement:
+        | "always"
+        | "never"
+        | "non-empty"
+        | "non-negative"
+        | "min-length"
+        | "max-length"
+        | "gte"
+        | "lte"
+        | "gt"
+        | "lt"
+        | "length"
+        | "empty"
+        | "nonEmpty"
+        | "pattern";
+      argument?: number;
+      inner: SchemaAst;
+    }
+  | {
+      kind: "modifier";
+      modifier: "strict" | "strip" | "deepStrict" | "deepStrip" | "noValidation" | "meta";
+      inner: SchemaAst;
+    }
+  | {
+      kind: "unary";
+      api:
+        | "compactColumns"
+        | "list"
+        | "trim"
+        | "brand"
+        | "shape"
+        | "asyncDecoderAssert"
+        | "reverse";
+      inner: SchemaAst;
+      codec?: CodecFunctionName;
+    }
+  | { kind: "merge"; left: SchemaAst; right: SchemaAst }
+  | { kind: "to"; source: SchemaAst; target: SchemaAst; codec: ToCodec }
+  | { kind: "recursive"; name: string; leaf: SchemaAst };
+
+export type OperationKind =
+  | "parser"
+  | "decoder"
+  | "encoder"
+  | "asyncParser"
+  | "asyncDecoder"
+  | "asyncEncoder";
+
+export type CompilerCase = {
+  version: typeof CASE_VERSION;
+  id: string;
+  operation: OperationKind;
+  schemas: SchemaAst[];
+  runWitness: boolean;
+};
+
+export type FailurePhase = "schema" | "compile" | "source" | "runtime" | "timeout";
+
+export type Failure = {
+  phase: FailurePhase;
+  name: string;
+  message: string;
+  signature: string;
+};
+
+export type CaseResult =
+  | { status: "compiled"; cacheHit: boolean; witness: "passed" | "sury-error" | "skipped" }
+  | { status: "expected-error"; name: string; message: string }
+  | { status: "bug"; failure: Failure };
+
+export type FailureArtifact = {
+  artifactVersion: 1;
+  createdAt: string;
+  seed?: number;
+  original: CompilerCase;
+  minimized: CompilerCase;
+  failure: Failure;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,22 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
 
+  packages/fuzz:
+    dependencies:
+      sury:
+        specifier: file:../sury
+        version: link:../sury
+    devDependencies:
+      '@types/node':
+        specifier: 20.19.41
+        version: 20.19.41
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
+      typescript:
+        specifier: 5.8.3
+        version: 5.8.3
+
   packages/json-schema-test-suite:
     dependencies:
       sury:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a deterministic schema compiler fuzzing tool for exploring decoder and encoder behavior.
  - Added seeded test-case generation, replay support, failure minimization, timeout handling, and coverage reporting.
  - Added commands for running fuzz campaigns and replaying individual cases or saved failures.
  - Added support for generating and testing a broad range of schema and codec combinations.

- **Documentation**
  - Added usage guidance, supported scenarios, exclusions, reproducibility details, and failure-replay instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->