### PR TITLE
Reorder benchmark columns to highlight Sury performance

### DIFF
--- a/packages/sury/README.md
+++ b/packages/sury/README.md
@@ -162,11 +162,11 @@ JSON.stringify({ price: Infinity });
 // => '{"price":null}'
 ```
 
-| Encode to JSON string                        | `JSON.stringify` | fast-json-stringify | **Sury**    |
-| -------------------------------------------- | ---------------- | ------------------- | ----------- |
-| API response (user profile, 7 fields)        | 396 ns           | 301 ns              | **250 ns**  |
-| Event feed (50 tagged-union events)          | 4.61 µs          | 13.52 µs            | **3.67 µs** |
-| `bigint` id + binary payload + `Date`        | 1.10 µs          | 1.11 µs             | **1.02 µs** |
+| Encode to JSON string                        | **Sury**    | `JSON.stringify` | fast-json-stringify |
+| -------------------------------------------- | ----------- | ---------------- | ------------------- |
+| API response (user profile, 7 fields)        | **250 ns**  | 396 ns           | 301 ns              |
+| Event feed (50 tagged-union events)          | **3.67 µs** | 4.61 µs          | 13.52 µs            |
+| `bigint` id + binary payload + `Date`        | **1.02 µs** | 1.10 µs          | 1.11 µs             |
 
 Faster than `JSON.stringify`, and 3.5× lighter than fast-json-stringify — 16.2 kB against 56.7 kB, encoder included.
 

--- a/packages/sury/scripts/jsonStringifyBench.ts
+++ b/packages/sury/scripts/jsonStringifyBench.ts
@@ -265,7 +265,7 @@ const fmt = (ns: number): string =>
 const main = () => {
   console.log(`node ${process.version}\n`);
   const rows: string[][] = [
-    ["Encode to JSON string", "JSON.stringify", "fast-json-stringify", "Sury"],
+    ["Encode to JSON string", "Sury", "JSON.stringify", "fast-json-stringify"],
   ];
   for (const c of cases) {
     // Guard against benchmarking functions that disagree on the output.
@@ -273,7 +273,7 @@ const main = () => {
     if (JSON.stringify(JSON.parse(out.stringify)) !== JSON.stringify(JSON.parse(out.sury))) {
       throw new Error(`${c.name}: Sury output differs\n${out.stringify}\n${out.sury}`);
     }
-    rows.push([c.name, fmt(bench(c.stringify)), fmt(bench(c.fastJson)), fmt(bench(c.sury))]);
+    rows.push([c.name, fmt(bench(c.sury)), fmt(bench(c.stringify)), fmt(bench(c.fastJson))]);
   }
   const widths = rows[0]!.map((_, i) => Math.max(...rows.map((r) => r[i]!.length)));
   for (const r of rows) {


### PR DESCRIPTION
Reorganize the benchmark results table to place Sury's performance metrics first, making it the primary comparison point rather than listing it last.

**Changes:**
- Reordered benchmark table columns in README to show Sury first, followed by JSON.stringify and fast-json-stringify
- Updated the benchmark script to generate results in the new column order
- Sury's superior performance is now immediately visible in each benchmark row

This change improves the presentation of Sury's performance advantages without altering any actual benchmark data or methodology.

https://claude.ai/code/session_01D64CNXpjuMxt9Ffx6ATgfG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reordered the JSON encoding benchmark table to present Sury first, followed by `JSON.stringify` and `fast-json-stringify`.

* **Chores**
  * Updated benchmark output ordering to match the revised documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->