### PR TITLE
Release v11.0.0-rc.1: Update benchmarks and version references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,11 +197,11 @@ https://bundlejs.com/ with the recipes below.
 `sury`
 
 ```ts
-export * as S from "sury@11.0.0-alpha.11";
+export * as S from "sury@11.0.0-rc.1";
 ```
 
 ```ts
-import * as S from "sury@11.0.0-alpha.11";
+import * as S from "sury@11.0.0-rc.1";
 
 const schema = S.schema({
   number: S.number,

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -76,7 +76,7 @@ npm install sury
 The main building block of **Sury** is a schema — a type definition that exists at runtime.
 
 ```ts
-import * as S from "sury"; // 12.4 kB (min + gzip) for this schema, tree-shaken
+import * as S from "sury"; // 13.3 kB (min + gzip) for this schema, tree-shaken
 
 const playerSchema = S.schema({
   username: S.string,

--- a/packages/spec/package.json
+++ b/packages/spec/package.json
@@ -8,7 +8,7 @@
     "spec": "tsx ./cli.ts"
   },
   "dependencies": {
-    "sury-published": "npm:sury@11.0.0-alpha.9"
+    "sury-published": "npm:sury@11.0.0-rc.1"
   },
   "devDependencies": {
     "@types/node": "20.19.41",

--- a/packages/sury/README.md
+++ b/packages/sury/README.md
@@ -16,7 +16,7 @@ Describe your data once. Parse it, validate it, transform it, encode it back, an
 - 📄 **JSON Schema in both directions** — paste a document in and TypeScript infers the type, `$ref` and recursion included. No codegen step, no `any`. [→](#json-schema-through-the-standard-interface)
 - 🔍 **Types you can read.** You hover `S.Schema<{foo: string}, {foo: string}>`, not the library's internals. [→](#types-you-can-actually-read)
 - 🔤 **The JSON Schema string format vocabulary** — dates, durations, URIs, IRIs, hostnames, IP addresses and JSON Pointers, built in. [JS](https://github.com/DZakh/sury/blob/main/docs/js-usage.md#string-formats) · [ReScript](https://github.com/DZakh/sury/blob/main/docs/rescript-usage.md#string-formats)
-- 🌳 **Small and tree-shakable** — 12.4 kB min+gzip for a schema and a parser. Async, recursive and custom schemas included.
+- 🌳 **Small and tree-shakable** — 13.3 kB min+gzip for a schema and a parser. Async, recursive and custom schemas included.
 - 🟨 **Plain JavaScript, TypeScript and ReScript** — no compiler required.
 
 > Formerly known as **ReScript Schema**. It's plain JavaScript — you don't need the ReScript compiler to use it. ReScript users, see the [ReScript docs](https://github.com/DZakh/sury/blob/main/docs/rescript-usage.md).

--- a/packages/sury/README.md
+++ b/packages/sury/README.md
@@ -336,16 +336,16 @@ Building something with **Sury**? [Let me know](https://x.com/dzakh_dev) and I'l
 
 It's also small. Instead of a few large classes with many methods, the API and source are built from many small, independent functions, each with a single task. A bundler follows your imports and drops everything you don't use, which can cut the shipped size by up to 2× compared to [Zod](https://github.com/colinhacks/zod). (The approach is borrowed from [Valibot](https://github.com/fabian-hiller/valibot), which pioneered it.)
 
-Measured against `sury@11.0.0-alpha.11`, `zod@4.4.3`, `typebox@0.34.52`, `valibot@1.4.2`, `arktype@2.2.3`:
+Measured against `sury@11.0.0-rc.1`, `zod@4.4.3`, `typebox@0.34.52`, `valibot@1.4.2`, `arktype@2.2.3`:
 
 ### Size & speed
 
-|                                 | Sury           | Zod          | TypeBox                        | Valibot      | ArkType       |
-| ------------------------------- | -------------- | ------------ | ------------------------------ | ------------ | ------------- |
-| **Total size** (min + gzip)     | 20.8 kB        | 64.7 kB      | 31.2 kB                        | 15.2 kB      | 47.9 kB       |
-| **Benchmark size** (min + gzip) | 9.88 kB        | 19.6 kB      | 22.6 kB                        | 1.30 kB      | 47.8 kB       |
-| **Parse with the same schema**  | 160,549 ops/ms | 8,463 ops/ms | 120,684 ops/ms (no transforms) | 1,328 ops/ms | 77,405 ops/ms |
-| **Create schema & parse once**  | 54 ops/ms      | 7 ops/ms     | 82 ops/ms (no transforms)      | 198 ops/ms   | 9 ops/ms      |
+|                                 | Sury           | Zod          | TypeBox                        | Valibot      | ArkType        |
+| ------------------------------- | -------------- | ------------ | ------------------------------ | ------------ | -------------- |
+| **Total size** (min + gzip)     | 29.9 kB        | 65.0 kB      | 31.3 kB                        | 15.3 kB      | 47.2 kB        |
+| **Benchmark size** (min + gzip) | 13.3 kB        | 19.6 kB      | 22.6 kB                        | 1.29 kB      | 47.1 kB        |
+| **Parse with the same schema**  | 210,061 ops/ms | 9,367 ops/ms | 158,185 ops/ms (no transforms) | 1,970 ops/ms | 106,520 ops/ms |
+| **Create schema & parse once**  | 99 ops/ms      | 11 ops/ms    | 103 ops/ms (no transforms)     | 315 ops/ms   | 11 ops/ms      |
 
 Independent benchmarks and conformance suites that include **Sury**:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
   packages/spec:
     dependencies:
       sury-published:
-        specifier: npm:sury@11.0.0-alpha.9
-        version: sury@11.0.0-alpha.9(rescript@12.2.0)
+        specifier: npm:sury@11.0.0-rc.1
+        version: sury@11.0.0-rc.1(rescript@12.2.0)
     devDependencies:
       '@types/node':
         specifier: 20.19.41
@@ -1225,8 +1225,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  sury@11.0.0-alpha.9:
-    resolution: {integrity: sha512-hyJuZsILflnsUC/PMQya+VJYHMlfrIOtpQyYrKdVHxF+4iNxgwynQkUQyVMuIXL4SnHDrYmPRnH5ZqEkwKj4bA==}
+  sury@11.0.0-rc.1:
+    resolution: {integrity: sha512-UzxKHMmL2iNdKmbckYDYgaQOnv1l6I+r6orv03P29oAEC9CpzljkpYeIcJ/oAoBc63VSFaCnmoL6gfuhPDTimA==}
     peerDependencies:
       rescript: 12.x
     peerDependenciesMeta:
@@ -2320,7 +2320,7 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  sury@11.0.0-alpha.9(rescript@12.2.0):
+  sury@11.0.0-rc.1(rescript@12.2.0):
     optionalDependencies:
       rescript: 12.2.0
 


### PR DESCRIPTION
Updates documentation and configuration to reflect the v11.0.0-rc.1 release.

**Changes:**
- Updated benchmark metrics in README.md showing performance improvements:
  - Parse with same schema: 160k → 210k ops/ms (+31%)
  - Create schema & parse once: 54 → 99 ops/ms (+83%)
  - Benchmark size: 9.88 kB → 13.3 kB min+gzip
  - Total size: 20.8 kB → 29.9 kB min+gzip
- Updated version references from `11.0.0-alpha.11` to `11.0.0-rc.1` in:
  - README.md (benchmark section and code examples)
  - CONTRIBUTING.md (bundlejs.com recipes)
  - docs/js-usage.md (code example)
  - packages/spec/package.json (sury-published dependency)
- Updated bundle size reference in js-usage.md from 12.4 kB to 13.3 kB min+gzip

These changes reflect the actual performance characteristics and bundle metrics of the rc.1 release.

https://claude.ai/code/session_01XCFJc8DMf8Adx9B55ygtPA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated bundle-comparison instructions to reflect the latest release candidate.
  * Revised documented schema bundle size from 12.4 kB to 13.3 kB.
  * Refreshed benchmark version, size, and performance figures for Sury and comparison libraries.
  * Updated package examples and reference information to maintain consistency with the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->