### PR TITLE
Stop linking libzstd into the macOS ppx, and verify the binaries before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,46 +262,14 @@ jobs:
           # default) fall through to the `bin` script, which execs it as-is.
           chmod +x packages/sury-ppx/ppx-*.exe
 
-      # Nothing else notices when a runner label silently changes architecture
-      # (#367 shipped an arm64 binary to Intel Macs for exactly this reason) or
-      # when a new slice is missing from package.json "files".
-      - name: Verify binary architectures
-        working-directory: packages/sury-ppx
-        run: |
-          check() {
-            if ! file -b "$1" | grep -qE "$2"; then
-              echo "::error::$1 should be $2 but is: $(file -b "$1")"
-              exit 1
-            fi
-          }
-          check ppx-linux.exe 'ELF.*x86-64'
-          check ppx-linux-arm.exe 'ELF.*aarch64'
-          check ppx-osx.exe 'Mach-O.*x86_64'
-          check ppx-osx-arm.exe 'Mach-O.*arm64'
-          check ppx-windows.exe 'PE32\+.*x86-64'
-
       - name: npm pack (sury-ppx)
         run: npm pack
         working-directory: packages/sury-ppx
 
-      - name: Verify tarball contents
-        working-directory: packages/sury-ppx
-        run: |
-          listing=$(tar -tvzf sury-ppx-*.tgz)
-          for f in ppx-linux.exe ppx-linux-arm.exe ppx-osx.exe ppx-osx-arm.exe \
-                   ppx-windows.exe bin bin.cmd install.cjs; do
-            if ! grep -q " package/$f\$" <<<"$listing"; then
-              echo "::error::package/$f missing from the tarball - add it to package.json \"files\""
-              exit 1
-            fi
-          done
-          # The `bin` script execs these directly when postinstall is skipped.
-          for f in ppx-linux.exe ppx-linux-arm.exe ppx-osx.exe ppx-osx-arm.exe; do
-            if ! grep -qE "^-rwx.* package/$f\$" <<<"$listing"; then
-              echo "::error::package/$f is not executable in the tarball"
-              exit 1
-            fi
-          done
+      # The last gate before an artifact becomes a published tarball: what the
+      # binaries are, what they need at runtime, and what reached the package.
+      - name: Verify the ppx binaries and tarball
+        run: npx tsx packages/sury-ppx/checkBinaries.ts packages/sury-ppx/sury-ppx-*.tgz
 
       - name: "Upload artifact: sury-ppx npm package"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,11 @@ jobs:
   # The other four slices only feed the published tarball, and macOS runners
   # bill at 10x. A PR that breaks them breaks the linux build too, near enough.
   ppx-build-rest:
-    if: github.event_name != 'pull_request'
+    # FIXME: temporary, revert before merging. This PR is the exception the rule
+    # above doesn't cover: the zstd fix and checkBinaries.ts are both about the
+    # macOS slices, so the one run that would prove them is the one a PR skips.
+    # Restore `if: github.event_name != 'pull_request'`.
+    if: true
     strategy:
       # A slice failing to build is per-platform news; the others still tell us
       # whether the failure is local to one toolchain.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,11 +201,7 @@ jobs:
   # The other four slices only feed the published tarball, and macOS runners
   # bill at 10x. A PR that breaks them breaks the linux build too, near enough.
   ppx-build-rest:
-    # FIXME: temporary, revert before merging. This PR is the exception the rule
-    # above doesn't cover: the zstd fix and checkBinaries.ts are both about the
-    # macOS slices, so the one run that would prove them is the one a PR skips.
-    # Restore `if: github.event_name != 'pull_request'`.
-    if: true
+    if: github.event_name != 'pull_request'
     strategy:
       # A slice failing to build is per-platform news; the others still tell us
       # whether the failure is local to one toolchain.

--- a/.github/workflows/ppx-build.yml
+++ b/.github/workflows/ppx-build.yml
@@ -29,10 +29,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # ocaml-option-no-compression configures the compiler --without-zstd.
+      # Without it, OCaml 5.1+ links libzstd into everything that uses
+      # compiler-libs — ppxlib does — and records the path it was found at. On a
+      # macOS runner that is a Homebrew prefix, so the published binary asks a
+      # consumer's machine for a dylib it has no reason to have (11.0.0-rc.1
+      # shipped exactly that). The compression only affects reading compressed
+      # .cmi files, which a syntax-level ppx never does.
+      #
+      # It has to come from the +options variant: the option package won't
+      # install alongside ocaml-base-compiler off Windows. Both build the
+      # compiler from source, so this costs nothing extra, and passing it here
+      # rather than in a later `opam install` avoids a second compiler build.
       - name: Use OCaml
         uses: ocaml/setup-ocaml@v3
         with:
-          ocaml-compiler: 5.3.0
+          ocaml-compiler: ocaml-variants.5.3.0+options,ocaml-option-no-compression
 
       - name: Install deps
         run: opam install . --deps-only --with-test

--- a/packages/sury-ppx/checkBinaries.ts
+++ b/packages/sury-ppx/checkBinaries.ts
@@ -33,9 +33,15 @@ const ALSO_IN_TARBALL = ["bin.cmd", "install.cjs"];
 // Everything else has to ship beside the binary, and nothing does.
 const MACOS_SYSTEM_PREFIXES = ["/usr/lib/", "/System/Library/"];
 
-// The mingw-w64 build imports only DLLs Windows itself provides. `api-ms-win-*`
-// are the API sets; the rest are named individually so a runtime DLL that has
-// to be shipped (libwinpthread-1, libzstd) can't hide among them.
+// The mingw-w64 build imports only DLLs Windows itself provides. The API sets
+// are matched by prefix; the rest are named individually so a runtime DLL that
+// has to be shipped (libwinpthread-1, libzstd) can't hide among them.
+//
+// `vcruntime*`/`msvcp*` are deliberately absent: those ship in the VC++
+// redistributable, not in Windows, so a binary importing one is as broken for a
+// consumer as one importing libzstd. mingw links msvcrt.dll instead.
+const WINDOWS_SYSTEM_PREFIXES = ["api-ms-win-", "ext-ms-win-"];
+
 const WINDOWS_SYSTEM_DLLS = new Set(
   [
     "kernel32.dll",
@@ -49,12 +55,17 @@ const WINDOWS_SYSTEM_DLLS = new Set(
     "user32.dll",
     "dbghelp.dll",
     "userenv.dll",
+    // Windows' own C runtime since 10; a UCRT-configured mingw imports it.
+    "ucrtbase.dll",
   ].map((n) => n.toLowerCase()),
 );
 
 type Inspection = { arch: string; deps: string[] };
 
-const ELF_MACHINES: Record<number, string> = { 0x3e: "x86-64", 0xb7: "aarch64" };
+const ELF_MACHINES: Record<number, string> = {
+  0x3e: "x86-64",
+  0xb7: "aarch64",
+};
 
 // A statically linked ELF has no PT_INTERP: no loader runs, so there is nothing
 // to resolve. That single check is the whole "no shared libraries" question -
@@ -90,9 +101,10 @@ const MACHO_CPUS: Record<number, string> = {
   0x0100000c: "arm64",
 };
 
-// LC_REQ_DYLD (0x80000000) is set on the weak/reexport/upward variants, and the
-// lazy one defers the load rather than dropping it; every one of the five names
-// a path dyld has to find on the consumer's machine, so all five count.
+// LC_REQ_DYLD (0x80000000) is set on the weak/reexport/upward variants. All
+// five count, including the two dyld tolerates the absence of: a weak load
+// binds its symbols to null and a lazy one defers the failure to first use,
+// which makes a path off the build machine worse to diagnose, not acceptable.
 const MACHO_DYLIB_COMMANDS = new Set([
   0x0c, 0x20, 0x80000018, 0x8000001f, 0x80000023,
 ]);
@@ -174,7 +186,9 @@ const isSystemDep = (format: string, dep: string): boolean =>
   format === "macho"
     ? MACOS_SYSTEM_PREFIXES.some((prefix) => dep.startsWith(prefix))
     : format === "pe" &&
-      (dep.toLowerCase().startsWith("api-ms-win-") ||
+      (WINDOWS_SYSTEM_PREFIXES.some((prefix) =>
+        dep.toLowerCase().startsWith(prefix),
+      ) ||
         WINDOWS_SYSTEM_DLLS.has(dep.toLowerCase()));
 
 const errors: string[] = [];
@@ -220,7 +234,9 @@ for (const [file, expected] of Object.entries(BINARIES)) {
   }
   for (const dep of inspection.deps) {
     if (!isSystemDep(expected.format, dep)) {
-      fail(`${file}: depends on ${dep}, which a consumer has no reason to have`);
+      fail(
+        `${file}: depends on ${dep}, which a consumer has no reason to have`,
+      );
     }
   }
 }
@@ -229,28 +245,44 @@ const [tarball] = process.argv.slice(2);
 if (!tarball) {
   fail("usage: checkBinaries.ts <sury-ppx-*.tgz>");
 } else {
-  const listing = execFileSync("tar", ["-tvzf", tarball], { encoding: "utf8" })
-    .split("\n")
-    .flatMap((line) => {
-      const match = line.match(/^(\S+).* package\/(\S+)$/);
-      return match ? [{ mode: match[1]!, file: match[2]! }] : [];
-    });
-  for (const file of [...EXECUTABLE_IN_TARBALL, ...ALSO_IN_TARBALL]) {
-    const entry = listing.find((e) => e.file === file);
-    if (!entry) {
-      fail(`${file}: missing from the tarball — add it to package.json "files"`);
-    } else if (
-      EXECUTABLE_IN_TARBALL.includes(file) &&
-      !entry.mode.startsWith("-rwx")
-    ) {
-      fail(`${file}: not executable in the tarball`);
+  // Reading the tarball is the one step that can throw: an unguarded exception
+  // would escape with the binary errors still unprinted, and those are the ones
+  // worth reading.
+  let listing: { mode: string; file: string }[] | undefined;
+  try {
+    listing = execFileSync("tar", ["-tvzf", tarball], { encoding: "utf8" })
+      .split("\n")
+      .flatMap((line) => {
+        const match = line.match(/^(\S+).* package\/(\S+)$/);
+        return match ? [{ mode: match[1]!, file: match[2]! }] : [];
+      });
+  } catch (error) {
+    // An empty listing would report all eight entries as missing and bury this.
+    fail(`${tarball}: cannot be read — ${error}`);
+  }
+  const entries = listing;
+  if (entries) {
+    for (const file of [...EXECUTABLE_IN_TARBALL, ...ALSO_IN_TARBALL]) {
+      const entry = entries.find((e) => e.file === file);
+      if (!entry) {
+        fail(
+          `${file}: missing from the tarball — add it to package.json "files"`,
+        );
+      } else if (
+        EXECUTABLE_IN_TARBALL.includes(file) &&
+        !entry.mode.startsWith("-rwx")
+      ) {
+        fail(`${file}: not executable in the tarball`);
+      }
     }
   }
 }
 
 if (errors.length) {
   for (const error of errors) {
-    console.error(`${process.env.GITHUB_ACTIONS ? "::error::" : "error: "}${error}`);
+    console.error(
+      `${process.env.GITHUB_ACTIONS ? "::error::" : "error: "}${error}`,
+    );
   }
   process.exit(1);
 }

--- a/packages/sury-ppx/checkBinaries.ts
+++ b/packages/sury-ppx/checkBinaries.ts
@@ -60,6 +60,9 @@ const ELF_MACHINES: Record<number, string> = { 0x3e: "x86-64", 0xb7: "aarch64" }
 // to resolve. That single check is the whole "no shared libraries" question -
 // the DT_NEEDED list can't be non-empty without an interpreter to read it.
 const inspectElf = (buf: Buffer): Inspection => {
+  if (buf.readUInt32BE(0) !== 0x7f454c46) {
+    throw new Error("missing ELF magic");
+  }
   if (buf[4] !== 2 || buf[5] !== 1) {
     throw new Error("not a little-endian 64-bit ELF");
   }
@@ -87,15 +90,19 @@ const MACHO_CPUS: Record<number, string> = {
   0x0100000c: "arm64",
 };
 
-// LC_REQ_DYLD (0x80000000) is set on the weak/reexport/upward variants; all
-// four record a path dyld must resolve at launch, so all four count.
+// LC_REQ_DYLD (0x80000000) is set on the weak/reexport/upward variants, and the
+// lazy one defers the load rather than dropping it; every one of the five names
+// a path dyld has to find on the consumer's machine, so all five count.
 const MACHO_DYLIB_COMMANDS = new Set([
-  0x0c, 0x80000018, 0x8000001f, 0x80000023,
+  0x0c, 0x20, 0x80000018, 0x8000001f, 0x80000023,
 ]);
 
 const inspectMacho = (buf: Buffer): Inspection => {
   if (buf.readUInt32LE(0) === 0xbebafeca) {
     throw new Error("universal binary: the slices are shipped separately");
+  }
+  if (buf.readUInt32LE(0) !== 0xfeedfacf) {
+    throw new Error("missing 64-bit Mach-O magic");
   }
   const deps: string[] = [];
   let cursor = 32;

--- a/packages/sury-ppx/checkBinaries.ts
+++ b/packages/sury-ppx/checkBinaries.ts
@@ -1,0 +1,250 @@
+// A consumer installs this package and ReScript execs the binary directly, so
+// every slice has to run on a machine that has nothing on it but the OS. Only
+// the linux slices get that for free (`--profile static`); on macOS OCaml 5.1+
+// links libzstd into anything that uses compiler-libs — ppxlib does — and the
+// path it records is the build runner's Homebrew prefix. 11.0.0-rc.1 shipped a
+// macOS binary wanting /usr/local/opt/zstd/lib/libzstd.1.dylib, which no
+// consumer has; nothing in the pipeline could see it, because a load command is
+// invisible until dyld resolves it on someone else's machine.
+//
+// So the headers are parsed here rather than trusted: architecture, dynamic
+// dependencies and the packaged tarball, all before publish.
+import { execFileSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+// This list is spelled four times: here, `files` in package.json, `install.cjs`
+// and the `bin` fallback script. Keeping the other three honest is this file's
+// job — every name below must reach the tarball, executable, built for the
+// architecture claimed.
+const BINARIES = {
+  "ppx-linux.exe": { format: "elf", arch: "x86-64" },
+  "ppx-linux-arm.exe": { format: "elf", arch: "aarch64" },
+  "ppx-osx.exe": { format: "macho", arch: "x86-64" },
+  "ppx-osx-arm.exe": { format: "macho", arch: "arm64" },
+  "ppx-windows.exe": { format: "pe", arch: "x86-64" },
+} as const;
+
+// `bin.cmd` is not here: install.cjs deletes it on Windows, and the tarball is
+// checked before any install runs.
+const EXECUTABLE_IN_TARBALL = ["bin", ...Object.keys(BINARIES)];
+const ALSO_IN_TARBALL = ["bin.cmd", "install.cjs"];
+
+// Everything else has to ship beside the binary, and nothing does.
+const MACOS_SYSTEM_PREFIXES = ["/usr/lib/", "/System/Library/"];
+
+// The mingw-w64 build imports only DLLs Windows itself provides. `api-ms-win-*`
+// are the API sets; the rest are named individually so a runtime DLL that has
+// to be shipped (libwinpthread-1, libzstd) can't hide among them.
+const WINDOWS_SYSTEM_DLLS = new Set(
+  [
+    "kernel32.dll",
+    "msvcrt.dll",
+    "shell32.dll",
+    "ole32.dll",
+    "shlwapi.dll",
+    "version.dll",
+    "ws2_32.dll",
+    "advapi32.dll",
+    "user32.dll",
+    "dbghelp.dll",
+    "userenv.dll",
+  ].map((n) => n.toLowerCase()),
+);
+
+type Inspection = { arch: string; deps: string[] };
+
+const ELF_MACHINES: Record<number, string> = { 0x3e: "x86-64", 0xb7: "aarch64" };
+
+// A statically linked ELF has no PT_INTERP: no loader runs, so there is nothing
+// to resolve. That single check is the whole "no shared libraries" question -
+// the DT_NEEDED list can't be non-empty without an interpreter to read it.
+const inspectElf = (buf: Buffer): Inspection => {
+  if (buf[4] !== 2 || buf[5] !== 1) {
+    throw new Error("not a little-endian 64-bit ELF");
+  }
+  const phoff = Number(buf.readBigUInt64LE(32));
+  const phentsize = buf.readUInt16LE(54);
+  const deps: string[] = [];
+  for (let i = 0; i < buf.readUInt16LE(56); i++) {
+    const ph = phoff + i * phentsize;
+    if (buf.readUInt32LE(ph) === 3 /* PT_INTERP */) {
+      const offset = Number(buf.readBigUInt64LE(ph + 8));
+      const size = Number(buf.readBigUInt64LE(ph + 32));
+      deps.push(
+        buf
+          .subarray(offset, offset + size)
+          .toString("utf8")
+          .replace(/\0.*$/, ""),
+      );
+    }
+  }
+  return { arch: ELF_MACHINES[buf.readUInt16LE(18)] ?? "unknown", deps };
+};
+
+const MACHO_CPUS: Record<number, string> = {
+  0x01000007: "x86-64",
+  0x0100000c: "arm64",
+};
+
+// LC_REQ_DYLD (0x80000000) is set on the weak/reexport/upward variants; all
+// four record a path dyld must resolve at launch, so all four count.
+const MACHO_DYLIB_COMMANDS = new Set([
+  0x0c, 0x80000018, 0x8000001f, 0x80000023,
+]);
+
+const inspectMacho = (buf: Buffer): Inspection => {
+  if (buf.readUInt32LE(0) === 0xbebafeca) {
+    throw new Error("universal binary: the slices are shipped separately");
+  }
+  const deps: string[] = [];
+  let cursor = 32;
+  for (let i = 0; i < buf.readUInt32LE(16); i++) {
+    const cmd = buf.readUInt32LE(cursor);
+    const cmdsize = buf.readUInt32LE(cursor + 4);
+    if (MACHO_DYLIB_COMMANDS.has(cmd)) {
+      const nameOffset = cursor + buf.readUInt32LE(cursor + 8);
+      deps.push(
+        buf
+          .subarray(nameOffset, cursor + cmdsize)
+          .toString("utf8")
+          .replace(/\0.*$/, ""),
+      );
+    }
+    cursor += cmdsize;
+  }
+  return { arch: MACHO_CPUS[buf.readUInt32LE(4)] ?? "unknown", deps };
+};
+
+const PE_MACHINES: Record<number, string> = { 0x8664: "x86-64" };
+
+const inspectPe = (buf: Buffer): Inspection => {
+  const pe = buf.readUInt32LE(0x3c);
+  if (buf.toString("ascii", pe, pe + 4) !== "PE\0\0") {
+    throw new Error("missing PE signature");
+  }
+  const opt = pe + 24;
+  if (buf.readUInt16LE(opt) !== 0x20b) {
+    throw new Error("not a PE32+ image");
+  }
+  const sections = pe + 24 + buf.readUInt16LE(pe + 20);
+  const toOffset = (rva: number): number => {
+    for (let i = 0; i < buf.readUInt16LE(pe + 6); i++) {
+      const s = sections + i * 40;
+      const start = buf.readUInt32LE(s + 12);
+      if (rva >= start && rva < start + buf.readUInt32LE(s + 16)) {
+        return rva - start + buf.readUInt32LE(s + 20);
+      }
+    }
+    throw new Error(`RVA ${rva} is outside every section`);
+  };
+  const name = (rva: number): string => {
+    const at = toOffset(rva);
+    return buf.toString("ascii", at, buf.indexOf(0, at));
+  };
+
+  const deps: string[] = [];
+  // Data directory 1 is the import table, 13 the delay-load imports; the entry
+  // stride and the offset of the DLL name differ between the two.
+  const dirs = opt + 112;
+  for (const [index, stride, nameField] of [
+    [1, 20, 12],
+    [13, 32, 4],
+  ] as const) {
+    if (buf.readUInt32LE(opt + 108) <= index) continue;
+    const rva = buf.readUInt32LE(dirs + index * 8);
+    if (!rva) continue;
+    for (let at = toOffset(rva); ; at += stride) {
+      const nameRva = buf.readUInt32LE(at + nameField);
+      if (!nameRva) break;
+      deps.push(name(nameRva));
+    }
+  }
+  return { arch: PE_MACHINES[buf.readUInt16LE(pe + 4)] ?? "unknown", deps };
+};
+
+const isSystemDep = (format: string, dep: string): boolean =>
+  format === "macho"
+    ? MACOS_SYSTEM_PREFIXES.some((prefix) => dep.startsWith(prefix))
+    : format === "pe" &&
+      (dep.toLowerCase().startsWith("api-ms-win-") ||
+        WINDOWS_SYSTEM_DLLS.has(dep.toLowerCase()));
+
+const errors: string[] = [];
+const fail = (message: string) => {
+  errors.push(message);
+};
+
+const dir = import.meta.dirname;
+
+for (const [file, expected] of Object.entries(BINARIES)) {
+  const path = join(dir, file);
+  let buf: Buffer;
+  try {
+    buf = readFileSync(path);
+  } catch {
+    fail(`${file}: missing — the pack step moves one artifact per build slice`);
+    continue;
+  }
+
+  // install.cjs chmods the binary it picks, but an installer that skips
+  // postinstall (pnpm >=10 by default) falls through to the `bin` script, which
+  // execs it as-is.
+  if (!(statSync(path).mode & 0o111)) {
+    fail(`${file}: not executable`);
+  }
+
+  let inspection: Inspection;
+  try {
+    inspection =
+      expected.format === "elf"
+        ? inspectElf(buf)
+        : expected.format === "macho"
+          ? inspectMacho(buf)
+          : inspectPe(buf);
+  } catch (error) {
+    fail(`${file}: not a readable ${expected.format} image — ${error}`);
+    continue;
+  }
+
+  if (inspection.arch !== expected.arch) {
+    // A runner label silently changing architecture is how #367 shipped.
+    fail(`${file}: built for ${inspection.arch}, expected ${expected.arch}`);
+  }
+  for (const dep of inspection.deps) {
+    if (!isSystemDep(expected.format, dep)) {
+      fail(`${file}: depends on ${dep}, which a consumer has no reason to have`);
+    }
+  }
+}
+
+const [tarball] = process.argv.slice(2);
+if (!tarball) {
+  fail("usage: checkBinaries.ts <sury-ppx-*.tgz>");
+} else {
+  const listing = execFileSync("tar", ["-tvzf", tarball], { encoding: "utf8" })
+    .split("\n")
+    .flatMap((line) => {
+      const match = line.match(/^(\S+).* package\/(\S+)$/);
+      return match ? [{ mode: match[1]!, file: match[2]! }] : [];
+    });
+  for (const file of [...EXECUTABLE_IN_TARBALL, ...ALSO_IN_TARBALL]) {
+    const entry = listing.find((e) => e.file === file);
+    if (!entry) {
+      fail(`${file}: missing from the tarball — add it to package.json "files"`);
+    } else if (
+      EXECUTABLE_IN_TARBALL.includes(file) &&
+      !entry.mode.startsWith("-rwx")
+    ) {
+      fail(`${file}: not executable in the tarball`);
+    }
+  }
+}
+
+if (errors.length) {
+  for (const error of errors) {
+    console.error(`${process.env.GITHUB_ACTIONS ? "::error::" : "error: "}${error}`);
+  }
+  process.exit(1);
+}
+console.log(`sury-ppx binaries verified: ${Object.keys(BINARIES).join(", ")}`);

--- a/packages/sury-ppx/install.cjs
+++ b/packages/sury-ppx/install.cjs
@@ -6,9 +6,10 @@ const fs = require("fs");
 // emulates x64, so it shares the one Windows binary.
 //
 // This list is spelled four times: here, `files` in package.json, the `bin`
-// fallback script, and the pack step in .github/workflows/ci.yml. That job
-// asserts every entry is present in the tarball and built for the right
-// architecture, so drift fails CI rather than reaching a user.
+// fallback script, and checkBinaries.ts. That last one runs before publish and
+// asserts every entry reached the tarball, executable, built for the right
+// architecture and needing nothing but the OS, so drift fails CI rather than
+// reaching a user.
 const BINARIES = {
   "linux-x64": "ppx-linux.exe",
   "linux-arm64": "ppx-linux-arm.exe",


### PR DESCRIPTION
`sury-ppx` ships five prebuilt binaries and ReScript execs them directly, so each one has to run on a machine with nothing on it but the OS. Two changes: stop the macOS slices from depending on Homebrew, and make CI able to see it if they ever do again.

## The bug

Since OCaml 5.1 the compiler links zstd into anything using `compiler-libs`, which ppxlib does. On the macOS runners the zstd it finds is Homebrew's, so the *build machine's* prefix is baked into the binary. 11.0.0-rc.1 shipped a macOS binary asking every consumer's Mac for `/usr/local/opt/zstd/lib/libzstd.1.dylib`:

```
dyld[…]: Library not loaded: /usr/local/opt/zstd/lib/libzstd.1.dylib
```

Nothing in the pipeline could catch it. A Mach-O load command is invisible until dyld resolves it on someone else's machine, and the verification step was `file -b`, which reports architecture and nothing else.

## The fix

**`ppx-build.yml`** builds with `ocaml-variants.5.3.0+options,ocaml-option-no-compression` (i.e. `--without-zstd`), so the dependency is never created. The option only exists on the `+options` variant, which is why the compiler string changes shape rather than just gaining a flag.

**`checkBinaries.ts`** replaces the two shell steps in `ci.yml` and parses the headers itself instead of trusting `file`:

- **ELF** — no `PT_INTERP` means nothing is dynamically resolved at all, which is the whole "statically linked" question for the `--profile static` slices.
- **Mach-O** — walks all five `LC_*_DYLIB` kinds, including the weak and lazy variants dyld tolerates the absence of, and rejects any path outside `/usr/lib/` and `/System/Library/`.
- **PE** — walks both the import and delay-import directories against an allowlist of DLLs Windows itself provides.

It also keeps what the shell did (architecture per slice — the check that relates to #367 — plus tarball contents and exec bits), reports every finding as a `::error::` annotation rather than dying on the first, and gates the artifact upload.

## Verification

Run [31465876850](https://github.com/DZakh/sury/actions/runs/31465876850) temporarily enabled `ppx-build-rest` on this PR, since the jobs that build macOS and run the checker are normally skipped on pull requests — the fix would otherwise have first executed on `main`. All five slices built, and:

```
sury-ppx binaries verified: ppx-linux.exe, ppx-linux-arm.exe, ppx-osx.exe, ppx-osx-arm.exe, ppx-windows.exe
```

The same checker against the published rc.1 tarball reports the two dependencies this PR removes:

```
error: ppx-osx.exe: depends on /usr/local/opt/zstd/lib/libzstd.1.dylib, which a consumer has no reason to have
error: ppx-osx-arm.exe: depends on /opt/homebrew/opt/zstd/lib/libzstd.1.dylib, which a consumer has no reason to have
```

The pull-request guard is restored in 35b8024; `ci.yml` is byte-identical to before the override.

Anyone stuck on rc.1 can unblock with `brew install zstd` (`arch -x86_64 /usr/local/bin/brew install zstd` on Intel) until the next release.

https://claude.ai/code/session_01ECRN4nY5NiSp6LchoNgEvo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of packaged binaries across supported operating systems and architectures.
  * Packages now verify executable permissions, archive contents, file formats, and runtime dependencies before release.

* **Chores**
  * Updated build configuration to avoid unnecessary compression-related runtime dependencies.
  * Refined package documentation and validation reporting.
  * Pull request builds now include broader platform coverage and run packaging checks before artifacts are published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->