### PR TITLE
Bump version to 11.0.0-rc.2

### DIFF
--- a/packages/sury-ppx/jsr.json
+++ b/packages/sury-ppx/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@sury/ppx",
-  "version": "11.0.0-rc.0",
+  "version": "11.0.0-rc.2",
   "license": "MIT",
   "exports": "./index.ts"
 }

--- a/packages/sury-ppx/package.json
+++ b/packages/sury-ppx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury-ppx",
-  "version": "11.0.0-rc.0",
+  "version": "11.0.0-rc.2",
   "description": "⚙️ ReScript PPX to generate Sury schema from types",
   "keywords": [
     "Sury",
@@ -34,6 +34,6 @@
     "postinstall": "node ./install.cjs"
   },
   "peerDependencies": {
-    "sury": "^11.0.0-rc.0"
+    "sury": "^11.0.0-rc.2"
   }
 }

--- a/packages/sury/package.json
+++ b/packages/sury/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sury",
-  "version": "11.0.0-rc.0",
+  "version": "11.0.0-rc.2",
   "private": true,
   "description": "🧬 The fastest schema with next-gen DX",
   "keywords": [


### PR DESCRIPTION
Release candidate update across the Sury monorepo.

**Changes:**
- Bumped `sury` package version from `11.0.0-rc.0` to `11.0.0-rc.2`
- Bumped `sury-ppx` package version from `11.0.0-rc.0` to `11.0.0-rc.2`
- Updated `sury-ppx` peer dependency constraint to match new version
- Updated `@sury/ppx` JSR package version to `11.0.0-rc.2`

All version updates are consistent across npm and JSR registries.

https://claude.ai/code/session_01UKw1DRfim5HqDWtMtUfzES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the `sury` and `sury-ppx` packages to release candidate version 11.0.0-rc.2.
  * Aligned package compatibility requirements with the updated release candidate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->