### PR TITLE
test(sury): snapshot S.number accepting -Infinity

### DIFF
--- a/packages/sury/specs/number.yaml
+++ b/packages/sury/specs/number.yaml
@@ -25,6 +25,9 @@ operations:
       valid-infinity:
         input: Infinity
         output: Infinity
+      valid-negative-infinity:
+        input: -Infinity
+        output: -Infinity
       invalid-nan:
         input: NaN
         error: Expected number, received NaN


### PR DESCRIPTION
## Why

`S.number` already accepts `-Infinity`. `typeof` is `"number"` and `Number.isNaN` is false. The spec recorded `+Infinity` as `valid-infinity` and left the negative value untested.

## Scope

Adds `valid-negative-infinity` under `operations.parse.examples` in `packages/sury/specs/number.yaml`. The example input is JS source `-Infinity`. `pnpm spec check number --write` filled `output: -Infinity`.

## Tradeoffs

`--write` emits unquoted `-Infinity`, matching nearby `Infinity` and `NaN`. Quoted `"-0"` is the other case, because YAML would parse that as a number. Forced quotes here fail the canonical-form check.

## Blast Radius

Callers of `S.number` see no API change. A later parse change that starts rejecting `-Infinity` fails `spec check`.

## Verification

Ran `pnpm spec check number --perf=skip` in the worktree. Exit 0. The committed diff is one file and three lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that `-Infinity` is parsed correctly as a valid number value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->