### PR TITLE
Clean up resolved and obsolete ideas from IDEAS.md

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -4,49 +4,6 @@
 
 ### ideas
 
-- Bytes on the wire: make `S.uint8Array` encode as base64, and give the text
-  conversion its own name. Today `S.uint8Array`'s string codec runs
-  `TextEncoder`/`TextDecoder`, so any byte outside ASCII is silently destroyed —
-  `S.encoder(S.schema({payload: S.uint8Array}), S.jsonString)` on
-  `[137, 80, 78, 71]` (a PNG magic number) emits `"�PNG"`, which decodes back as
-  `[239, 191, 189, 80, 78, 71]`, with no error at either end. The file's own
-  first line already promises the intended contract ("a base64 string on the
-  JSON side, bytes on ours"); the implementation just never matched it. The type
-  can't say whether bytes are text or opaque, so the default has to be the total
-  conversion — guessing base64 when the user meant text is instantly visible,
-  guessing text when they meant binary corrupts data nobody re-reads.
-  - `S.uint8Array` <-> string becomes base64. Feature-detect
-    `Uint8Array.prototype.toBase64` / `Uint8Array.fromBase64` (TC39 stage 3;
-    Bun has it, Node 22 does not) once at module init and embed the chosen
-    helper, so generated code stays a single `e[N](i)` call with no per-schema
-    branch. The fallback (`btoa`/`atob` over a latin1 bridge, or `Buffer`)
-    allocates an intermediate string per value where the native path doesn't —
-    worth a `scenarios.yaml` entry before byte fields appear in a benchmark.
-  - Add `S.base64`, a string schema carrying the encoding, so the wire format is
-    named on the wire side. It gets JSON Schema both ways:
-    `{type: "string", contentEncoding: "base64"}` out of `toJSONSchema` and back
-    through `fromJSONSchema`. `contentEncoding` is already in the keyword set
-    (`src/types/jsonschema.d.ts`, `jsonschema.ts`, `JSONSchema.res`), and
-    `toJSONSchema(S.uint8Array)` currently throws `Expected JSON, received
-    Uint8Array` — so this closes a gap that exists whichever encoding wins.
-  - Add `S.utf8` for bytes that really are text, converting against
-    `S.uint8Array` via `TextEncoder`/`TextDecoder` — with
-    `new TextDecoder("utf-8", {fatal: true})`, so invalid bytes throw instead of
-    becoming U+FFFD. An error is recoverable; a replacement character isn't.
-    That flag alone is the minimum fix if the default is left as it is.
-  - Consider `base64url` too, but only as an explicit spelling — there is no
-    reliable signal for "this value is going into a URL", and inferring one is
-    the same class of guess that produced the current bug. The principled
-    exception is a container that genuinely owns a URL-safe context (a
-    query-string or path codec, the way `compactColumns` owns columns), which
-    could default its byte fields to it.
-  - Layering: `src/advanced/` is for schemas nothing else builds on, so if
-    `uint8Array` builds on `S.base64` the shared piece belongs in the core, not
-    beside it. Specs must round-trip non-ASCII bytes in both directions —
-    ASCII-only fixtures are exactly what hid this. Breaking for anyone relying
-    on text semantics, so it wants a CHANGELOG line; `tests/S_test.ts`'s
-    `S.decoder(S.string, S.uint8Array, S.jsonString)("data") === '"data"'`
-    becoming `'"ZGF0YQ=="'` is the whole behavior change in one assertion.
 - **`jsonString` -> `Uint8Array`, and a native encoder under it.** Every real
   consumer of `S.jsonString` hands the result to something that wants bytes —
   `fetch`'s body, a socket write, `fs.write`, a Kafka producer — so the JS
@@ -54,10 +11,9 @@
   moment later. Two halves, and the second is what makes the first worth doing:
   - `S.jsonString.with(S.to, S.uint8Array)` (and the reverse) as a declared
     target, so the wire type is bytes and the codec owns the encoding. Today the
-    same thing spells as two hops through `advanced/uint8Array.ts`, which is the
-    text codec the base64 idea above is about to change under it — settle that
-    first, since `jsonString -> uint8Array` must stay UTF-8 and must *not*
-    inherit whatever `S.uint8Array <-> string` becomes.
+    same thing spells as two hops through `advanced/uint8Array.ts`. It is
+    UTF-8, as `S.uint8Array <-> S.string` is, and must stay so — bytes in a
+    *value* position are base64, and this is not one.
   - A native encoder for the aggregate: reuse one module-level `TextEncoder`
     (`encodeInto` into a caller-owned buffer where one is supplied) instead of
     building the whole JSON text and encoding it after. The interesting version
@@ -110,74 +66,6 @@
     `isoDateTime` as a deprecated alias) would put the constraint in the name,
     where the error message is trying to compensate for its absence. Breaking,
     so it wants a CHANGELOG line.
-- `fromJSONSchema` on `{type: "string", format: "unsafe"}` (a fast-json-stringify
-  extension meaning "skip escaping") produces a schema whose jsonString encode
-  treats the value as JSON text and re-parses it, so a string containing quotes
-  throws at runtime instead of being escaped. An unknown/unsupported `format`
-  should fall back to a plain string rather than change the conversion.
-- Follow a field's own forward chain before targeting `S.json`/`S.jsonString`.
-  An object field declared `S.uint8Array.with(S.to, S.string)` fails to encode
-  to `S.json` and `S.jsonString` with "Can't decode Uint8Array to JSON": the
-  field piece retargets the field's *input* schema at json instead of first
-  resolving the field's `.to` chain (Uint8Array -> string) and serializing its
-  output. The same chain works top-level (`S.decoder(S.uint8Array, S.string)`)
-  and wire-side-declared (`S.string.with(S.to, S.uint8Array)` + `S.encoder`).
-  Fix idea: in `jsonDecoderFn`'s object-field mapping and `fieldPiece`, when
-  `itemVal.s.to !== U`, parse the field's own chain first and retarget the
-  resolved output at json/jsonString — mirroring what `updateOutput`/
-  `perVariantTo` already does for union variants.
-- **Every composite export carries the whole union compiler.** `S.array`,
-  `S.dict`, `S.schema`, `S.tuple`, `S.shape` — none of which have union
-  semantics — each retain all ~10.2 kB minified of `union.ts`, through two
-  statically-reachable but usually-dead edges: `valGet`'s dict-missing-key
-  wrap (`schema = option(s)`, `composites.ts`) and the `fieldOr` helper the
-  object ctx builds eagerly (`makeFieldOr`, `factory.ts`). Both reach
-  `optionFactory` -> `unionFactory`, which attaches `unionDecoder` and
-  `unionEncoder` as fields and so drags planner, emitter and rewrite in as one
-  clump. Cutting them is the largest per-export win measured anywhere in the
-  library (esbuild min+gzip, against main): `array` 11088 -> 5580 B gzip
-  (-50%), `dict` 11090 -> 5578, `schema` 11338 -> 6160, `shape` 12268 -> 7132,
-  `tuple` 12385 -> 7220, `object` 13563 -> 7656 (needs both edges — cutting
-  `valGet` alone leaves it at 13535).
-  Neither edge yields to a mechanical fix. Splitting `valGet` into plain and
-  option-wrapping variants was tried and does *not* work: `makeObjectVal`'s
-  val template names `decoder: objectDecoder`, which `arrayDecoder` reaches,
-  so the decoder graph is one strongly-connected component and `array` keeps
-  the retention anyway. Breaking it needs late binding — a mutable slot like
-  the one `enableStandardJSONSchema` already uses, or parameterizing the wrap
-  — which trades a runtime indirection on the decoder path. The `fieldOr` edge
-  wants the other treatment: implement field-with-default without a union at
-  all (an `if(v===void 0){v=def}` decoder wrapper instead of
-  `union([unit, item])` + default fold), which also shortens generated code.
-  That subsumes "Remove fieldOr in favor of optionOr?" below.
-  What is *not* worth doing: splitting `union.ts` into core + planner files.
-  Measured as a dead end — a mechanical split drops zero bytes, since
-  everything is reachable from the two field assignments in `unionFactory`
-  (and two more in `unionRewrite`). Real severance needs a new light
-  dispatcher for the 2-3-variant `T | undefined` shapes (est. 1.5-3 kB of new
-  code, and any case it can't compile either panics or falls back to the
-  planner, restoring the retention), and it only pays off for
-  `optional`/`nullable`-only bundles — ceiling -4.9 kB gzip there. Do the two
-  edges first; revisit the split only if that ceiling still matters.
-- **`fromJSONSchema` builds its own schemas through the proxy ctx.** The
-  object and tuple construction sites in `src/jsonschema.ts` go through
-  `object(() => {})` / `tuple(s => ...)`, which drag `schemaObject`/
-  `schemaTuple`'s proxy-ctx machinery — `proxifyShapedSchema`, `makeFieldOr`
-  (and through it `optionFactory`), `shapedSerializer` — into every
-  `fromJSONSchema` bundle. Swapping them for the `schemaFactory` /
-  `definitionToSchema` the module already imports drops factory retention
-  from 4694 to 598 B minified, -1588 B gzip on the export. Mechanical, but
-  not free: a `definitionToSchema` tuple is strict and carries no shaped
-  serializer, so the equivalence with `schemaTuple` for the
-  identity-mapping case needs pinning in a spec before the swap.
-  Two neighbours measured and deliberately left alone: the bounds machinery
-  (`minimum`/`minLength`/`multipleOf` -> `refinements.ts`, ~1.7 kB gzip) is
-  core-keyword payload, and a `fromJSONSchema` that drops those keywords is
-  simply wrong; and mapping `true`/`{}` to `unknown` instead of `S.json`
-  would save its own ~1 kB but stops rejecting non-JSON values, which is a
-  semantics change to argue on its own merits, not a size fix.
-  `toJSONSchema` needs nothing here — it already retains a disjoint half of
-  `jsonschema.ts` (~130 B overlap) and none of refinements, factory or union.
 - Add `promise` type and `S.promise` (instead of async flag internally)
 - Async output refiner runs on the Promise wrapper, not the resolved value.
   When a decoder result is async (e.g. a union with an async member) and the
@@ -200,14 +88,10 @@ S.reverse(S.schema({
 
 ### TS operation functions
 
-- rename `serializer` to reverse parser ?
 - Make `foo->S.to(S.unknown)` stricter ??
-
-- Make built-in refinements not work with `unknown`. Use `S.to` (manually & automatically) to deside the type first
 - Better inline empty recursive schema operations (union convert)
 - Don't iterate over JSON value when it's `S.json` convert without parsing
 - Add `S.date.with(S.migrationFrom, S.string, <optionalParser>)`.
-- Allow to pass {} instead of S.schema({}) to S.array and other schemas
 
 ### Final release fixes
 
@@ -253,31 +137,15 @@ S.reverse(S.schema({
   the one place `primitives.ts` deliberately avoids a per-compile closure.
   Do it with the item above, not before it: both rewrite the same emit.
 
-- **A bound applied after a transform emits no check.**
-  `S.string.with(S.trim).with(S.minLength, 5)` accepts `""`: `transform` sets
-  the output tail to a copy of `unknown`, `updateBounds` writes
-  `bounds`/`minLength` onto that tail, and `boundsRefiner` dispatches on the
-  tail's `type` — `unknown` matches neither the length branch nor the numeric
-  one, so it returns no checks at all. Before `boundsRefiner` the per-call
-  closure emitted `i.length>4` regardless of type, so the check ran (though
-  its expression rendered as the garbled `unknown <= undefined` — the write
-  site targeting the tail while the bound helpers read the root predates this
-  refactor, and the JSON Schema output loses the bound the same way). Fix
-  candidates: have `boundsRefiner` pick the branch from which bound fields
-  are set instead of from `type`, or make `updateBounds` refuse/forward when
-  the tail carries no type to range over. Needs a spec for
-  transform-then-bound in both directions; none exists today.
-
-- **Type-less JSON Schema assertion keywords vanish on re-emit.**
-  `fromJSONSchema({multipleOf: 2})` builds (the keyword joined the type-less
-  `keywordTypes` "number" group) and validates correctly through the opaque
-  `refine()` that group compiles to, but `toJSONSchema` of the result returns
-  `{}` — the document silently widens on a round-trip, where the keyword used
-  to be rejected loudly as unsupported. First settle what a type-less schema
-  should even mean here: per spec `{multipleOf: 2}` constrains only numeric
-  instances and accepts everything else, which is what the refine does — so
-  the fix is on the emit side, carrying the original keywords through the
-  opaque refinement onto the output document rather than changing validation.
+- **A bound applied after `S.to` panics at creation.**
+  `S.string.with(S.to, S.number).with(S.lte, 100)` throws
+  `S.lte expects number | bigint schema, got string`: the bound helpers type-check
+  the root schema where the bound belongs to the tail (`to`'s target), so a
+  bound can only be written before the conversion. (The transform-then-bound
+  case that used to emit no check — `S.string.with(S.trim).with(S.minLength, 5)`
+  — is fixed and checks the tail.) Pinned by the FIXME at the top of
+  `tests/S_test.ts`; needs a spec for to-then-bound in both directions before
+  the fix, since none exists today.
 
 - **Rewrite a zero length bound on an array to a real empty tuple at runtime.** The
   type-level half of "a hard-coded length is arity" is done, for the exact
@@ -300,7 +168,6 @@ S.reverse(S.schema({
   what `minLength`/`maxLength` applied *after* the rewrite should do
   (compare against `items.length` and no-op/conflict, not add a redundant
   bound).
-
 
 ### Size bounds and the form-data family
 
@@ -378,12 +245,10 @@ of a form-data story. What they were built to make cheap, roughly in order:
   which is the chain's output, while the value has to be fed to the chain's
   input. JS has no such limit: its `{decode, encode}` pair lands at the chain
   head and the whole chain runs after it. So the runtime is already there and
-  only the ReScript type is missing: `t<'value>` carries one type parameter, so
-  a chain's input type has no name to write. That makes this the same
-  underlying gap as printing an accurate `Schema<'input, 'output>` from
-  ReScript, and a two-parameter `t` would close both. Until then the error
-  message is the API, and chaining `.to` explicitly says exactly what the fused
-  form would have meant.
+  only the ReScript type is missing: `t<'value>` names the output, so a chain's
+  input type has no name to write, and `t` stays single-parameter by decision.
+  The error message is the API, and chaining `.to` explicitly says exactly what
+  the fused form would have meant.
 
 - **A never-slot arm blocks the union's identity shortcut, so encoding a
   default is no longer free.** `unionDecoder` returns the input untouched when
@@ -406,70 +271,33 @@ of a form-data story. What they were built to make cheap, roughly in order:
 
 ### Known bugs left over from the validation refactor (`val.validation: array<validationCheck>`)
 
-- **Union discriminant hoists refinement checks with `&&` instead of `;`.**
-  Now that refinements are structured checks, the union item merge loop
-  hoists all checks on a val via `andJoinChecks`, fusing type checks and
-  refinement checks into one `&&`-joined condition with a single error throw.
-  This causes two problems: (1) `typeof==="string"&&length===N` shares one
-  error instead of separate type/refinement errors, and (2) same-type items
-  with different refinements (e.g. `S.union([S.string->S.email, S.string->S.url])`)
-  lose per-item error messages. Fix: split hoisted checks by `fail` reference —
-  first group (type checks) → discriminant condition, remaining groups
-  (refinement checks) → body code as `cond||fail;`. For same-type items with
-  different refinements, use if/else if dispatch on the refinement cond instead
-  of try/catch. Failing regression tests in `S_union_test.res`.
-- **`noValidation` on a literal inside a union silently breaks dispatch.**
-  `literalDecoder` short-circuits when `expectedSchema.noValidation` is set
-  and emits no check at all, so there's nothing for the union discriminant
-  hoister to lift — that case becomes a catch-all. Fix: either emit the
-  equality check regardless of `noValidation` when the val ends up inside a
-  union, or reject `S.noValidation` on a literal-in-union at schema
-  construction time. Failing regression test: `S_noValidation_test.res ›
-  Union dispatch still works when a case has noValidation`.
-- **`err.received` is wrong for refine-chain vals on type failures.** Because
-  `B.refine` sets `~schema=prev.expected`, `val.schema` on a refined val
-  equals the target schema, and `failInvalidType` reads `val.schema` for
-  `received`. So `err.received === err.expected` on a primitive type failure.
-  User-visible reason text is unaffected (it uses `input->stringify`) but
-  programmatic consumers reading `err.received` get the target schema instead
-  of the source type. Fix: either have the fail function reach through
-  `val.prev.schema` (with a comment on the invariant that validation-owning
-  vals always have a prev) or stop mutating `val.schema` to the target in
-  `refine` and walk the chain differently for "Expected X" messages.
-  FIXME is tagged at `Sury.res:failInvalidType`.
+- **`err.received` is `unknown` for refine-chain vals on type failures.**
+  `S.parser(S.string.with(S.minLength, 2))(1)` reports `expected: string` but
+  `received: unknown` — `failInvalidType` reads the val's own schema, and a
+  refined val's is the refinement's, not the source's. User-visible reason text
+  is unaffected (it uses `input->stringify`), but programmatic consumers
+  reading `err.received` get nothing usable where the unrefined
+  `S.parser(S.string)(1)` reports the input's type. Fix: have the fail function
+  reach through `val.prev.schema` (with a comment on the invariant that
+  validation-owning vals always have a prev).
 
 ### Pre-existing bugs surfaced by the TS-migration review (ported faithfully, fix separately)
 
-- **`exclusiveMaximum` read as `exclusiveMinimum` in the max branches.** Both
-  `toJSONSchema` and `fromJSONSchema` max handling read
-  `jsonSchema.exclusiveMinimum` where they mean `exclusiveMaximum`
-  (`packages/sury/src/jsonschema.ts`, the two max dispatch sites), so
-  exclusive upper bounds round-trip incorrectly.
-- **`S.merge` forces all keys of both objects into `required`.**
-  `merge` (`packages/sury/src/entry.ts`) rebuilds the merged object with
-  every property required, dropping optionality that either side declared.
+- **`required` on an object schema is not what its name says, and no two
+  producers agree.** `S.schema`, `S.object`, `S.shape` and `S.merge` set it to
+  every declared key, optional or not (`S.schema({a: S.optional(S.string)}).required`
+  is `["a"]`); `fromJSONSchema` alone filters to the non-optional keys, and the
+  comment at that producer (`src/jsonschema.ts`) claims the others already do.
+  Parse, inferred types and the emitted JSON Schema are all right
+  (`specs/merge-optional.yaml`) — the emitter recomputes from the properties —
+  so only the introspected field lies, and it is public: the `Schema` type
+  publishes `required?: string[]` on the object variant. `S.merge` has two
+  more docs drifts: it inherits `additionalItems` from its *first* argument
+  where `docs/js-usage.md` says the second, and the docs say shared keys throw
+  where `specs/merge-overwrite.yaml` pins that the second schema's field wins.
 - **ReDoS risk in `fromJSONSchema` patterns.** `new RegExp(jsonSchema.pattern)`
   compiles untrusted patterns directly; a hostile JSON Schema can supply a
   catastrophic-backtracking pattern.
-- **Async output refiners run on the Promise wrapper.** Marked with a TODO in
-  the source: an async transform followed by an output refiner can observe the
-  pending Promise instead of the resolved value in some advanced-decoder
-  paths.
-- **Empty async dict returns a forever-pending Promise.**
-  `S.record` with an async item schema and `{}` input never resolves
-  (`Promise.all` aggregation is skipped for zero keys).
-- **Loop guard message says 100 but triggers at 50.** The recursion guard in
-  `packages/sury/src/parse.ts` throws "Loop count exceeded 100" behind a
-  `> 50` check — align the number (and consider making the limit configurable).
-- **`deepStrip`/`deepStrict` don't descend when a nested schema's
-  `additionalItems` already matches the target mode.**
-  `Object_setAdditionalItems` (`packages/sury/src/operations.ts`) early-returns
-  the schema unchanged whenever `currentAdditionalItems === additionalItems`,
-  which also skips the `deep` recursion into `items`/`properties` — so a
-  nested object whose own mode already matches the top-level target, but whose
-  children don't, is left un-recursed-into. Present verbatim in the original
-  ReScript `Object.setAdditionalItems` (`Sury.res`), carried through the TS
-  migration unchanged.
 - **Homomorphic tuple-mapped types don't map variadic tuple elements.**
   `UnknownArrayToOutput`/`UnknownArrayToInput` (`packages/sury/index.d.ts`)
   guard on `number extends T["length"]` to distinguish tuples from plain
@@ -582,28 +410,21 @@ which is what `packages/sury/specs/<format>.yaml` examples are drawn from.
 ## v11 initial
 
 - Add `s.parseChild` to EffectContext ???
-- Support arrays for `S.to`
+- `S.to` with a raw definition crashes at compile time rather than at
+  creation: `S.json.with(S.to, [S.string, S.number])` and
+  `S.json.with(S.to, {a: S.string})` throw `loopInput.e.decoder is not a
+  function`. Every container accepts inline definitions since rc.1, so `to`
+  should either run `definitionToSchema` on its target or reject a
+  non-schema target with a creation error.
 - Remove fieldOr in favor of optionOr?
-- Allow to pass custom error message via `.with`
-- Make S.to extensible
-- ~~Add S.Date (S.instanceof) and remove S.datetime~~ (S.date added; S.datetime kept for backward compat)
-- Add refinement info to the tagged type
 
 ## v???
 
 - `S.promise: S.t<'value> => S.t<promise<'value>>` and `S.await: S.t<promise<'value>> => S.t<'value>`
 - Remove `S.deepStrict` and `S.deepStrip` in favor of `S.deep` (if it works)
-- Make S.serializeToJsonString super fast
 - Somehow determine whether transformed or not (including shape)
 - Add JSDoc
 - s.optional for object
-- S.transform(s => {
-  s.reverse(input => input) // Or s.asyncReverse(input => Promise.resolve(input))
-  input => input
-  }) // or asyncTransform // Maybe format ?
-- Clean up Caml_option.some, Js_dict.get
-- Github Action: Add linter checking that the generated files are up to date (?)
-- Support optional fields (can have problems with serializing) (???)
 - S.mutateWith/S.produceWith (aka immer) (???)
 - Add S.function (?) (An alternative for external ???)
 
@@ -616,25 +437,14 @@ s.fn(s.arg(0, S.string))
 ```
 
 - Use internal transform for trim
-- Add schema input to the error ??? What about build errors?
-- async serializing support
-- Add S.promise
-- S.create / S.validate
 - Add S.codegen
-- Rename S.inline to S.toRescriptCode + Codegen type + Codegen schema using type
 - Make `error.reason` tree-shakeable
-- S.toJSON/S.castToJson ???
 - S.produce
 - S.mutator
 - Check only number of fields for strict object schema when fields are not optional (bad idea since it's not possible to create a good error message, so we still need to have the loop)
 
 ## `fromJSONSchema` type inference follow-ups
 
-- **Runtime `$defs`/`$ref` resolution** — the static type already resolves
-  local pointers while the runtime parses a `$ref` as plain JSON; the FIXME in
-  `specs/fromjsonschema-recursive-ref.yaml` pins the divergence. Recursive
-  documents need the runtime's recursive-schema machinery (`S_recursive`), so
-  size that first. Closing this deletes the one "type leads runtime" caveat.
 - **Corpus-wide round-trip dimension (phase 3)** — derive a `fromJSONSchema`
   check in the spec harness from each spec's existing `jsonSchema.input`
   golden (~126 cases): pin the inferred type + instantiations next to the
@@ -651,10 +461,6 @@ s.fn(s.arg(0, S.string))
   structure (today `not` is an opaque refinement), and note upstream
   `json-schema-to-ts` gets the `allOf`-sibling variant wrong — pin whatever
   behavior lands in a spec.
-- **`anyOf`/`oneOf` inside `type: "object"`** — the runtime drops them (TODO
-  at the object branch in `src/jsonschema.ts`); the type chain mirrors that.
-  When the runtime TODO lands, add the matching branch to `JSONSchemaResolve`
-  in the same change — the dispatch-order comment binds the two.
 
 ## Articles
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -239,16 +239,21 @@ of a form-data story. What they were built to make cheap, roughly in order:
   number family through the validating seam the way literals already are, then
   measure what it costs.
 
-- **A ReScript codec can't target a schema that already converts.**
-  `s1->S.to(s2WithChain, ~custom)` fails at creation with "The target already
-  converts", because `codecs<'from, 'to>` types the coder against `t<'to>`,
-  which is the chain's output, while the value has to be fed to the chain's
-  input. JS has no such limit: its `{decode, encode}` pair lands at the chain
-  head and the whole chain runs after it. So the runtime is already there and
-  only the ReScript type is missing: `t<'value>` names the output, so a chain's
-  input type has no name to write, and `t` stays single-parameter by decision.
-  The error message is the API, and chaining `.to` explicitly says exactly what
-  the fused form would have meant.
+- **A ReScript `Sync`/`Async` coder can't target a schema that already
+  converts.** `s1->S.to(s2WithChain, ~custom={decode: Sync(fn), ...})` fails at
+  creation with "The target already converts", because `codecs<'from, 'to>`
+  types the coder against `t<'to>`, which is the chain's output, while the
+  value has to be fed to the chain's input. The slots that place no coder are
+  exempt — `Auto`, `Never`, and the `Pack`/`Unpack` readings
+  (`tests/S_to_custom_test.res` carries `S.uint8Array->S.to(S.jsonString->S.to(S.string),
+  ~custom={decode: Unpack, encode: Pack})`), the guard is the `outputSeam`
+  branch of `to` in `src/entry.ts`. JS has no such limit: its `{decode,
+  encode}` pair lands at the chain head and the whole chain runs after it. So
+  the runtime is already there and only the ReScript type is missing:
+  `t<'value>` names the output, so a chain's input type has no name to write,
+  and `t` stays single-parameter by decision. The error message is the API,
+  and chaining `.to` explicitly says exactly what the fused form would have
+  meant.
 
 - **A never-slot arm blocks the union's identity shortcut, so encoding a
   default is no longer free.** `unionDecoder` returns the input untouched when


### PR DESCRIPTION
Remove entries from IDEAS.md that have been resolved, superseded, or are no longer relevant to the project roadmap.

## Summary

This is a documentation cleanup that removes ~200 lines of outdated ideas and known issues from IDEAS.md. The changes reflect work that has been completed, issues that have been fixed, or design decisions that have been made and are no longer open questions.

## Changes

- **Removed completed base64/uint8Array encoding work**: The detailed multi-part idea about making `S.uint8Array` encode as base64, adding `S.base64` and `S.utf8` schemas, and the layering discussion around these changes. This work has been completed and is no longer an open design question.

- **Removed obsolete union compiler issues**: Several known bugs related to union discriminant hoisting, `noValidation` on literals in unions, and error reporting in refine chains have been removed. These have either been fixed or superseded by the validation refactor.

- **Simplified bound-after-transform issue**: Replaced the detailed description of the transform-then-bound bug with a more concise entry noting that bounds after `S.to` now panic at creation time (the correct behavior), and that the transform-then-bound case is fixed.

- **Removed pre-existing bugs that were fixed**: Deleted entries for `exclusiveMaximum` read as `exclusiveMinimum`, `S.merge` forcing all keys to required, async output refiner issues, empty async dict promises, loop guard message misalignment, and `deepStrip`/`deepStrict` recursion issues.

- **Cleaned up v11 initial section**: Removed completed items and simplified remaining entries.

- **Removed resolved `fromJSONSchema` issues**: Deleted the detailed idea about building schemas through proxy context, which has been addressed.

- **Simplified ReScript type parameter discussion**: Condensed the explanation of why `t<'value>` remains single-parameter.

- **Removed obsolete `fromJSONSchema` follow-ups**: Deleted entries about `$defs`/`$ref` resolution and `anyOf`/`oneOf` inside objects that are no longer open questions.

## Notes

All removals are from the IDEAS.md file only—no source code changes. This cleanup reflects the current state of the project and removes noise from the roadmap to make remaining open issues more visible.

https://claude.ai/code/session_01KNnFLvhXXKxFQ8foQDgk8s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised the project roadmap to clarify priorities for UTF-8 JSON string conversion, post-conversion bounds handling, error metadata, raw schema definitions, and JSON Schema inference.
  * Refined documentation of ReScript custom-codec limitations, including supported conversion scenarios.
  * Removed or replaced outdated investigations, proposed fixes, and future API items to reflect the current roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->