### PR TITLE
Collapse the .with overloads and type refine's path as Path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,6 @@ base → builder → primitives → parse → union → composites → factory
 - Write bit-flag literals, not named `const`s — esbuild won't inline them, so the
   name costs bytes at every use. Document the values in a comment.
 - Every schema must be reversible (Input ↔ Output) unless explicitly opted out.
-- `Schema.with` gets an overload per *shape* of call, not per arity. Every
-  `.with` call pays for each overload it reaches past, and the specs'
-  `ts.instantiations` is the gate — measure a subset before adding one.
 - Name anything esbuild emits `index.*`. `S.*` belongs to the ReScript compiler,
   which overwrites whatever sits where its output lands.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,9 @@ base → builder → primitives → parse → union → composites → factory
 - Write bit-flag literals, not named `const`s — esbuild won't inline them, so the
   name costs bytes at every use. Document the values in a comment.
 - Every schema must be reversible (Input ↔ Output) unless explicitly opted out.
+- `Schema.with` gets an overload per *shape* of call, not per arity. Every
+  `.with` call pays for each overload it reaches past, and the specs'
+  `ts.instantiations` is the gate — measure a subset before adding one.
 - Name anything esbuild emits `index.*`. `S.*` belongs to the ReScript compiler,
   which overwrites whatever sits where its output lands.
 

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -1350,7 +1350,7 @@ const shortStringSchema = S.string.with(S.refine, (value) => value.length <= 255
 
 #### Custom error path
 
-When refining an object schema, you can use the `path` option to attach the error to a specific field:
+When refining an object schema, you can use the `path` option to attach the error to a specific field. It is the same array `error.path` carries: strings for keys and numbers for array indices, so `["items", 0]` reports `Failed at items[0]`:
 
 ```ts
 const passwordFormSchema = S.schema({

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1470,7 +1470,7 @@ S.parseOrThrow(%raw(`[1, 2, 3]`), ~to=intSetSchema) // throws S.Error: Expected 
 
 ### **`refine`**
 
-`(S.t<'value>, 'value => bool, ~error: string=?, ~path: array<string>=?) => S.t<'value>`
+`(S.t<'value>, 'value => bool, ~error: string=?, ~path: S.Path.t=?) => S.t<'value>`
 
 ```rescript
 let positiveNumberSchema = S.int->S.refine(value => value > 0)
@@ -1491,7 +1491,7 @@ let shortStringSchema = S.string->S.refine(
 
 #### Custom error path
 
-When refining an object schema, you can use the `~path` labeled argument to attach the error to a specific field:
+When refining an object schema, you can use the `~path` labeled argument to attach the error to a specific field. It is an `S.Path.t`, the same array `error.path` carries: `String` segments for keys and `Number` ones for array indices, so `[String("items"), Number(0.)]` reports `Failed at items[0]`:
 
 ```rescript
 let passwordFormSchema = S.object(s => {
@@ -1500,7 +1500,7 @@ let passwordFormSchema = S.object(s => {
 })->S.refine(
   data => data["password"] === data["confirm"],
   ~error="Passwords don't match",
-  ~path=["confirm"],
+  ~path=S.Path.fromArray(["confirm"]),
 )
 ```
 

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -71,11 +71,11 @@ export type Schema<TInput = unknown, TOutput = TInput> = {
     // the same reason as the Codecs slots (see the Coder note below).
     codecs?: Coder<TOutput, TTargetInput> | Codecs<TOutput, TTargetInput> | "pack" | "unpack"
   ): Schema<TInput, TTargetOutput>;
-  // The callback sits in parameter position so the arrow is contextually
-  // typed with `TOutput`; through the rest-tuple overload it would be
-  // inferred before the arrow is checked. The required third parameter keeps
-  // `S.optional`/`S.nullable` out — their lazy default `() => TOr` would match
-  // `callback` and lose the absent case — via the `_?: never` both declare.
+  // `S.shape`, and any modifier whose callback decides the output type.
+  // Naming the callback here is what types its parameter as `TOutput`. The
+  // required third parameter excludes `S.optional`/`S.nullable`: a lazy
+  // default `() => value` is not a shaper, and the trailing `_?: never` they
+  // declare is what fails this overload so they resolve below instead.
   with<TShape>(
     fn: (
       schema: Schema<unknown, unknown>,
@@ -84,22 +84,22 @@ export type Schema<TInput = unknown, TOutput = TInput> = {
     ) => Schema<unknown, unknown>,
     callback: (value: TOutput) => TShape
   ): Schema<TInput, TShape>;
-  // Zero and one argument have their own overloads: the rest tuple below
-  // costs a simple schema most of its type budget per call (CLAUDE.md).
+  // No argument and one argument each get a dedicated overload: TypeScript
+  // resolves them far cheaper than the rest-tuple form below.
   with<TNextInput, TNextOutput>(
     fn: (schema: Schema<TInput, TOutput>) => SchemaLike<TNextInput, TNextOutput>
   ): Schema<TNextInput, TNextOutput>;
-  // The constraint is every value, spelled so a literal stays literal —
-  // `.with(S.brand, "myId")`, `.with(S.length, 2)`. With a bare result type
-  // parameter instead of the structured return, the constraint stops this
-  // overload matching a generic modifier at all.
+  // Accepts any value while keeping a literal literal, so `.with(S.brand,
+  // "myId")` brands with `"myId"` and `.with(S.length, 2)` infers a 2-tuple.
+  // The `SchemaLike` return is required: with a plain type parameter as the
+  // result, generic modifiers stop matching this overload.
   with<TNextInput, TNextOutput, TArg1 extends {} | null | undefined>(
     fn: (schema: Schema<TInput, TOutput>, arg1: TArg1) => SchemaLike<TNextInput, TNextOutput>,
     arg1: TArg1
   ): Schema<TNextInput, TNextOutput>;
-  // A rest tuple, not `(fn, arg1, arg2)`: it is inferred from `fn`'s own
-  // parameter list first, which is what keeps `v` typed in
-  // `.with(S.refine, (v) => …, { error })`.
+  // Two or more arguments. A rest tuple rather than one type parameter per
+  // argument: TypeScript infers it from `fn`'s parameters, which is what keeps
+  // `value` typed in `.with(S.refine, (value) => …, { error })`.
   with<TNextInput, TNextOutput, TArgs extends readonly unknown[]>(
     fn: (schema: Schema<TInput, TOutput>, ...args: TArgs) => SchemaLike<TNextInput, TNextOutput>,
     ...args: TArgs
@@ -845,7 +845,8 @@ export function optional<
 >(
   schema: SchemaLike<TInput, TOutput> | TDef,
   or?: (() => TOr) | TOr,
-  // Keeps the lazy form off `with`'s callback overload.
+  // Never passed: fails `with`'s callback overload, so a lazy default is
+  // not typed as a shaper.
   _?: never
 ): Schema<
   TInput | undefined,
@@ -860,7 +861,8 @@ export function nullable<
 >(
   schema: SchemaLike<TInput, TOutput> | TDef,
   or?: (() => TOr) | TOr,
-  // Keeps the lazy form off `with`'s callback overload.
+  // Never passed: fails `with`'s callback overload, so a lazy default is
+  // not typed as a shaper.
   _?: never
 ): Schema<TInput | null, TOr extends null ? TOutput | null : TOutput>;
 

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -1021,7 +1021,7 @@ export function refine<TInput, TOutput>(
   refineCheck: (value: TOutput) => boolean,
   refineOptions?: {
     error?: string;
-    path?: string[];
+    path?: Path;
   }
 ): Schema<TInput, TOutput>;
 

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -71,14 +71,11 @@ export type Schema<TInput = unknown, TOutput = TInput> = {
     // the same reason as the Codecs slots (see the Coder note below).
     codecs?: Coder<TOutput, TTargetInput> | Codecs<TOutput, TTargetInput> | "pack" | "unpack"
   ): Schema<TInput, TTargetOutput>;
-  // A modifier whose callback decides the output type — `S.shape`'s shaper.
-  // The callback has to sit in parameter position for the arrow to be
-  // contextually typed with `TOutput`; through the rest-tuple overload below
-  // it would be inferred before the arrow is checked and its parameter would
-  // land as `unknown`. The required third parameter is the discriminator that
-  // keeps `S.optional`/`S.nullable` out: their lazy default `() => TOr` would
-  // otherwise match `callback` and lose the absent case, so both declare a
-  // trailing `_?: never` that this `unknown` cannot satisfy.
+  // The callback sits in parameter position so the arrow is contextually
+  // typed with `TOutput`; through the rest-tuple overload it would be
+  // inferred before the arrow is checked. The required third parameter keeps
+  // `S.optional`/`S.nullable` out — their lazy default `() => TOr` would match
+  // `callback` and lose the absent case — via the `_?: never` both declare.
   with<TShape>(
     fn: (
       schema: Schema<unknown, unknown>,
@@ -87,29 +84,22 @@ export type Schema<TInput = unknown, TOutput = TInput> = {
     ) => Schema<unknown, unknown>,
     callback: (value: TOutput) => TShape
   ): Schema<TInput, TShape>;
-  // The two common arities get their own overload; routing either through the
-  // rest-tuple one below measured ~2 500 instantiations more per call, which
-  // is most of a simple schema's whole type cost. Every overload here is paid
-  // by each `.with` call that reaches past it, so no further arity is spelled
-  // out — two or more arguments share the rest-tuple overload.
+  // Zero and one argument have their own overloads: the rest tuple below
+  // costs a simple schema most of its type budget per call (CLAUDE.md).
   with<TNextInput, TNextOutput>(
     fn: (schema: Schema<TInput, TOutput>) => SchemaLike<TNextInput, TNextOutput>
   ): Schema<TNextInput, TNextOutput>;
-  // The constraint keeps a literal argument literal — `.with(S.brand, "myId")`
-  // needs the string literal for nominal typing, `.with(S.length, 2)` the
-  // number literal for its tuple-typed result — and `{} | null | undefined`
-  // is every value, so nothing falls through on it. The structured return is
-  // load-bearing: with a bare result type parameter the constraint stops the
+  // The constraint is every value, spelled so a literal stays literal —
+  // `.with(S.brand, "myId")`, `.with(S.length, 2)`. With a bare result type
+  // parameter instead of the structured return, the constraint stops this
   // overload matching a generic modifier at all.
   with<TNextInput, TNextOutput, TArg1 extends {} | null | undefined>(
     fn: (schema: Schema<TInput, TOutput>, arg1: TArg1) => SchemaLike<TNextInput, TNextOutput>,
     arg1: TArg1
   ): Schema<TNextInput, TNextOutput>;
-  // `s.with(fn, ...args)` is `fn(s, ...args)`, typed as such. A rest tuple
-  // rather than `(fn, arg1, arg2)`: the tuple is inferred from `fn`'s own
-  // parameter list first, which is what keeps a callback argument
-  // contextually typed — `.with(S.refine, (v) => …, { error })` gets `v` from
-  // `refine`'s signature, where a per-position type parameter left it `any`.
+  // A rest tuple, not `(fn, arg1, arg2)`: it is inferred from `fn`'s own
+  // parameter list first, which is what keeps `v` typed in
+  // `.with(S.refine, (v) => …, { error })`.
   with<TNextInput, TNextOutput, TArgs extends readonly unknown[]>(
     fn: (schema: Schema<TInput, TOutput>, ...args: TArgs) => SchemaLike<TNextInput, TNextOutput>,
     ...args: TArgs
@@ -855,7 +845,7 @@ export function optional<
 >(
   schema: SchemaLike<TInput, TOutput> | TDef,
   or?: (() => TOr) | TOr,
-  // Keeps the lazy form off `with`'s callback overload — see the note there.
+  // Keeps the lazy form off `with`'s callback overload.
   _?: never
 ): Schema<
   TInput | undefined,
@@ -870,7 +860,7 @@ export function nullable<
 >(
   schema: SchemaLike<TInput, TOutput> | TDef,
   or?: (() => TOr) | TOr,
-  // Keeps the lazy form off `with`'s callback overload — see the note there.
+  // Keeps the lazy form off `with`'s callback overload.
   _?: never
 ): Schema<TInput | null, TOr extends null ? TOutput | null : TOutput>;
 

--- a/packages/sury/index.d.ts
+++ b/packages/sury/index.d.ts
@@ -71,64 +71,48 @@ export type Schema<TInput = unknown, TOutput = TInput> = {
     // the same reason as the Codecs slots (see the Coder note below).
     codecs?: Coder<TOutput, TTargetInput> | Codecs<TOutput, TTargetInput> | "pack" | "unpack"
   ): Schema<TInput, TTargetOutput>;
-  with(
-    refine: (
-      schema: Schema<unknown, unknown>,
-      refineCheck: (value: unknown) => boolean,
-      refineOptions?: { error?: string; path?: string[] }
-    ) => Schema<unknown, unknown>,
-    refineCheck: (value: TOutput) => boolean,
-    refineOptions?: { error?: string; path?: string[] }
-  ): Schema<TInput, TOutput>;
-  // This overload is what both S.refine and S.shape resolve to under
-  // overload matching — the exact mechanism that routes S.refine calls here
-  // instead of the more specific `refine` overload above hasn't been pinned
-  // down. Treat it as load-bearing for both call sites and verify against
-  // S_refine_test.res / S_shape_test.res before changing its shape.
-  //
-  // FIXME: it also swallows every other `.with(fn, callback)`, since a
-  // function argument matches nothing more specific first. `.with(S.optional,
-  // () => …)` infers TShape as the callback's return type and loses the absent
-  // case, so the lazy default has to be called directly to type correctly.
+  // A modifier whose callback decides the output type — `S.shape`'s shaper.
+  // The callback has to sit in parameter position for the arrow to be
+  // contextually typed with `TOutput`; through the rest-tuple overload below
+  // it would be inferred before the arrow is checked and its parameter would
+  // land as `unknown`. The required third parameter is the discriminator that
+  // keeps `S.optional`/`S.nullable` out: their lazy default `() => TOr` would
+  // otherwise match `callback` and lose the absent case, so both declare a
+  // trailing `_?: never` that this `unknown` cannot satisfy.
   with<TShape>(
     fn: (
       schema: Schema<unknown, unknown>,
-      callback: ((value: unknown) => unknown) | undefined
+      callback: (value: unknown) => unknown,
+      _: unknown
     ) => Schema<unknown, unknown>,
-    callback: ((value: TOutput) => TShape) | undefined
+    callback: (value: TOutput) => TShape
   ): Schema<TInput, TShape>;
+  // The two common arities get their own overload; routing either through the
+  // rest-tuple one below measured ~2 500 instantiations more per call, which
+  // is most of a simple schema's whole type cost. Every overload here is paid
+  // by each `.with` call that reaches past it, so no further arity is spelled
+  // out — two or more arguments share the rest-tuple overload.
   with<TNextInput, TNextOutput>(
     fn: (schema: Schema<TInput, TOutput>) => SchemaLike<TNextInput, TNextOutput>
   ): Schema<TNextInput, TNextOutput>;
-  // Constraining TArg1 to string | number makes a literal arg1 infer its
-  // literal type instead of widening — `.with(S.brand, "myId")` needs the
-  // string literal for nominal typing, `.with(S.length, 2)` the number
-  // literal for its tuple-typed result. One overload for both: a second
-  // overload would be attempted (and instantiated) by every `.with` call
-  // that falls through to the general case, taxing schemas that never pass
-  // a literal. The next overload covers the general arg1 case.
-  with<TNextInput, TNextOutput, TArg1 extends string | number>(
-    fn: (
-      schema: Schema<TInput, TOutput>,
-      arg1: TArg1
-    ) => SchemaLike<TNextInput, TNextOutput>,
+  // The constraint keeps a literal argument literal — `.with(S.brand, "myId")`
+  // needs the string literal for nominal typing, `.with(S.length, 2)` the
+  // number literal for its tuple-typed result — and `{} | null | undefined`
+  // is every value, so nothing falls through on it. The structured return is
+  // load-bearing: with a bare result type parameter the constraint stops the
+  // overload matching a generic modifier at all.
+  with<TNextInput, TNextOutput, TArg1 extends {} | null | undefined>(
+    fn: (schema: Schema<TInput, TOutput>, arg1: TArg1) => SchemaLike<TNextInput, TNextOutput>,
     arg1: TArg1
   ): Schema<TNextInput, TNextOutput>;
-  with<TNextInput, TNextOutput, TArg1>(
-    fn: (
-      schema: Schema<TInput, TOutput>,
-      arg1: TArg1
-    ) => SchemaLike<TNextInput, TNextOutput>,
-    arg1: TArg1
-  ): Schema<TNextInput, TNextOutput>;
-  with<TNextInput, TNextOutput, TArg1, TArg2>(
-    fn: (
-      schema: Schema<TInput, TOutput>,
-      arg1: TArg1,
-      arg2: TArg2
-    ) => SchemaLike<TNextInput, TNextOutput>,
-    arg1: TArg1,
-    arg2: TArg2
+  // `s.with(fn, ...args)` is `fn(s, ...args)`, typed as such. A rest tuple
+  // rather than `(fn, arg1, arg2)`: the tuple is inferred from `fn`'s own
+  // parameter list first, which is what keeps a callback argument
+  // contextually typed — `.with(S.refine, (v) => …, { error })` gets `v` from
+  // `refine`'s signature, where a per-position type parameter left it `any`.
+  with<TNextInput, TNextOutput, TArgs extends readonly unknown[]>(
+    fn: (schema: Schema<TInput, TOutput>, ...args: TArgs) => SchemaLike<TNextInput, TNextOutput>,
+    ...args: TArgs
   ): Schema<TNextInput, TNextOutput>;
 
   /**
@@ -871,7 +855,7 @@ export function optional<
 >(
   schema: SchemaLike<TInput, TOutput> | TDef,
   or?: (() => TOr) | TOr,
-  // To make .with work
+  // Keeps the lazy form off `with`'s callback overload — see the note there.
   _?: never
 ): Schema<
   TInput | undefined,
@@ -886,7 +870,7 @@ export function nullable<
 >(
   schema: SchemaLike<TInput, TOutput> | TDef,
   or?: (() => TOr) | TOr,
-  // To make .with work
+  // Keeps the lazy form off `with`'s callback overload — see the note there.
   _?: never
 ): Schema<TInput | null, TOr extends null ? TOutput | null : TOutput>;
 

--- a/packages/sury/specs/array-empty.yaml
+++ b/packages/sury/specs/array-empty.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.length, 0)
   input: "[]"
   output: "[]"
-  instantiations: 1034
+  instantiations: 1030
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array", minItems: 0, maxItems: 0 }'
   output: '{ items: { type: "string" }, type: "array", minItems: 0, maxItems: 0 }'

--- a/packages/sury/specs/array-length-range.yaml
+++ b/packages/sury/specs/array-length-range.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.minLength, 1).with(S.maxLength, 2)
   input: "[string, ...string[]]"
   output: "[string, ...string[]]"
-  instantiations: 1396
+  instantiations: 1388
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array", minItems: 1, maxItems: 2 }'
   fromInputType: string[]

--- a/packages/sury/specs/array-length.yaml
+++ b/packages/sury/specs/array-length.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.length, 2)
   input: "[string, string]"
   output: "[string, string]"
-  instantiations: 1079
+  instantiations: 1075
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array", minItems: 2, maxItems: 2 }'
   output: '{ items: { type: "string" }, type: "array", minItems: 2, maxItems: 2 }'

--- a/packages/sury/specs/array-maxLength.yaml
+++ b/packages/sury/specs/array-maxLength.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.maxLength, 2)
   input: string[]
   output: string[]
-  instantiations: 749
+  instantiations: 745
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array", maxItems: 2 }'
   output: '{ items: { type: "string" }, type: "array", maxItems: 2 }'

--- a/packages/sury/specs/array-minLength.yaml
+++ b/packages/sury/specs/array-minLength.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.minLength, 2)
   input: "[string, string, ...string[]]"
   output: "[string, string, ...string[]]"
-  instantiations: 1125
+  instantiations: 1121
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array", minItems: 2 }'
   fromInputType: string[]

--- a/packages/sury/specs/array-multipleOf.yaml
+++ b/packages/sury/specs/array-multipleOf.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.number.with(S.multipleOf, 2))
   input: number[]
   output: number[]
-  instantiations: 1097
+  instantiations: 1041
 jsonSchema:
   input: '{ items: { type: "number", multipleOf: 2 }, type: "array" }'
   output: '{ items: { type: "number", multipleOf: 2 }, type: "array" }'

--- a/packages/sury/specs/array-nonEmpty.yaml
+++ b/packages/sury/specs/array-nonEmpty.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.nonEmpty)
   input: "[string, ...string[]]"
   output: "[string, ...string[]]"
-  instantiations: 872
+  instantiations: 870
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array", minItems: 1 }'
   fromInputType: string[]

--- a/packages/sury/specs/async-assert.yaml
+++ b/packages/sury/specs/async-assert.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.string, { decode: { async: async (value) => { if (value === "bad") { throw new Error("rejected") } return value } }, encode: "auto" })'
   input: string
   output: string
-  instantiations: 5265
+  instantiations: 4451
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/bigint-gt.yaml
+++ b/packages/sury/specs/bigint-gt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.bigint.with(S.gt, 5n)
   input: bigint
   output: bigint
-  instantiations: 601
+  instantiations: 578
 jsonSchema:
   input: Expected JSON, received bigint > 5n
   output: Expected JSON, received bigint > 5n

--- a/packages/sury/specs/bigint-gte.yaml
+++ b/packages/sury/specs/bigint-gte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.bigint.with(S.gte, 5n)
   input: bigint
   output: bigint
-  instantiations: 601
+  instantiations: 578
 jsonSchema:
   input: Expected JSON, received bigint >= 5n
   output: Expected JSON, received bigint >= 5n

--- a/packages/sury/specs/bigint-lt.yaml
+++ b/packages/sury/specs/bigint-lt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.bigint.with(S.lt, 5n)
   input: bigint
   output: bigint
-  instantiations: 601
+  instantiations: 578
 jsonSchema:
   input: Expected JSON, received bigint < 5n
   output: Expected JSON, received bigint < 5n

--- a/packages/sury/specs/bigint-lte.yaml
+++ b/packages/sury/specs/bigint-lte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.bigint.with(S.lte, 5n)
   input: bigint
   output: bigint
-  instantiations: 601
+  instantiations: 578
 jsonSchema:
   input: Expected JSON, received bigint <= 5n
   output: Expected JSON, received bigint <= 5n

--- a/packages/sury/specs/bigint-multipleOf.yaml
+++ b/packages/sury/specs/bigint-multipleOf.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.bigint.with(S.multipleOf, 2n)
   input: bigint
   output: bigint
-  instantiations: 601
+  instantiations: 578
 jsonSchema:
   input: Expected JSON, received bigint % 2n
   output: Expected JSON, received bigint % 2n

--- a/packages/sury/specs/blob-size.yaml
+++ b/packages/sury/specs/blob-size.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.blob.with(S.size, 2)
   input: Blob
   output: Blob
-  instantiations: 596
+  instantiations: 592
 jsonSchema:
   input: Expected JSON, received Blob.size == 2
   output: Expected JSON, received Blob.size == 2

--- a/packages/sury/specs/codec-array-bigint-string.yaml
+++ b/packages/sury/specs/codec-array-bigint-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.bigint).with(S.to, S.array(S.string))
   input: bigint[]
   output: string[]
-  instantiations: 5551
+  instantiations: 4737
 jsonSchema:
   input: "Failed at []: Expected JSON, received bigint"
   output: '{ items: { type: "string" }, type: "array" }'

--- a/packages/sury/specs/codec-array-length.yaml
+++ b/packages/sury/specs/codec-array-length.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.to(S.array(S.string), S.array(S.unknown)).with(S.length, 2)
   input: string[]
   output: "[unknown, unknown]"
-  instantiations: 1418
+  instantiations: 1414
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array" }'
   output: "Failed at []: Expected JSON, received unknown"

--- a/packages/sury/specs/codec-array-never-jsonstring.yaml
+++ b/packages/sury/specs/codec-array-never-jsonstring.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.never).with(S.to, S.jsonString)
   input: never[]
   output: string
-  instantiations: 5398
+  instantiations: 4584
 jsonSchema:
   input: '{ items: { not: {} }, type: "array" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-array-never-uint8array.yaml
+++ b/packages/sury/specs/codec-array-never-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.never).with(S.to, S.array(S.uint8Array))
   input: never[]
   output: Uint8Array<ArrayBufferLike>[]
-  instantiations: 5551
+  instantiations: 4737
 jsonSchema:
   input: '{ items: { not: {} }, type: "array" }'
   output: "Failed at []: Expected JSON, received Uint8Array"

--- a/packages/sury/specs/codec-base64-base64url.yaml
+++ b/packages/sury/specs/codec-base64-base64url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.to, S.base64url)
   input: string
   output: string
-  instantiations: 5175
+  instantiations: 4361
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: '{ type: "string", contentEncoding: "base64url" }'

--- a/packages/sury/specs/codec-base64-file.yaml
+++ b/packages/sury/specs/codec-base64-file.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.to, S.file)
   input: string
   output: File
-  instantiations: 5245
+  instantiations: 4431
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64", contentMediaType: "application/octet-stream" }'
   output: Expected JSON, received File

--- a/packages/sury/specs/codec-base64-jsonstring-ambiguous.yaml
+++ b/packages/sury/specs/codec-base64-jsonstring-ambiguous.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.to, S.jsonString)
   input: string
   output: string
-  instantiations: 5175
+  instantiations: 4361
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-base64-jsonstring-payload.yaml
+++ b/packages/sury/specs/codec-base64-jsonstring-payload.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.base64.with(S.to, S.jsonString.with(S.to, S.schema({ sub: S.string })))"
   input: string
   output: "{ sub: string; }"
-  instantiations: 6557
+  instantiations: 5712
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: '{ type: "object", properties: { sub: { type: "string" } }, required: ["sub"] }'

--- a/packages/sury/specs/codec-base64-string.yaml
+++ b/packages/sury/specs/codec-base64-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.to, S.string)
   input: string
   output: string
-  instantiations: 5175
+  instantiations: 4361
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: '{ type: "string", contentEncoding: "base64" }'

--- a/packages/sury/specs/codec-base64-trim-base64url.yaml
+++ b/packages/sury/specs/codec-base64-trim-base64url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.trim).with(S.to, S.base64url)
   input: string
   output: string
-  instantiations: 5409
+  instantiations: 4593
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: '{ type: "string", contentEncoding: "base64url" }'

--- a/packages/sury/specs/codec-base64-trim-jsonstring-ambiguous.yaml
+++ b/packages/sury/specs/codec-base64-trim-jsonstring-ambiguous.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.trim).with(S.to, S.jsonString)
   input: string
   output: string
-  instantiations: 5409
+  instantiations: 4593
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-base64-trim-uint8array.yaml
+++ b/packages/sury/specs/codec-base64-trim-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.trim).with(S.to, S.uint8Array)
   input: string
   output: Uint8Array<ArrayBufferLike>
-  instantiations: 5509
+  instantiations: 4693
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: Expected JSON, received Uint8Array

--- a/packages/sury/specs/codec-base64-uint8array.yaml
+++ b/packages/sury/specs/codec-base64-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.base64.with(S.to, S.uint8Array)
   input: string
   output: Uint8Array<ArrayBufferLike>
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64" }'
   output: Expected JSON, received Uint8Array

--- a/packages/sury/specs/codec-base64url-jsonstring-payload.yaml
+++ b/packages/sury/specs/codec-base64url-jsonstring-payload.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.base64url.with(S.to, S.jsonString.with(S.to, S.schema({ sub: S.string })))"
   input: string
   output: "{ sub: string; }"
-  instantiations: 6557
+  instantiations: 5712
 jsonSchema:
   input: '{ type: "string", contentEncoding: "base64url" }'
   output: '{ type: "object", properties: { sub: { type: "string" } }, required: ["sub"] }'

--- a/packages/sury/specs/codec-bool-number-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-number-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.boolean.with(S.to, S.number)
   input: boolean
   output: number
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "boolean" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-bool-union2-all-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-union2-all-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.boolean.with(S.to, S.union([S.number, S.symbol]))
   input: boolean
   output: number | symbol
-  instantiations: 6208
+  instantiations: 5394
 jsonSchema:
   input: '{ type: "boolean" }'
   output: Expected JSON, received number | symbol

--- a/packages/sury/specs/codec-bool-union2-unsupported.yaml
+++ b/packages/sury/specs/codec-bool-union2-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.boolean.with(S.to, S.union([S.string, S.symbol]))
   input: boolean
   output: string | symbol
-  instantiations: 6208
+  instantiations: 5394
 jsonSchema:
   input: '{ type: "boolean" }'
   output: Expected JSON, received string | symbol

--- a/packages/sury/specs/codec-custom-any-union.yaml
+++ b/packages/sury/specs/codec-custom-any-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.union([S.string.with(S.to, S.any, { decode: (value) => value.length, encode: (value) => String(value) }), S.boolean])"
   input: string | boolean
   output: any
-  instantiations: 6177
+  instantiations: 5332
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "boolean" }] }'
   output: Expected JSON, received unknown | boolean

--- a/packages/sury/specs/codec-custom-any.yaml
+++ b/packages/sury/specs/codec-custom-any.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.string.with(S.to, S.any, { decode: (value) => value.length, encode: (value) => String(value) })"
   input: string
   output: any
-  instantiations: 5309
+  instantiations: 4495
 jsonSchema:
   input: '{ type: "string" }'
   output: Expected JSON, received unknown

--- a/packages/sury/specs/codec-custom-async-decode.yaml
+++ b/packages/sury/specs/codec-custom-async-decode.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.number, { decode: { async: (value) => Promise.resolve(value.length) }, encode: (value) => "x".repeat(value) })'
   input: string
   output: number
-  instantiations: 5367
+  instantiations: 4553
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-custom-async-encode.yaml
+++ b/packages/sury/specs/codec-custom-async-encode.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.number, { decode: (value) => value.length, encode: { async: (value) => Promise.resolve("x".repeat(value)) } })'
   input: string
   output: number
-  instantiations: 5365
+  instantiations: 4551
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-custom-async-union.yaml
+++ b/packages/sury/specs/codec-custom-async-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.string.with(S.to, S.number, { decode: { async: (value) => Promise.resolve(value.length) }, encode: (value) => "x".repeat(value) }), S.number])'
   input: string | number
   output: number
-  instantiations: 6173
+  instantiations: 5328
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "number" }] }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-custom-chained-input.yaml
+++ b/packages/sury/specs/codec-custom-chained-input.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.string.with(S.to, S.json, { decode: (value) => JSON.parse(value), encode: (value) => JSON.stringify(value) }).with(S.to, S.schema({ id: S.number }))"
   input: string
   output: "{ id: number; }"
-  instantiations: 6595
+  instantiations: 5781
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "object", properties: { id: { type: "number" } }, required: ["id"] }'

--- a/packages/sury/specs/codec-custom-mixed-auto-any.yaml
+++ b/packages/sury/specs/codec-custom-mixed-auto-any.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.any.with(S.to, S.number, { decode: "auto", encode: (value) => value })'
   input: any
   output: number
-  instantiations: 5304
+  instantiations: 4490
 jsonSchema:
   input: Expected JSON, received unknown
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-custom-mixed-auto.yaml
+++ b/packages/sury/specs/codec-custom-mixed-auto.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.string, { decode: (value) => value.trim(), encode: "auto" })'
   input: string
   output: string
-  instantiations: 5245
+  instantiations: 4431
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-custom-never-union.yaml
+++ b/packages/sury/specs/codec-custom-never-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.string, S.schema(undefined).with(S.to, S.string, { decode: () => "anonymous", encode: "never" })])'
   input: string | undefined
   output: string
-  instantiations: 6228
+  instantiations: 5383
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-custom-never.yaml
+++ b/packages/sury/specs/codec-custom-never.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.number, { decode: "never", encode: (value) => String(value) })'
   input: string
   output: number
-  instantiations: 5304
+  instantiations: 4490
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-custom-pair.yaml
+++ b/packages/sury/specs/codec-custom-pair.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.number.with(S.gt, 0), { decode: (value) => value.length, encode: (value) => "x".repeat(value) })'
   input: string
   output: number
-  instantiations: 5842
+  instantiations: 4993
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number", exclusiveMinimum: 0 }'

--- a/packages/sury/specs/codec-custom-shorthand-union.yaml
+++ b/packages/sury/specs/codec-custom-shorthand-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.to, S.number, (value) => Number(value)), S.number])
   input: string | number
   output: number
-  instantiations: 6072
+  instantiations: 5227
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "number" }] }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-custom-shorthand.yaml
+++ b/packages/sury/specs/codec-custom-shorthand.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.number, (value) => Number(value))
   input: string
   output: number
-  instantiations: 5266
+  instantiations: 4452
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-email-string.yaml
+++ b/packages/sury/specs/codec-email-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.email.with(S.to, S.string)
   input: string
   output: string
-  instantiations: 5175
+  instantiations: 4361
 jsonSchema:
   # FIXME: widening a string format overflows the stack —
   # `internalToJSONSchema` encode-reverses a schema that has `.to`, and the

--- a/packages/sury/specs/codec-email-uint8array.yaml
+++ b/packages/sury/specs/codec-email-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.email.with(S.to, S.uint8Array)
   input: string
   output: Uint8Array<ArrayBufferLike>
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string" }'
   output: Expected JSON, received Uint8Array

--- a/packages/sury/specs/codec-file-blob.yaml
+++ b/packages/sury/specs/codec-file-blob.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.to, S.blob)
   input: File
   output: Blob
-  instantiations: 5256
+  instantiations: 4442
 jsonSchema:
   input: Expected JSON, received File
   output: Expected JSON, received Blob

--- a/packages/sury/specs/codec-file-jsonstring-ambiguous.yaml
+++ b/packages/sury/specs/codec-file-jsonstring-ambiguous.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.to, S.jsonString)
   input: File
   output: string
-  instantiations: 5245
+  instantiations: 4431
 jsonSchema:
   input: Expected JSON, received File
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-file-optional-email-unsupported.yaml
+++ b/packages/sury/specs/codec-file-optional-email-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.to, S.optional(S.email))
   input: File
   output: string | undefined
-  instantiations: 5446
+  instantiations: 4632
 jsonSchema:
   input: Expected JSON, received File
   output: Expected JSON, received email | undefined

--- a/packages/sury/specs/codec-iso-date-time-date.yaml
+++ b/packages/sury/specs/codec-iso-date-time-date.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.isoDateTime.with(S.to, S.date)
   input: string
   output: Date
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string", format: "date-time" }'
   output: Expected JSON, received Date

--- a/packages/sury/specs/codec-json-array-optional-bounded.yaml
+++ b/packages/sury/specs/codec-json-array-optional-bounded.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.array(S.optional(S.number.with(S.lte, 1))))
   input: JSON
   output: (number | undefined)[]
-  instantiations: 6196
+  instantiations: 5347
 # FIXME: jsonSchema.input drops the item's `maximum: 1` — a variant converted
 # through `.to(json)` reports the target's type without the source's refinements.
 # The generated code still enforces the bound, in both directions.

--- a/packages/sury/specs/codec-json-object-date.yaml
+++ b/packages/sury/specs/codec-json-object-date.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.json.with(S.to, S.schema({ field: S.date }))"
   input: JSON
   output: "{ field: Date; }"
-  instantiations: 6260
+  instantiations: 5446
 jsonSchema:
   input: '{ type: "object", properties: { field: { type: "string", format: "date-time" } }, additionalProperties: false, required: ["field"] }'
   fromInputType: "{ field: string; }"

--- a/packages/sury/specs/codec-json-object-uint8array.yaml
+++ b/packages/sury/specs/codec-json-object-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.json.with(S.to, S.schema({ payload: S.uint8Array }))"
   input: JSON
   output: "{ payload: Uint8Array<ArrayBufferLike>; }"
-  instantiations: 6260
+  instantiations: 5446
 jsonSchema:
   input: '{ type: "object", properties: { payload: { type: "string", contentEncoding: "base64" } }, additionalProperties: false, required: ["payload"] }'
   fromInputType: "{ payload: string; }"

--- a/packages/sury/specs/codec-json-optional-union-literal-first.yaml
+++ b/packages/sury/specs/codec-json-optional-union-literal-first.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object({ selector: S.optional(S.union([S.literal("*"), S.string, S.array(S.string)])) }).with(S.to, S.json)'
   input: "{ selector?: string | string[] | undefined; }"
   output: JSON
-  instantiations: 8213
+  instantiations: 7399
 jsonSchema:
   input: '{ type: "object", properties: { selector: { anyOf: [{ type: "string", const: "*" }, { type: "string" }, { items: { type: "string" }, type: "array" }] } } }'
   output: '{ type: "object", properties: { selector: { anyOf: [{ type: "string" }, { items: { type: "string" }, type: "array" }] } }, additionalProperties: false }'

--- a/packages/sury/specs/codec-json-record-optional.yaml
+++ b/packages/sury/specs/codec-json-record-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.record(S.optional(S.boolean)))
   input: JSON
   output: "{ [x: string]: boolean | undefined; }"
-  instantiations: 5642
+  instantiations: 4828
 jsonSchema:
   input: '{ type: "object", additionalProperties: { anyOf: [{ type: "boolean" }, { type: "null" }] } }'
   fromInputType: "{ [key: string]: boolean | null; }"

--- a/packages/sury/specs/codec-json-tuple-optional.yaml
+++ b/packages/sury/specs/codec-json-tuple-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.schema(["B", S.optional(S.string)]))
   input: JSON
   output: '["B", string | undefined]'
-  instantiations: 6131
+  instantiations: 5317
 jsonSchema:
   input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "string", const: "B" }, { anyOf: [{ type: "string" }, { type: "null" }] }] }'
   fromInputType: '["B", string | null]'

--- a/packages/sury/specs/codec-json-union2-optional-date.yaml
+++ b/packages/sury/specs/codec-json-union2-optional-date.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.json.with(S.to, S.schema({ value: S.union([S.schema({ a: S.optional(S.string.with(S.to, S.date)) }), S.string]) }))"
   input: JSON
   output: "{ value: string | { a?: Date | undefined; }; }"
-  instantiations: 10854
+  instantiations: 10009
 jsonSchema:
   input: '{ type: "object", properties: { value: { anyOf: [{ type: "object", properties: { a: { type: "string", format: "date-time" } }, additionalProperties: false }, { type: "string" }] } }, additionalProperties: false, required: ["value"] }'
   fromInputType: "{ value: string | { a?: string | undefined; }; }"

--- a/packages/sury/specs/codec-json-union2-tagged-optional-date.yaml
+++ b/packages/sury/specs/codec-json-union2-tagged-optional-date.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.json.with(S.to, S.schema({ value: S.union([S.schema({ type: "B", value: S.optional(S.string.with(S.to, S.date)) }), S.schema({ type: "C", value: S.optional(S.string.with(S.to, S.date)) })]) }))'
   input: JSON
   output: '{ value: { type: "B"; value?: Date | undefined; } | { type: "C"; value?: Date | undefined; }; }'
-  instantiations: 14197
+  instantiations: 13352
 jsonSchema:
   input: '{ type: "object", properties: { value: { anyOf: [{ type: "object", properties: { type: { type: "string", const: "B" }, value: { type: "string", format: "date-time" } }, additionalProperties: false, required: ["type"] }, { type: "object", properties: { type: { type: "string", const: "C" }, value: { type: "string", format: "date-time" } }, additionalProperties: false, required: ["type"] }] } }, additionalProperties: false, required: ["value"] }'
   fromInputType: '{ value: { type: "B"; value?: string | undefined; } | { type: "C"; value?: string | undefined; }; }'

--- a/packages/sury/specs/codec-json-union2.yaml
+++ b/packages/sury/specs/codec-json-union2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.union([S.bigint, S.string]))
   input: JSON
   output: string | bigint
-  instantiations: 6208
+  instantiations: 5394
 jsonSchema:
   input: '{ type: "string" }'
   fromInputType: string

--- a/packages/sury/specs/codec-json-union3-grouped.yaml
+++ b/packages/sury/specs/codec-json-union3-grouped.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.union([S.literal("a"), S.number, S.literal("b")]))
   input: JSON
   output: number | "a" | "b"
-  instantiations: 6703
+  instantiations: 5889
 jsonSchema:
   input: '{ anyOf: [{ type: "string", const: "a" }, { type: "number" }, { type: "string", const: "b" }] }'
   fromInputType: number | "a" | "b"

--- a/packages/sury/specs/codec-json-union3-ungrouped.yaml
+++ b/packages/sury/specs/codec-json-union3-ungrouped.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.union(["123", S.bigint, S.string]))
   input: JSON
   output: string | bigint
-  instantiations: 6322
+  instantiations: 5508
 jsonSchema:
   input: '{ anyOf: [{ type: "string", const: "123" }, { type: "string" }] }'
   fromInputType: string

--- a/packages/sury/specs/codec-json-url.yaml
+++ b/packages/sury/specs/codec-json-url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.url)
   input: JSON
   output: URL
-  instantiations: 5244
+  instantiations: 4430
 jsonSchema:
   input: '{ type: "string", format: "uri" }'
   fromInputType: string

--- a/packages/sury/specs/codec-jsonstring-bigint-array.yaml
+++ b/packages/sury/specs/codec-jsonstring-bigint-array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.jsonString.with(S.to, S.array(S.bigint))
   input: string
   output: bigint[]
-  instantiations: 5431
+  instantiations: 4617
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at []: Expected JSON, received bigint"

--- a/packages/sury/specs/codec-jsonstring-boolean.yaml
+++ b/packages/sury/specs/codec-jsonstring-boolean.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.jsonString.with(S.to, S.boolean)
   input: string
   output: boolean
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "boolean" }'

--- a/packages/sury/specs/codec-jsonstring-dict-file.yaml
+++ b/packages/sury/specs/codec-jsonstring-dict-file.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.jsonString.with(S.to, S.record(S.file))
   input: string
   output: "{ [x: string]: File; }"
-  instantiations: 5458
+  instantiations: 4644
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at []: Expected JSON, received File"

--- a/packages/sury/specs/codec-jsonstring-extract-field.yaml
+++ b/packages/sury/specs/codec-jsonstring-extract-field.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.jsonString.with(S.to, S.schema({ type: "info", value: S.number }).with(S.shape, (msg) => msg.value)).with(S.to, S.jsonString)'
   input: string
   output: string
-  instantiations: 8045
+  instantiations: 5546
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-jsonstring-file-slots.yaml
+++ b/packages/sury/specs/codec-jsonstring-file-slots.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.jsonString.with(S.to, S.file, { decode: "unpack", encode: "pack" })'
   input: string
   output: File
-  instantiations: 5310
+  instantiations: 4496
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: Expected JSON, received File

--- a/packages/sury/specs/codec-jsonstring-jsonstring-payload.yaml
+++ b/packages/sury/specs/codec-jsonstring-jsonstring-payload.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.jsonString.with(S.to, S.schema({ a: S.string })))"
   input: string
   output: "{ a: string; }"
-  instantiations: 6557
+  instantiations: 5712
 jsonSchema:
   # FIXME: `encodeToJsonSchema` reverses and parses to learn the input's shape,
   # and a document carrying a document hands it back a node of the same shape,

--- a/packages/sury/specs/codec-jsonstring-object-file.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-file.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ avatar: S.file }))"
   input: string
   output: "{ avatar: File; }"
-  instantiations: 6276
+  instantiations: 5462
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at avatar: Expected JSON, received File"

--- a/packages/sury/specs/codec-jsonstring-object-jsonstring.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-jsonstring.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ id: S.string, meta: S.jsonString.with(S.to, S.schema({ tag: S.string })) }))"
   input: string
   output: "{ id: string; meta: { tag: string; }; }"
-  instantiations: 7271
+  instantiations: 6426
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "object", properties: { id: { type: "string" }, meta: { type: "object", properties: { tag: { type: "string" } }, required: ["tag"] } }, required: ["id", "meta"] }'

--- a/packages/sury/specs/codec-jsonstring-object-optional-file.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-optional-file.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ note: S.optional(S.string), avatar: S.file }))"
   input: string
   output: "{ avatar: File; note?: string | undefined; }"
-  instantiations: 7367
+  instantiations: 6553
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at avatar: Expected JSON, received File"

--- a/packages/sury/specs/codec-jsonstring-object-optional-jsonstring.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-optional-jsonstring.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ id: S.string, meta: S.optional(S.jsonString.with(S.to, S.schema({ tag: S.string }))) }))"
   input: string
   output: "{ id: string; meta?: { tag: string; } | undefined; }"
-  instantiations: 8313
+  instantiations: 7468
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "object", properties: { id: { type: "string" }, meta: { type: "object", properties: { tag: { type: "string" } }, required: ["tag"] } }, required: ["id"] }'

--- a/packages/sury/specs/codec-jsonstring-object-optional-text-uint8array.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-optional-text-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ a: S.optional(S.string.with(S.to, S.uint8Array)) }))"
   input: string
   output: "{ a?: Uint8Array<ArrayBufferLike> | undefined; }"
-  instantiations: 7365
+  instantiations: 6520
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at a: Expected JSON, received Uint8Array | undefined"

--- a/packages/sury/specs/codec-jsonstring-object-optional-uint8array.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-optional-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ payload: S.optional(S.uint8Array) }))"
   input: string
   output: "{ payload?: Uint8Array<ArrayBufferLike> | undefined; }"
-  instantiations: 7036
+  instantiations: 6222
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at payload: Expected JSON, received Uint8Array | undefined"

--- a/packages/sury/specs/codec-jsonstring-object-text-uint8array.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-text-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ a: S.string.with(S.to, S.uint8Array) }))"
   input: string
   output: "{ a: Uint8Array<ArrayBufferLike>; }"
-  instantiations: 6552
+  instantiations: 5707
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at a: Expected JSON, received Uint8Array"

--- a/packages/sury/specs/codec-jsonstring-object-uint8array.yaml
+++ b/packages/sury/specs/codec-jsonstring-object-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ payload: S.uint8Array }))"
   input: string
   output: "{ payload: Uint8Array<ArrayBufferLike>; }"
-  instantiations: 6260
+  instantiations: 5446
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at payload: Expected JSON, received Uint8Array"

--- a/packages/sury/specs/codec-jsonstring-string.yaml
+++ b/packages/sury/specs/codec-jsonstring-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.jsonString.with(S.to, S.string)
   input: string
   output: string
-  instantiations: 5175
+  instantiations: 4361
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-literal-array-literal-string.yaml
+++ b/packages/sury/specs/codec-literal-array-literal-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([1, 2]).with(S.to, S.schema("done"))
   input: "[1, 2]"
   output: '"done"'
-  instantiations: 5833
+  instantiations: 5019
 jsonSchema:
   input: '{ type: "array", minItems: 2, maxItems: 2, items: [{ type: "number", const: 1 }, { type: "number", const: 2 }] }'
   output: '{ type: "string", const: "done" }'

--- a/packages/sury/specs/codec-literal-string-literal-number.yaml
+++ b/packages/sury/specs/codec-literal-string-literal-number.yaml
@@ -5,7 +5,7 @@ ts:
     - S.literal("a").with(S.to, S.literal(42))
   input: '"a"'
   output: "42"
-  instantiations: 5719
+  instantiations: 4905
 jsonSchema:
   input: '{ type: "string", const: "a" }'
   output: '{ type: "number", const: 42 }'

--- a/packages/sury/specs/codec-nan-union2-exact.yaml
+++ b/packages/sury/specs/codec-nan-union2-exact.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema(NaN).with(S.to, S.union([S.schema(NaN), S.string]))
   input: number
   output: string | number
-  instantiations: 6326
+  instantiations: 5512
 jsonSchema:
   input: Expected JSON, received NaN
   output: Expected JSON, received NaN | string

--- a/packages/sury/specs/codec-null-undefined.yaml
+++ b/packages/sury/specs/codec-null-undefined.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema(null).with(S.to, S.schema(undefined))
   input: "null"
   output: undefined
-  instantiations: 5651
+  instantiations: 4837
 jsonSchema:
   input: '{ type: "null" }'
   output: Expected JSON, received undefined

--- a/packages/sury/specs/codec-number-jsonstring-pattern.yaml
+++ b/packages/sury/specs/codec-number-jsonstring-pattern.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.to, S.jsonString).with(S.pattern, /^\d+$/)
   input: number
   output: string
-  instantiations: 5548
+  instantiations: 4711
 jsonSchema:
   input: '{ type: "number" }'
   output: '{ type: "string", contentMediaType: "application/json", pattern: "^\\d+$" }'

--- a/packages/sury/specs/codec-number-jsonstring.yaml
+++ b/packages/sury/specs/codec-number-jsonstring.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.to, S.jsonString)
   input: number
   output: string
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "number" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-number-union2-int32.yaml
+++ b/packages/sury/specs/codec-number-union2-int32.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.to, S.union([S.int32, S.string]))
   input: number
   output: string | number
-  instantiations: 6187
+  instantiations: 5373
 jsonSchema:
   input: '{ anyOf: [{ type: "integer", minimum: -2147483648, maximum: 2147483647 }, { type: "number" }] }'
   output: '{ anyOf: [{ type: "integer", minimum: -2147483648, maximum: 2147483647 }, { type: "string" }] }'

--- a/packages/sury/specs/codec-object-array-field.yaml
+++ b/packages/sury/specs/codec-object-array-field.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ x: S.array(S.string) }).with(S.to, S.schema({ x: S.array(S.string) }), { decode: (v) => v, encode: (v) => v })"
   input: "{ x: string[]; }"
   output: "{ x: string[]; }"
-  instantiations: 6989
+  instantiations: 6175
 jsonSchema:
   input: '{ type: "object", properties: { x: { items: { type: "string" }, type: "array" } }, required: ["x"] }'
   output: '{ type: "object", properties: { x: { items: { type: "string" }, type: "array" } }, required: ["x"] }'

--- a/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
+++ b/packages/sury/specs/codec-optional-literal-nullable-literal.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.literal("x")).with(S.to, S.nullable(S.literal("x")))
   input: '"x" | undefined'
   output: '"x" | null'
-  instantiations: 5910
+  instantiations: 5096
 jsonSchema:
   input: Expected JSON, received "x" | undefined
   output: '{ enum: ["x", null] }'

--- a/packages/sury/specs/codec-optional-nullable-partial.yaml
+++ b/packages/sury/specs/codec-optional-nullable-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.nullable(S.boolean))
   input: string | undefined
   output: boolean | null
-  instantiations: 5600
+  instantiations: 4786
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: '{ anyOf: [{ type: "boolean" }, { type: "null" }] }'

--- a/packages/sury/specs/codec-optional-nullable-transformed.yaml
+++ b/packages/sury/specs/codec-optional-nullable-transformed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.nullable(S.string.with(S.to, S.boolean)))
   input: string | undefined
   output: boolean | null
-  instantiations: 5983
+  instantiations: 5138
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: '{ anyOf: [{ type: "boolean" }, { type: "null" }] }'

--- a/packages/sury/specs/codec-optional-nullable.yaml
+++ b/packages/sury/specs/codec-optional-nullable.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.nullable(S.string))
   input: string | undefined
   output: string | null
-  instantiations: 5542
+  instantiations: 4728
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: '{ anyOf: [{ type: "string" }, { type: "null" }] }'

--- a/packages/sury/specs/codec-optional-nullish.yaml
+++ b/packages/sury/specs/codec-optional-nullish.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.union([S.string, null, undefined]))
   input: string | undefined
   output: string | null | undefined
-  instantiations: 6124
+  instantiations: 5310
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: Expected JSON, received string | null | undefined

--- a/packages/sury/specs/codec-optional-object-json.yaml
+++ b/packages/sury/specs/codec-optional-object-json.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ a: S.optional(S.schema({ s: S.optional(S.string) })) }).with(S.to, S.json)"
   input: "{ a?: { s?: string | undefined; } | undefined; }"
   output: JSON
-  instantiations: 9403
+  instantiations: 8589
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "object", properties: { s: { type: "string" } } } } }'
   output: '{ type: "object", properties: { a: { type: "object", properties: { s: { type: "string" } }, additionalProperties: false } }, additionalProperties: false }'

--- a/packages/sury/specs/codec-optional-string-uint8array-unsupported.yaml
+++ b/packages/sury/specs/codec-optional-string-uint8array-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.string).with(S.to, S.uint8Array)
   input: string | undefined
   output: Uint8Array<ArrayBufferLike>
-  instantiations: 5401
+  instantiations: 4587
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: Expected JSON, received Uint8Array

--- a/packages/sury/specs/codec-string-date.yaml
+++ b/packages/sury/specs/codec-string-date.yaml
@@ -5,7 +5,7 @@ ts:
     - S.to(S.string, S.date)
   input: string
   output: Date
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string", format: "date-time" }'
   output: Expected JSON, received Date

--- a/packages/sury/specs/codec-string-novalidation-uint8array.yaml
+++ b/packages/sury/specs/codec-string-novalidation-uint8array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.noValidation, true).with(S.to, S.uint8Array)
   input: string
   output: Uint8Array<ArrayBufferLike>
-  instantiations: 5578
+  instantiations: 4741
 jsonSchema:
   input: '{ type: "string" }'
   output: Expected JSON, received Uint8Array

--- a/packages/sury/specs/codec-string-number-transform.yaml
+++ b/packages/sury/specs/codec-string-number-transform.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.to, S.number, { decode: (string) => { const number = Number(string); if (Number.isNaN(number)) { throw new Error("Invalid number") } return number }, encode: (number) => { if (number < 100) { throw new Error("Number is too small") } return number.toString() } })'
   input: string
   output: number
-  instantiations: 5309
+  instantiations: 4495
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-string-number.yaml
+++ b/packages/sury/specs/codec-string-number.yaml
@@ -5,7 +5,7 @@ ts:
     - S.to(S.string, S.number)
   input: string
   output: number
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-string-optional-never.yaml
+++ b/packages/sury/specs/codec-string-optional-never.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.string, S.never.with(S.to, S.schema(undefined))]))
   input: string
   output: string | undefined
-  instantiations: 6836
+  instantiations: 5991
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-string-optional-partial.yaml
+++ b/packages/sury/specs/codec-string-optional-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.optional(S.string))
   input: string
   output: string | undefined
-  instantiations: 5413
+  instantiations: 4599
 jsonSchema:
   input: '{ type: "string" }'
   output: Expected JSON, received string | undefined

--- a/packages/sury/specs/codec-string-port.yaml
+++ b/packages/sury/specs/codec-string-port.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.port)
   input: string
   output: number
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "integer", minimum: 0, maximum: 65535 }'

--- a/packages/sury/specs/codec-string-undefined.yaml
+++ b/packages/sury/specs/codec-string-undefined.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.schema(undefined))
   input: string
   output: undefined
-  instantiations: 5604
+  instantiations: 4790
 jsonSchema:
   input: '{ type: "string", const: "undefined" }'
   fromInputType: '"undefined"'

--- a/packages/sury/specs/codec-string-union2-never.yaml
+++ b/packages/sury/specs/codec-string-union2-never.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.never.with(S.to, S.number), S.string]))
   input: string
   output: string | number
-  instantiations: 6507
+  instantiations: 5662
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-string-union2-partial.yaml
+++ b/packages/sury/specs/codec-string-union2-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.number, S.string]))
   input: string
   output: string | number
-  instantiations: 6187
+  instantiations: 5373
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ anyOf: [{ type: "number" }, { type: "string" }] }'

--- a/packages/sury/specs/codec-string-union2-transformed.yaml
+++ b/packages/sury/specs/codec-string-union2-transformed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.union([S.string.with(S.to, S.number), S.string]))
   input: string
   output: string | number
-  instantiations: 6442
+  instantiations: 5597
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ anyOf: [{ type: "number" }, { type: "string" }] }'

--- a/packages/sury/specs/codec-string-url.yaml
+++ b/packages/sury/specs/codec-string-url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.url)
   input: string
   output: URL
-  instantiations: 5244
+  instantiations: 4430
 jsonSchema:
   input: '{ type: "string", format: "uri" }'
   output: Expected JSON, received URL

--- a/packages/sury/specs/codec-uint8array-base64.yaml
+++ b/packages/sury/specs/codec-uint8array-base64.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.base64)
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string", contentEncoding: "base64" }'

--- a/packages/sury/specs/codec-uint8array-base64url.yaml
+++ b/packages/sury/specs/codec-uint8array-base64url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.base64url)
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string", contentEncoding: "base64url" }'

--- a/packages/sury/specs/codec-uint8array-json-unsupported.yaml
+++ b/packages/sury/specs/codec-uint8array-json-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.json)
   input: Uint8Array<ArrayBufferLike>
   output: JSON
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: "{}"

--- a/packages/sury/specs/codec-uint8array-jsonstring-ambiguous.yaml
+++ b/packages/sury/specs/codec-uint8array-jsonstring-ambiguous.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.jsonString)
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-uint8array-jsonstring-pack.yaml
+++ b/packages/sury/specs/codec-uint8array-jsonstring-pack.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.jsonString, "pack")
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5260
+  instantiations: 4446
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-uint8array-jsonstring-packed.yaml
+++ b/packages/sury/specs/codec-uint8array-jsonstring-packed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.uint8Array.with(S.to, S.jsonString, { decode: "pack", encode: "unpack" })'
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5298
+  instantiations: 4484
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-uint8array-jsonstring-payload.yaml
+++ b/packages/sury/specs/codec-uint8array-jsonstring-payload.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.uint8Array.with(S.to, S.jsonString.with(S.to, S.schema({ sub: S.string })))"
   input: Uint8Array<ArrayBufferLike>
   output: "{ sub: string; }"
-  instantiations: 6660
+  instantiations: 5815
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "object", properties: { sub: { type: "string" } }, required: ["sub"] }'

--- a/packages/sury/specs/codec-uint8array-jsonstring-unpack.yaml
+++ b/packages/sury/specs/codec-uint8array-jsonstring-unpack.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.uint8Array.with(S.to, S.jsonString, { decode: "unpack", encode: "pack" })'
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5298
+  instantiations: 4484
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/codec-uint8array-number-unsupported.yaml
+++ b/packages/sury/specs/codec-uint8array-number-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.number)
   input: Uint8Array<ArrayBufferLike>
   output: number
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "number" }'

--- a/packages/sury/specs/codec-uint8array-optional-base64.yaml
+++ b/packages/sury/specs/codec-uint8array-optional-base64.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.optional(S.base64))
   input: Uint8Array<ArrayBufferLike>
   output: string | undefined
-  instantiations: 5434
+  instantiations: 4620
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: Expected JSON, received base64 | undefined

--- a/packages/sury/specs/codec-uint8array-optional-jsonstring-unsupported.yaml
+++ b/packages/sury/specs/codec-uint8array-optional-jsonstring-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.optional(S.jsonString))
   input: Uint8Array<ArrayBufferLike>
   output: string | undefined
-  instantiations: 5434
+  instantiations: 4620
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: Expected JSON, received JSON string | undefined

--- a/packages/sury/specs/codec-uint8array-optional-string.yaml
+++ b/packages/sury/specs/codec-uint8array-optional-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.optional(S.string))
   input: Uint8Array<ArrayBufferLike>
   output: string | undefined
-  instantiations: 5434
+  instantiations: 4620
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: Expected JSON, received string | undefined

--- a/packages/sury/specs/codec-uint8array-string-novalidation.yaml
+++ b/packages/sury/specs/codec-uint8array-string-novalidation.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.string.with(S.noValidation, true))
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5813
+  instantiations: 4916
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-uint8array-string.yaml
+++ b/packages/sury/specs/codec-uint8array-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uint8Array.with(S.to, S.string)
   input: Uint8Array<ArrayBufferLike>
   output: string
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: Expected JSON, received Uint8Array
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-union-nested-refined-union.yaml
+++ b/packages/sury/specs/codec-union-nested-refined-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.union([S.string, S.number]).with(S.refine, (value) => value !== "", { error: "Expected a non-empty value" }), S.boolean])'
   input: string | number | boolean
   output: string | number | boolean
-  instantiations: 6613
+  instantiations: 2333
 jsonSchema:
   input: '{ anyOf: [{ anyOf: [{ type: "string" }, { type: "number" }] }, { type: "boolean" }] }'
   output: '{ anyOf: [{ anyOf: [{ type: "string" }, { type: "number" }] }, { type: "boolean" }] }'

--- a/packages/sury/specs/codec-union-nested-union3-flatten.yaml
+++ b/packages/sury/specs/codec-union-nested-union3-flatten.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.union([S.number, S.boolean])]).with(S.to, S.union([S.boolean, S.number, S.string]))
   input: string | number | boolean
   output: string | number | boolean
-  instantiations: 7035
+  instantiations: 6221
 jsonSchema:
   input: '{ anyOf: [{ type: "boolean" }, { type: "number" }, { type: "string" }] }'
   output: '{ anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] }'

--- a/packages/sury/specs/codec-union-refined-fallback.yaml
+++ b/packages/sury/specs/codec-union-refined-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.minLength, 3), S.number, S.string])
   input: string | number
   output: string | number
-  instantiations: 1814
+  instantiations: 1758
 jsonSchema:
   input: '{ anyOf: [{ type: "string", minLength: 3 }, { type: "number" }, { type: "string" }] }'
   output: '{ anyOf: [{ type: "string", minLength: 3 }, { type: "number" }, { type: "string" }] }'

--- a/packages/sury/specs/codec-union-unreachable-nullish-bridge.yaml
+++ b/packages/sury/specs/codec-union-unreachable-nullish-bridge.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.never.with(S.to, S.schema(null)), S.string]).with(S.to, S.union([S.schema(undefined), S.string]))
   input: string
   output: string | undefined
-  instantiations: 7301
+  instantiations: 6456
 jsonSchema:
   input: '{ anyOf: [{ not: {} }, { type: "string" }] }'
   output: Expected JSON, received undefined | string

--- a/packages/sury/specs/codec-union2-string-partial.yaml
+++ b/packages/sury/specs/codec-union2-string-partial.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.number, S.string]).with(S.to, S.string)
   input: string | number
   output: string
-  instantiations: 5893
+  instantiations: 5079
 jsonSchema:
   input: '{ anyOf: [{ type: "number" }, { type: "string" }] }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-union2-string-unsupported.yaml
+++ b/packages/sury/specs/codec-union2-string-unsupported.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.boolean, S.symbol]).with(S.to, S.string)
   input: boolean | symbol
   output: string
-  instantiations: 5951
+  instantiations: 5137
 jsonSchema:
   input: Expected JSON, received boolean | symbol
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-union2-union2-reject.yaml
+++ b/packages/sury/specs/codec-union2-union2-reject.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.never), S.string]))
   input: string | number
   output: string
-  instantiations: 6870
+  instantiations: 6025
 jsonSchema:
   input: '{ anyOf: [{ type: "number" }, { type: "string" }] }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-union2-union2-swap.yaml
+++ b/packages/sury/specs/codec-union2-union2-swap.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string]))
   input: string | number
   output: string | number
-  instantiations: 6324
+  instantiations: 5510
 jsonSchema:
   input: '{ anyOf: [{ type: "number" }, { type: "string" }] }'
   output: '{ anyOf: [{ type: "string" }, { type: "number" }] }'

--- a/packages/sury/specs/codec-union2-union2-transformed.yaml
+++ b/packages/sury/specs/codec-union2-union2-transformed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.number, S.string]).with(S.to, S.union([S.number.with(S.to, S.string), S.string]))
   input: string | number
   output: string
-  instantiations: 6808
+  instantiations: 5963
 jsonSchema:
   input: '{ anyOf: [{ type: "number" }, { type: "string" }] }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/codec-union2-union3-extra-target.yaml
+++ b/packages/sury/specs/codec-union2-union3-extra-target.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number]).with(S.to, S.union([S.number, S.string, S.boolean]))
   input: string | number
   output: string | number | boolean
-  instantiations: 6664
+  instantiations: 5850
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "number" }] }'
   output: '{ anyOf: [{ type: "number" }, { type: "string" }, { type: "boolean" }] }'

--- a/packages/sury/specs/codec-union3-union2-extra-source.yaml
+++ b/packages/sury/specs/codec-union3-union2-extra-source.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number, S.boolean]).with(S.to, S.union([S.number, S.string]))
   input: string | number | boolean
   output: string | number
-  instantiations: 6664
+  instantiations: 5850
 jsonSchema:
   input: '{ anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] }'
   output: '{ anyOf: [{ type: "number" }, { type: "string" }] }'

--- a/packages/sury/specs/codec-union3-union2-json.yaml
+++ b/packages/sury/specs/codec-union3-union2-json.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string, S.number, S.bigint]).with(S.to, S.union([S.json, S.bigint]))
   input: string | number | bigint
   output: bigint | JSON
-  instantiations: 7040
+  instantiations: 6226
 jsonSchema:
   input: Expected JSON, received string | number | bigint
   output: Expected JSON, received JSON | bigint

--- a/packages/sury/specs/codec-union3-union3-bridge.yaml
+++ b/packages/sury/specs/codec-union3-union3-bridge.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.bigint, S.number, null]).with(S.to, S.union([S.bigint, S.number, undefined]))
   input: number | bigint | null
   output: number | bigint | undefined
-  instantiations: 6480
+  instantiations: 5666
 jsonSchema:
   input: Expected JSON, received bigint | number | null
   output: Expected JSON, received bigint | number | undefined

--- a/packages/sury/specs/codec-unknown-union2.yaml
+++ b/packages/sury/specs/codec-unknown-union2.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.unknown.with(S.to, S.union([S.bigint, S.string]))
   input: unknown
   output: string | bigint
-  instantiations: 6187
+  instantiations: 5373
 jsonSchema:
   input: Expected JSON, received unknown
   output: Expected JSON, received bigint | string

--- a/packages/sury/specs/codec-uri-url.yaml
+++ b/packages/sury/specs/codec-uri-url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uri.with(S.to, S.url)
   input: string
   output: URL
-  instantiations: 5244
+  instantiations: 4430
 jsonSchema:
   input: '{ type: "string", format: "uri" }'
   output: Expected JSON, received URL

--- a/packages/sury/specs/compact-columns-json-bigint.yaml
+++ b/packages/sury/specs/compact-columns-json-bigint.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.compactColumns(S.json).with(S.to, S.array(S.schema({ id: S.string, amount: S.bigint })))"
   input: JSON[][]
   output: "{ id: string; amount: bigint; }[]"
-  instantiations: 7119
+  instantiations: 6305
 jsonSchema:
   input: '{ items: { items: {}, type: "array" }, type: "array" }'
   output: "Failed at [].amount: Expected JSON, received bigint"

--- a/packages/sury/specs/compact-columns-nullable.yaml
+++ b/packages/sury/specs/compact-columns-nullable.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.compactColumns(S.unknown).with(S.to, S.array(S.schema({ id: S.string, name: S.nullable(S.string), deleted: S.boolean })))"
   input: unknown[][]
   output: "{ id: string; name: string | null; deleted: boolean; }[]"
-  instantiations: 7433
+  instantiations: 6619
 jsonSchema:
   input: "Failed at [][]: Expected JSON, received unknown"
   output: '{ items: { type: "object", properties: { id: { type: "string" }, name: { anyOf: [{ type: "string" }, { type: "null" }] }, deleted: { type: "boolean" } }, required: ["id", "name", "deleted"] }, type: "array" }'

--- a/packages/sury/specs/compact-columns.yaml
+++ b/packages/sury/specs/compact-columns.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.compactColumns(S.unknown).with(S.to, S.array(S.schema({ id: S.number, name: S.string })))"
   input: unknown[][]
   output: "{ id: number; name: string; }[]"
-  instantiations: 7061
+  instantiations: 6247
 jsonSchema:
   input: "Failed at [][]: Expected JSON, received unknown"
   output: '{ items: { type: "object", properties: { id: { type: "number" }, name: { type: "string" } }, required: ["id", "name"] }, type: "array" }'

--- a/packages/sury/specs/dict-to-object-required-string.yaml
+++ b/packages/sury/specs/dict-to-object-required-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.record(S.string).with(S.to, S.schema({ foo: S.string }))"
   input: "{ [x: string]: string; }"
   output: "{ foo: string; }"
-  instantiations: 6380
+  instantiations: 5566
 jsonSchema:
   input: '{ type: "object", additionalProperties: { type: "string" } }'
   output: '{ type: "object", properties: { foo: { type: "string" } }, required: ["foo"] }'

--- a/packages/sury/specs/file-maxSize.yaml
+++ b/packages/sury/specs/file-maxSize.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.maxSize, 5)
   input: File
   output: File
-  instantiations: 599
+  instantiations: 595
 jsonSchema:
   input: Expected JSON, received File.size <= 5
   output: Expected JSON, received File.size <= 5

--- a/packages/sury/specs/file-minSize-zero.yaml
+++ b/packages/sury/specs/file-minSize-zero.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.minSize, 0)
   input: File
   output: File
-  instantiations: 599
+  instantiations: 595
 jsonSchema:
   input: Expected JSON, received File
   output: Expected JSON, received File

--- a/packages/sury/specs/file-minSize.yaml
+++ b/packages/sury/specs/file-minSize.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.minSize, 3)
   input: File
   output: File
-  instantiations: 599
+  instantiations: 595
 jsonSchema:
   input: Expected JSON, received File.size >= 3
   output: Expected JSON, received File.size >= 3

--- a/packages/sury/specs/file-size-range.yaml
+++ b/packages/sury/specs/file-size-range.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.file.with(S.minSize, 2).with(S.maxSize, 10)
   input: File
   output: File
-  instantiations: 785
+  instantiations: 781
 jsonSchema:
   input: Expected JSON, received 2 <= File.size <= 10
   output: Expected JSON, received 2 <= File.size <= 10

--- a/packages/sury/specs/flatten-array-shape.yaml
+++ b/packages/sury/specs/flatten-array-shape.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object((s) => s.flatten(S.schema({ items: S.array(S.string.with(S.shape, (v) => ({ TAG: "A" as const, _0: v }))) })))'
   input: "{ [x: string]: unknown; }"
   output: '{ items: { TAG: "A"; _0: string; }[]; }'
-  instantiations: 8530
+  instantiations: 6055
 jsonSchema:
   input: '{ type: "object", properties: { items: { items: { type: "string" }, type: "array" } }, required: ["items"] }'
   fromInputType: "{ items: string[]; }"

--- a/packages/sury/specs/flatten-codec-member-pick.yaml
+++ b/packages/sury/specs/flatten-codec-member-pick.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object((s) => ({ x: s.flatten(S.schema({ b: S.string }).with(S.to, S.schema({ b: S.string }), { decode: (v) => ({ b: v.b + "!" }), encode: (v) => ({ b: v.b.slice(0, -1) }) })).b }))'
   input: "{ [x: string]: unknown; }"
   output: "{ x: string; }"
-  instantiations: 6792
+  instantiations: 5947
 jsonSchema:
   input: '{ type: "object", properties: { b: { type: "string" } }, required: ["b"] }'
   fromInputType: "{ b: string; }"

--- a/packages/sury/specs/flatten-codec-member.yaml
+++ b/packages/sury/specs/flatten-codec-member.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object((s) => s.flatten(S.schema({ b: S.string }).with(S.to, S.schema({ b: S.string }), { decode: (v) => ({ b: v.b + "!" }), encode: (v) => ({ b: v.b.slice(0, -1) }) })))'
   input: "{ [x: string]: unknown; }"
   output: "{ b: string; }"
-  instantiations: 6975
+  instantiations: 6130
 jsonSchema:
   input: '{ type: "object", properties: { b: { type: "string" } }, required: ["b"] }'
   fromInputType: "{ b: string; }"

--- a/packages/sury/specs/flatten-field-codec.yaml
+++ b/packages/sury/specs/flatten-field-codec.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object((s) => ({ f: s.flatten(S.schema({ b: S.string.with(S.to, S.number, { decode: (v) => +v, encode: (v) => "" + v }) })), o: s.field("O", S.string) }))'
   input: "{ [x: string]: unknown; }"
   output: "{ f: { b: number; }; o: string; }"
-  instantiations: 6528
+  instantiations: 5683
 jsonSchema:
   input: '{ type: "object", properties: { b: { type: "string" }, O: { type: "string" } }, required: ["b", "O"] }'
   fromInputType: "{ b: string; O: string; }"

--- a/packages/sury/specs/flatten-refined.yaml
+++ b/packages/sury/specs/flatten-refined.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.object((s) => s.flatten(S.schema({ n: S.number.with(S.gte, 3) })))"
   input: "{ [x: string]: unknown; }"
   output: "{ n: number; }"
-  instantiations: 2016
+  instantiations: 1960
 jsonSchema:
   input: '{ type: "object", properties: { n: { type: "number", minimum: 3 } }, required: ["n"] }'
   fromInputType: "{ n: number; }"

--- a/packages/sury/specs/instance-own-size.yaml
+++ b/packages/sury/specs/instance-own-size.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.instance(class Chunk { size = 4 }).with(S.minSize, 4)
   input: Chunk
   output: Chunk
-  instantiations: 619
+  instantiations: 615
 jsonSchema:
   input: Expected JSON, received Chunk.size >= 4
   output: Expected JSON, received Chunk.size >= 4

--- a/packages/sury/specs/int32-gt.yaml
+++ b/packages/sury/specs/int32-gt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.int32.with(S.gt, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", maximum: 2147483647, exclusiveMinimum: 5 }'
   output: '{ type: "integer", maximum: 2147483647, exclusiveMinimum: 5 }'

--- a/packages/sury/specs/int32-gte.yaml
+++ b/packages/sury/specs/int32-gte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.int32.with(S.gte, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: 5, maximum: 2147483647 }'
   output: '{ type: "integer", minimum: 5, maximum: 2147483647 }'

--- a/packages/sury/specs/int32-lt.yaml
+++ b/packages/sury/specs/int32-lt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.int32.with(S.lt, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: -2147483648, exclusiveMaximum: 5 }'
   output: '{ type: "integer", minimum: -2147483648, exclusiveMaximum: 5 }'

--- a/packages/sury/specs/int32-lte.yaml
+++ b/packages/sury/specs/int32-lte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.int32.with(S.lte, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: -2147483648, maximum: 5 }'
   output: '{ type: "integer", minimum: -2147483648, maximum: 5 }'

--- a/packages/sury/specs/integer-gte.yaml
+++ b/packages/sury/specs/integer-gte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.integer.with(S.gte, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: 5 }'
   output: '{ type: "integer", minimum: 5 }'

--- a/packages/sury/specs/integer-multipleOf-lcm.yaml
+++ b/packages/sury/specs/integer-multipleOf-lcm.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.integer.with(S.multipleOf, 2).with(S.multipleOf, 3)
   input: number
   output: number
-  instantiations: 684
+  instantiations: 680
 jsonSchema:
   input: '{ type: "integer", multipleOf: 6 }'
   output: '{ type: "integer", multipleOf: 6 }'

--- a/packages/sury/specs/json-novalidation.yaml
+++ b/packages/sury/specs/json-novalidation.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.noValidation, true)
   input: JSON
   output: JSON
-  instantiations: 600
+  instantiations: 577
 jsonSchema:
   input: "{}"
   output: "{}"

--- a/packages/sury/specs/jsonstring-array-string.yaml
+++ b/packages/sury/specs/jsonstring-array-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.array(S.string).with(S.to, S.jsonString)
   input: string[]
   output: string
-  instantiations: 5340
+  instantiations: 4526
 jsonSchema:
   input: '{ items: { type: "string" }, type: "array" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-array.yaml
+++ b/packages/sury/specs/jsonstring-array.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.array(S.schema({id: S.number, name: S.string})).with(S.to, S.jsonString)"
   input: "{ id: number; name: string; }[]"
   output: string
-  instantiations: 6832
+  instantiations: 6018
 jsonSchema:
   input: '{ items: { type: "object", properties: { id: { type: "number" }, name: { type: "string" } }, required: ["id", "name"] }, type: "array" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-dict-inherited.yaml
+++ b/packages/sury/specs/jsonstring-dict-inherited.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.record(S.number).with(S.to, S.jsonString)
   input: "{ [x: string]: number; }"
   output: string
-  instantiations: 5413
+  instantiations: 4599
 jsonSchema:
   input: '{ type: "object", additionalProperties: { type: "number" } }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-dict-string.yaml
+++ b/packages/sury/specs/jsonstring-dict-string.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.record(S.string).with(S.to, S.jsonString)
   input: "{ [x: string]: string; }"
   output: string
-  instantiations: 5355
+  instantiations: 4541
 jsonSchema:
   input: '{ type: "object", additionalProperties: { type: "string" } }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-dict.yaml
+++ b/packages/sury/specs/jsonstring-dict.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.record(S.optional(S.string)).with(S.to, S.jsonString)
   input: "{ [x: string]: string | undefined; }"
   output: string
-  instantiations: 5556
+  instantiations: 4742
 jsonSchema:
   input: '{ type: "object", additionalProperties: { type: "string" } }'
   fromInputType: "{ [key: string]: string; }"

--- a/packages/sury/specs/jsonstring-format-escfree.yaml
+++ b/packages/sury/specs/jsonstring-format-escfree.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ id: S.uuid, at: S.isoDateTime, note: S.string }).with(S.to, S.jsonString)"
   input: "{ id: string; at: string; note: string; }"
   output: string
-  instantiations: 5964
+  instantiations: 5150
 jsonSchema:
   input: '{ type: "object", properties: { id: { type: "string", format: "uuid" }, at: { type: "string", format: "date-time" }, note: { type: "string" } }, required: ["id", "at", "note"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-json.yaml
+++ b/packages/sury/specs/jsonstring-json.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.json.with(S.to, S.jsonString)
   input: JSON
   output: string
-  instantiations: 5233
+  instantiations: 4419
 jsonSchema:
   input: "{}"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-mixed.yaml
+++ b/packages/sury/specs/jsonstring-mixed.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({u: S.unknown, j: S.json, big: S.bigint, d: S.date}).with(S.to, S.jsonString)"
   input: "{ j: JSON; big: bigint; d: Date; u?: unknown; }"
   output: string
-  instantiations: 7488
+  instantiations: 6674
 jsonSchema:
   input: "Failed at u: Expected JSON, received unknown"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-novalidation-base64.yaml
+++ b/packages/sury/specs/jsonstring-novalidation-base64.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ v: S.base64.with(S.noValidation, true) }).with(S.to, S.jsonString)"
   input: "{ v: string; }"
   output: string
-  instantiations: 6390
+  instantiations: 5522
 jsonSchema:
   input: '{ type: "object", properties: { v: { type: "string", contentEncoding: "base64" } }, required: ["v"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-novalidation-date.yaml
+++ b/packages/sury/specs/jsonstring-novalidation-date.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ d: S.date.with(S.noValidation, true) }).with(S.to, S.jsonString)"
   input: "{ d: Date; }"
   output: string
-  instantiations: 6453
+  instantiations: 5585
 jsonSchema:
   input: "Failed at d: Expected JSON, received Date"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-novalidation-format.yaml
+++ b/packages/sury/specs/jsonstring-novalidation-format.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ id: S.uuid.with(S.noValidation, true) }).with(S.to, S.jsonString)"
   input: "{ id: string; }"
   output: string
-  instantiations: 6390
+  instantiations: 5522
 jsonSchema:
   input: '{ type: "object", properties: { id: { type: "string", format: "uuid" } }, required: ["id"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-novalidation.yaml
+++ b/packages/sury/specs/jsonstring-novalidation.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.noValidation(S.json, true).with(S.to, S.jsonString)
   input: JSON
   output: string
-  instantiations: 5350
+  instantiations: 4536
 jsonSchema:
   input: "{}"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-nullable-format.yaml
+++ b/packages/sury/specs/jsonstring-nullable-format.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ at: S.nullable(S.isoDateTime) }).with(S.to, S.jsonString)"
   input: "{ at: string | null; }"
   output: string
-  instantiations: 6111
+  instantiations: 5297
 jsonSchema:
   input: '{ type: "object", properties: { at: { anyOf: [{ type: "string", format: "date-time" }, { type: "null" }] } }, required: ["at"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-object-field.yaml
+++ b/packages/sury/specs/jsonstring-object-field.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({meta: S.jsonString, name: S.string}).with(S.to, S.jsonString)"
   input: "{ meta: string; name: string; }"
   output: string
-  instantiations: 5949
+  instantiations: 5135
 jsonSchema:
   input: '{ type: "object", properties: { meta: { type: "string", contentMediaType: "application/json" }, name: { type: "string" } }, required: ["meta", "name"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-object-optional.yaml
+++ b/packages/sury/specs/jsonstring-object-optional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.optional(S.string), b: S.number, c: S.optional(S.boolean)}).with(S.to, S.jsonString)"
   input: "{ b: number; a?: string | undefined; c?: boolean | undefined; }"
   output: string
-  instantiations: 7452
+  instantiations: 6638
 jsonSchema:
   input: '{ type: "object", properties: { a: { type: "string" }, b: { type: "number" }, c: { type: "boolean" } }, required: ["b"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-object-unknown.yaml
+++ b/packages/sury/specs/jsonstring-object-unknown.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({a: S.optional(S.unknown), b: S.string}).with(S.to, S.jsonString)"
   input: "{ b: string; a?: unknown; }"
   output: string
-  instantiations: 6912
+  instantiations: 6098
 jsonSchema:
   input: "Failed at a: Expected JSON, received unknown | undefined"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-object-url.yaml
+++ b/packages/sury/specs/jsonstring-object-url.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ href: S.url }).with(S.to, S.jsonString)"
   input: "{ href: URL; }"
   output: string
-  instantiations: 6004
+  instantiations: 5190
 jsonSchema:
   input: "Failed at href: Expected JSON, received URL"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-object.yaml
+++ b/packages/sury/specs/jsonstring-object.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.schema({id: S.number, name: S.string, tag: "x", flag: S.boolean}).with(S.to, S.jsonString)'
   input: '{ id: number; name: string; tag: "x"; flag: boolean; }'
   output: string
-  instantiations: 6565
+  instantiations: 5751
 jsonSchema:
   input: '{ type: "object", properties: { id: { type: "number" }, name: { type: "string" }, tag: { type: "string", const: "x" }, flag: { type: "boolean" } }, required: ["id", "name", "tag", "flag"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-optional-base64-field.yaml
+++ b/packages/sury/specs/jsonstring-optional-base64-field.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ p: S.optional(S.base64.with(S.minLength, 2)) }))"
   input: string
   output: "{ p?: string | undefined; }"
-  instantiations: 7729
+  instantiations: 6880
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "object", properties: { p: { type: "string", contentEncoding: "base64", minLength: 2 } } }'

--- a/packages/sury/specs/jsonstring-optional-jsonstring-field.yaml
+++ b/packages/sury/specs/jsonstring-optional-jsonstring-field.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonString.with(S.to, S.schema({ f: S.optional(S.jsonString) }))"
   input: string
   output: "{ f?: string | undefined; }"
-  instantiations: 7015
+  instantiations: 6201
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "object", properties: { f: { type: "string", contentMediaType: "application/json" } } }'

--- a/packages/sury/specs/jsonstring-tuple-in-object.yaml
+++ b/packages/sury/specs/jsonstring-tuple-in-object.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({x: S.tuple([S.string, S.optional(S.string)])}).with(S.to, S.jsonString)"
   input: "{ x: [string, string | undefined]; }"
   output: string
-  instantiations: 9620
+  instantiations: 8264
 jsonSchema:
   input: "Failed at x[1]: Expected JSON, received string | undefined"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-tuple.yaml
+++ b/packages/sury/specs/jsonstring-tuple.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string, S.number, S.union([S.string, undefined])]).with(S.to, S.jsonString)
   input: "[string, number, string | undefined]"
   output: string
-  instantiations: 6555
+  instantiations: 5741
 jsonSchema:
   input: "Failed at [2]: Expected JSON, received string | undefined"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-union-array-item.yaml
+++ b/packages/sury/specs/jsonstring-union-array-item.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.array(S.union([S.schema({type: "click", x: S.number}), S.schema({type: "view", path: S.string})])).with(S.to, S.jsonString)'
   input: '({ type: "click"; x: number; } | { type: "view"; path: string; })[]'
   output: string
-  instantiations: 9369
+  instantiations: 8555
 jsonSchema:
   input: '{ items: { anyOf: [{ type: "object", properties: { type: { type: "string", const: "click" }, x: { type: "number" } }, required: ["type", "x"] }, { type: "object", properties: { type: { type: "string", const: "view" }, path: { type: "string" } }, required: ["type", "path"] }] }, type: "array" }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-union-dict.yaml
+++ b/packages/sury/specs/jsonstring-union-dict.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.jsonString.with(S.to, S.union([S.record(S.bigint), S.array(S.bigint)]))
   input: string
   output: Record<string, bigint> | bigint[]
-  instantiations: 6500
+  instantiations: 5686
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at []: Expected JSON, received bigint"

--- a/packages/sury/specs/jsonstring-union-encode.yaml
+++ b/packages/sury/specs/jsonstring-union-encode.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({type: "user.created", id: S.bigint}), S.schema({type: "user.renamed", id: S.bigint, name: S.string})]).with(S.to, S.jsonString)'
   input: '{ type: "user.created"; id: bigint; } | { type: "user.renamed"; id: bigint; name: string; }'
   output: string
-  instantiations: 8602
+  instantiations: 7788
 jsonSchema:
   input: "Failed at id: Expected JSON, received bigint"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-union-nested.yaml
+++ b/packages/sury/specs/jsonstring-union-nested.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.jsonString.with(S.to, S.union([S.schema({t: "a", inner: S.schema({id: S.bigint}), note: S.optional(S.string)}), S.schema({t: "b"})]))'
   input: string
   output: '{ t: "a"; inner: { id: bigint; }; note?: string | undefined; } | { t: "b"; }'
-  instantiations: 11475
+  instantiations: 10661
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at inner.id: Expected JSON, received bigint"

--- a/packages/sury/specs/jsonstring-union-tuple.yaml
+++ b/packages/sury/specs/jsonstring-union-tuple.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.jsonString.with(S.to, S.union([S.tuple(s => [s.item(0, S.bigint), s.item(1, S.string)]), S.schema({t: "x", id: S.bigint})]))'
   input: string
   output: '(string | bigint)[] | { t: "x"; id: bigint; }'
-  instantiations: 7899
+  instantiations: 7085
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: "Failed at [0]: Expected JSON, received bigint"

--- a/packages/sury/specs/jsonstring-union-unknown-member.yaml
+++ b/packages/sury/specs/jsonstring-union-unknown-member.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.array(S.union([S.schema({kind: "a", v: S.string}), S.unknown])).with(S.to, S.jsonString)'
   input: unknown[]
   output: string
-  instantiations: 7312
+  instantiations: 6498
 jsonSchema:
   input: 'Failed at []: Expected JSON, received { kind: "a"; v: string; } | unknown'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-union.yaml
+++ b/packages/sury/specs/jsonstring-union.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({t: "a", v: S.string}), S.schema({t: "b", v: S.number})]).with(S.to, S.jsonString)'
   input: '{ t: "a"; v: string; } | { t: "b"; v: number; }'
   output: string
-  instantiations: 8588
+  instantiations: 7774
 jsonSchema:
   input: '{ anyOf: [{ type: "object", properties: { t: { type: "string", const: "a" }, v: { type: "string" } }, additionalProperties: false, required: ["t", "v"] }, { type: "object", properties: { t: { type: "string", const: "b" }, v: { type: "number" } }, additionalProperties: false, required: ["t", "v"] }] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/jsonstring-with-space.yaml
+++ b/packages/sury/specs/jsonstring-with-space.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.jsonStringWithSpace(2).with(S.to, S.schema({ foo: [1, S.number] }))"
   input: string
   output: "{ foo: [1, number]; }"
-  instantiations: 6633
+  instantiations: 5819
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/json" }'
   output: '{ type: "object", properties: { foo: { type: "array", minItems: 2, maxItems: 2, items: [{ type: "number", const: 1 }, { type: "number" }] } }, required: ["foo"] }'

--- a/packages/sury/specs/number-gt.yaml
+++ b/packages/sury/specs/number-gt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.gt, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", exclusiveMinimum: 5 }'
   output: '{ type: "number", exclusiveMinimum: 5 }'

--- a/packages/sury/specs/number-gte-redundant.yaml
+++ b/packages/sury/specs/number-gte-redundant.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.gte, 5).with(S.gte, 1, "MY MESSAGE")
   input: number
   output: number
-  instantiations: 814
+  instantiations: 812
 jsonSchema:
   input: '{ type: "number", minimum: 5 }'
   output: '{ type: "number", minimum: 5 }'

--- a/packages/sury/specs/number-gte-replaces-message.yaml
+++ b/packages/sury/specs/number-gte-replaces-message.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.gte, 5, "A").with(S.gte, 10)
   input: number
   output: number
-  instantiations: 814
+  instantiations: 812
 jsonSchema:
   input: '{ type: "number", minimum: 10 }'
   output: '{ type: "number", minimum: 10 }'

--- a/packages/sury/specs/number-gte.yaml
+++ b/packages/sury/specs/number-gte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.gte, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", minimum: 5 }'
   output: '{ type: "number", minimum: 5 }'

--- a/packages/sury/specs/number-lt.yaml
+++ b/packages/sury/specs/number-lt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.lt, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", exclusiveMaximum: 5 }'
   output: '{ type: "number", exclusiveMaximum: 5 }'

--- a/packages/sury/specs/number-lte.yaml
+++ b/packages/sury/specs/number-lte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.lte, 5)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", maximum: 5 }'
   output: '{ type: "number", maximum: 5 }'

--- a/packages/sury/specs/number-multipleOf-bounded.yaml
+++ b/packages/sury/specs/number-multipleOf-bounded.yaml
@@ -5,7 +5,7 @@ ts:
     - S.number.with(S.gt, -50).with(S.lt, 50).with(S.multipleOf, 2)
   input: number
   output: number
-  instantiations: 952
+  instantiations: 948
 jsonSchema:
   input: '{ type: "number", multipleOf: 2, exclusiveMinimum: -50, exclusiveMaximum: 50 }'
   output: '{ type: "number", multipleOf: 2, exclusiveMinimum: -50, exclusiveMaximum: 50 }'

--- a/packages/sury/specs/number-multipleOf-fractional.yaml
+++ b/packages/sury/specs/number-multipleOf-fractional.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.multipleOf, 0.1)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", multipleOf: 0.1 }'
   output: '{ type: "number", multipleOf: 0.1 }'

--- a/packages/sury/specs/number-multipleOf-small.yaml
+++ b/packages/sury/specs/number-multipleOf-small.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.number.with(S.multipleOf, 0.0001)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", multipleOf: 0.0001 }'
   output: '{ type: "number", multipleOf: 0.0001 }'

--- a/packages/sury/specs/number-multipleOf.yaml
+++ b/packages/sury/specs/number-multipleOf.yaml
@@ -5,7 +5,7 @@ ts:
     - S.number.with(S.multipleOf, 2).with(S.multipleOf, 2)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "number", multipleOf: 2 }'
   output: '{ type: "number", multipleOf: 2 }'

--- a/packages/sury/specs/object-deep-strict.yaml
+++ b/packages/sury/specs/object-deep-strict.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({ foo: { a: S.string } }).with(S.deepStrict)"
   input: "{ foo: { a: string; }; }"
   output: "{ foo: { a: string; }; }"
-  instantiations: 1708
+  instantiations: 1706
 jsonSchema:
   input: '{ type: "object", properties: { foo: { type: "object", properties: { a: { type: "string" } }, additionalProperties: false, required: ["a"] } }, additionalProperties: false, required: ["foo"] }'
   output: '{ type: "object", properties: { foo: { type: "object", properties: { a: { type: "string" } }, additionalProperties: false, required: ["a"] } }, additionalProperties: false, required: ["foo"] }'

--- a/packages/sury/specs/object-key-escaping.yaml
+++ b/packages/sury/specs/object-key-escaping.yaml
@@ -3,7 +3,7 @@ ts:
   schema: "S.schema({[\"c\\\\d\"]: S.string, ['q\"t']: S.number}).with(S.to, S.jsonString)"
   input: '{ "c\\d": string; "q\"t": number; }'
   output: string
-  instantiations: 6199
+  instantiations: 5385
 jsonSchema:
   input: '{ type: "object", properties: { "c\\d": { type: "string" }, "q\"t": { type: "number" } }, required: ["c\\d", "q\"t"] }'
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/object-pick-from-codec-field.yaml
+++ b/packages/sury/specs/object-pick-from-codec-field.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.object((s) => ({ y: s.field("f", S.schema({ b: S.string }).with(S.to, S.schema({ b: S.string }), { decode: (v) => ({ b: v.b + "!" }), encode: (v) => ({ b: v.b.slice(0, -1) }) })).b }))'
   input: "{ [x: string]: unknown; }"
   output: "{ y: string; }"
-  instantiations: 6792
+  instantiations: 5947
 jsonSchema:
   input: '{ type: "object", properties: { f: { type: "object", properties: { b: { type: "string" } }, required: ["b"] } }, required: ["f"] }'
   fromInputType: "{ f: { b: string; }; }"

--- a/packages/sury/specs/object-strict.yaml
+++ b/packages/sury/specs/object-strict.yaml
@@ -5,7 +5,7 @@ ts:
     - "S.strict(S.schema({ foo: S.string }))"
   input: "{ foo: string; }"
   output: "{ foo: string; }"
-  instantiations: 1548
+  instantiations: 1546
 jsonSchema:
   input: '{ type: "object", properties: { foo: { type: "string" } }, additionalProperties: false, required: ["foo"] }'
   output: '{ type: "object", properties: { foo: { type: "string" } }, additionalProperties: false, required: ["foo"] }'

--- a/packages/sury/specs/optional-default-input-refined.yaml
+++ b/packages/sury/specs/optional-default-input-refined.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.optional(S.reverse(S.string.with(S.minLength, 2)), "xx")
   input: string | undefined
   output: string
-  instantiations: 1435
+  instantiations: 1379
 jsonSchema:
   input: Expected JSON, received string.length >= 2 | undefined
   output: '{ type: "string", minLength: 2 }'

--- a/packages/sury/specs/optional-default-lazy.yaml
+++ b/packages/sury/specs/optional-default-lazy.yaml
@@ -1,9 +1,9 @@
 # yaml-language-server: $schema=./spec.schema.json
 ts:
-  schema: S.string.with(S.optional, "foo")
+  schema: S.string.with(S.optional, () => "foo")
   input: string | undefined
   output: string
-  instantiations: 4437
+  instantiations: 4571
 jsonSchema:
   input: Expected JSON, received string | undefined
   output: '{ type: "string" }'
@@ -11,7 +11,7 @@ vs:
   zod: z.string().optional().transform((value) => value ?? "foo")
 operations:
   parse:
-    expression: i=>{for(;;){if(typeof i==="string")break;if(i===void 0){i="foo";break}e[0](i)}return i}
+    expression: i=>{for(;;){if(typeof i==="string")break;if(i===void 0){i=e[0]();break}e[1](i)}return i}
     examples:
       string:
         input: '"bar"'

--- a/packages/sury/specs/port-gt.yaml
+++ b/packages/sury/specs/port-gt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.port.with(S.gt, 80)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", maximum: 65535, exclusiveMinimum: 80 }'
   output: '{ type: "integer", maximum: 65535, exclusiveMinimum: 80 }'

--- a/packages/sury/specs/port-gte.yaml
+++ b/packages/sury/specs/port-gte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.port.with(S.gte, 80)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: 80, maximum: 65535 }'
   output: '{ type: "integer", minimum: 80, maximum: 65535 }'

--- a/packages/sury/specs/port-lt.yaml
+++ b/packages/sury/specs/port-lt.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.port.with(S.lt, 80)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: 0, exclusiveMaximum: 80 }'
   output: '{ type: "integer", minimum: 0, exclusiveMaximum: 80 }'

--- a/packages/sury/specs/port-lte.yaml
+++ b/packages/sury/specs/port-lte.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.port.with(S.lte, 80)
   input: number
   output: number
-  instantiations: 582
+  instantiations: 578
 jsonSchema:
   input: '{ type: "integer", minimum: 0, maximum: 80 }'
   output: '{ type: "integer", minimum: 0, maximum: 80 }'

--- a/packages/sury/specs/recursive-nested-recursive.yaml
+++ b/packages/sury/specs/recursive-nested-recursive.yaml
@@ -3,7 +3,7 @@ ts:
   schema: '((Inner) => S.recursive("Outer", (outer) => S.schema({ inner: Inner, next: S.optional(outer) })))(S.recursive("Inner", (inner) => S.schema({ v: S.string, next: S.optional(inner) })))'
   input: unknown
   output: unknown
-  instantiations: 11176
+  instantiations: 9528
 jsonSchema:
   input: '{ $ref: "#/$defs/Outer", $defs: { Outer: { type: "object", properties: { inner: { $ref: "#/$defs/Inner" }, next: { $ref: "#/$defs/Outer" } }, required: ["inner"] }, Inner: { type: "object", properties: { v: { type: "string" }, next: { $ref: "#/$defs/Inner" } }, required: ["v"] } } }'
   fromInputType: "{ inner: { v: string; next?: ... | undefined; }; next?: ... | undefined; }"

--- a/packages/sury/specs/recursive-proto-name.yaml
+++ b/packages/sury/specs/recursive-proto-name.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.recursive("__proto__", (self) => S.schema({ v: S.string, next: S.optional(self) }))'
   input: unknown
   output: unknown
-  instantiations: 9071
+  instantiations: 7709
 jsonSchema:
   input: '{ $ref: "#/$defs/__proto__", $defs: { ["__proto__"]: { type: "object", properties: { v: { type: "string" }, next: { $ref: "#/$defs/__proto__" } }, required: ["v"] } } }'
   fromInputType: "{ v: string; next?: ... | undefined; }"

--- a/packages/sury/specs/recursive-reserved-name.yaml
+++ b/packages/sury/specs/recursive-reserved-name.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.recursive("toString", (self) => S.schema({ v: S.string, next: S.optional(self) }))'
   input: unknown
   output: unknown
-  instantiations: 9071
+  instantiations: 7709
 jsonSchema:
   input: '{ $ref: "#/$defs/toString", $defs: { toString: { type: "object", properties: { v: { type: "string" }, next: { $ref: "#/$defs/toString" } }, required: ["v"] } } }'
   fromInputType: "{ v: string; next?: ... | undefined; }"

--- a/packages/sury/specs/refine-path-index.yaml
+++ b/packages/sury/specs/refine-path-index.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.schema({ items: S.array(S.string) }).with(S.refine, () => false, { error: "User error", path: ["items", 0] })'
+  input: "{ items: string[]; }"
+  output: "{ items: string[]; }"
+  instantiations: 1838
+jsonSchema:
+  input: '{ type: "object", properties: { items: { items: { type: "string" }, type: "array" } }, required: ["items"] }'
+  output: '{ type: "object", properties: { items: { items: { type: "string" }, type: "array" } }, required: ["items"] }'
+vs:
+  zod: 'z.object({ items: z.array(z.string()) }).refine(() => false, { message: "User error", path: ["items", 0] })'
+operations:
+  parse:
+    expression: i=>{typeof i==="object"&&i&&!Array.isArray(i)||e[4](i);let v0=i["items"];Array.isArray(v0)||e[1](v0);for(let v1=0;v1<v0.length;++v1){try{let v2=v0[v1];typeof v2==="string"||e[0](v2);}catch(v3){v3.path=["items",v1,...v3.path];throw v3}}let v4={items:v0};e[2](v4)||e[3](v4);return v4}
+    examples:
+      always-fails-at-index:
+        input: '{ items: ["a"] }'
+        error: "Failed at items[0]: User error"
+  decode:
+    expression: i=>{let v0=i["items"];e[0](i)||e[1](i);return i}
+    examples:
+      always-fails-at-index:
+        input: '{ items: ["a"] }'
+        error: "Failed at items[0]: User error"
+  encode:
+    expression: i=>{e[0](i)||e[1](i);let v0=i["items"];return i}
+    examples:
+      always-fails-at-index:
+        input: '{ items: ["a"] }'
+        error: "Failed at items[0]: User error"

--- a/packages/sury/specs/set-minSize-redundant.yaml
+++ b/packages/sury/specs/set-minSize-redundant.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.instance(Set).with(S.minSize, 5).with(S.minSize, 1, "MY MESSAGE")
   input: Set<unknown>
   output: Set<unknown>
-  instantiations: 2816
+  instantiations: 2814
 jsonSchema:
   input: Expected JSON, received Set.size >= 5
   output: Expected JSON, received Set.size >= 5

--- a/packages/sury/specs/set-minSize.yaml
+++ b/packages/sury/specs/set-minSize.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.instance(Set).with(S.minSize, 2)
   input: Set<unknown>
   output: Set<unknown>
-  instantiations: 2582
+  instantiations: 2578
 jsonSchema:
   input: Expected JSON, received Set.size >= 2
   output: Expected JSON, received Set.size >= 2

--- a/packages/sury/specs/set-size-supersedes-maxSize-message.yaml
+++ b/packages/sury/specs/set-size-supersedes-maxSize-message.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.instance(Set).with(S.maxSize, 5, "MAX").with(S.size, 3)
   input: Set<unknown>
   output: Set<unknown>
-  instantiations: 2898
+  instantiations: 2896
 jsonSchema:
   input: Expected JSON, received Set.size == 3
   output: Expected JSON, received Set.size == 3

--- a/packages/sury/specs/shape-pick-from-codec.yaml
+++ b/packages/sury/specs/shape-pick-from-codec.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.schema({ f: S.schema({ b: S.string }).with(S.to, S.schema({ b: S.string }), { decode: (v) => ({ b: v.b + "!" }), encode: (v) => ({ b: v.b.slice(0, -1) }) }) }).with(S.shape, (v) => ({ z: v.f.b }))'
   input: "{ f: { b: string; }; }"
   output: "{ z: string; }"
-  instantiations: 9539
+  instantiations: 7061
 jsonSchema:
   input: '{ type: "object", properties: { f: { type: "object", properties: { b: { type: "string" } }, required: ["b"] } }, required: ["f"] }'
   output: '{ type: "object", properties: { z: { type: "string" } }, required: ["z"] }'

--- a/packages/sury/specs/string-empty.yaml
+++ b/packages/sury/specs/string-empty.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.length, 0)
   input: '""'
   output: '""'
-  instantiations: 849
+  instantiations: 845
 jsonSchema:
   input: '{ type: "string", minLength: 0, maxLength: 0 }'
   output: '{ type: "string", minLength: 0, maxLength: 0 }'

--- a/packages/sury/specs/string-length-converged-message.yaml
+++ b/packages/sury/specs/string-length-converged-message.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.maxLength, 5, "custom too long").with(S.minLength, 5)
   input: string
   output: string
-  instantiations: 1107
+  instantiations: 1105
 jsonSchema:
   input: '{ type: "string", minLength: 5, maxLength: 5 }'
   output: '{ type: "string", minLength: 5, maxLength: 5 }'

--- a/packages/sury/specs/string-length-custom-message.yaml
+++ b/packages/sury/specs/string-length-custom-message.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.length, 5, "Postcode must have 5 symbols")
   input: string
   output: string
-  instantiations: 815
+  instantiations: 814
 jsonSchema:
   input: '{ type: "string", minLength: 5, maxLength: 5 }'
   output: '{ type: "string", minLength: 5, maxLength: 5 }'

--- a/packages/sury/specs/string-length-redundant.yaml
+++ b/packages/sury/specs/string-length-redundant.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.length, 2).with(S.length, 2, "MY MESSAGE")
   input: string
   output: string
-  instantiations: 1087
+  instantiations: 1085
 jsonSchema:
   input: '{ type: "string", minLength: 2, maxLength: 2 }'
   output: '{ type: "string", minLength: 2, maxLength: 2 }'

--- a/packages/sury/specs/string-length-supersedes-maxLength-message.yaml
+++ b/packages/sury/specs/string-length-supersedes-maxLength-message.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.maxLength, 5, "MAX").with(S.length, 3)
   input: string
   output: string
-  instantiations: 1125
+  instantiations: 1123
 jsonSchema:
   input: '{ type: "string", minLength: 3, maxLength: 3 }'
   output: '{ type: "string", minLength: 3, maxLength: 3 }'

--- a/packages/sury/specs/string-length.yaml
+++ b/packages/sury/specs/string-length.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.length, 2)
   input: string
   output: string
-  instantiations: 811
+  instantiations: 807
 jsonSchema:
   input: '{ type: "string", minLength: 2, maxLength: 2 }'
   output: '{ type: "string", minLength: 2, maxLength: 2 }'

--- a/packages/sury/specs/string-maxLength.yaml
+++ b/packages/sury/specs/string-maxLength.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.maxLength, 2)
   input: string
   output: string
-  instantiations: 581
+  instantiations: 577
 jsonSchema:
   input: '{ type: "string", maxLength: 2 }'
   output: '{ type: "string", maxLength: 2 }'

--- a/packages/sury/specs/string-minLength-zero.yaml
+++ b/packages/sury/specs/string-minLength-zero.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.minLength, 0)
   input: string
   output: string
-  instantiations: 793
+  instantiations: 789
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/string-minLength.yaml
+++ b/packages/sury/specs/string-minLength.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.minLength, 2)
   input: string
   output: string
-  instantiations: 793
+  instantiations: 789
 jsonSchema:
   input: '{ type: "string", minLength: 2 }'
   output: '{ type: "string", minLength: 2 }'

--- a/packages/sury/specs/string-nonEmpty.yaml
+++ b/packages/sury/specs/string-nonEmpty.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.nonEmpty)
   input: string
   output: string
-  instantiations: 652
+  instantiations: 650
 jsonSchema:
   input: '{ type: "string", minLength: 1 }'
   output: '{ type: "string", minLength: 1 }'

--- a/packages/sury/specs/string-refine-path.yaml
+++ b/packages/sury/specs/string-refine-path.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.refine, () => false, { error: "User error", path: ["data", "field"] })'
   input: string
   output: string
-  instantiations: 661
+  instantiations: 664
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/string-refine-path.yaml
+++ b/packages/sury/specs/string-refine-path.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.refine, () => false, { error: "User error", path: ["data", "field"] })'
   input: string
   output: string
-  instantiations: 5076
+  instantiations: 661
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/string-refine.yaml
+++ b/packages/sury/specs/string-refine.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.string.with(S.refine, (value) => value !== "bad", { error: "User error" })'
   input: string
   output: string
-  instantiations: 5069
+  instantiations: 762
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/string-to-blob.yaml
+++ b/packages/sury/specs/string-to-blob.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.string.with(S.to, S.blob)
   input: string
   output: Blob
-  instantiations: 5244
+  instantiations: 4430
 jsonSchema:
   input: '{ type: "string", contentMediaType: "application/octet-stream" }'
   output: Expected JSON, received Blob

--- a/packages/sury/specs/tuple1-transform.yaml
+++ b/packages/sury/specs/tuple1-transform.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.schema([S.string.with(S.to, S.number, (s) => Number(s))])
   input: "[string]"
   output: "[number]"
-  instantiations: 6002
+  instantiations: 5157
 jsonSchema:
   input: '{ type: "array", minItems: 1, maxItems: 1, items: [{ type: "string" }] }'
   output: '{ type: "array", minItems: 1, maxItems: 1, items: [{ type: "number" }] }'

--- a/packages/sury/specs/union-large-planner.yaml
+++ b/packages/sury/specs/union-large-planner.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union(["literal-0", "literal-1", "literal-2", "literal-3", "literal-4", "literal-5", "literal-6", "literal-7", { kind: "number", value: S.number }, { kind: "string", value: S.string }, { kind: "boolean", value: S.boolean }, { kind: "bigint", value: S.bigint }, S.instance(Date).with(S.to, S.string, () => "date"), S.instance(Error).with(S.to, S.string, () => "error"), S.instance(TypeError).with(S.to, S.string, () => "type-error"), S.union([S.string.with(S.minLength, 12), S.number]).with(S.refine, () => false, { error: "opaque member rejected" }), S.string, S.number, S.boolean, S.bigint, S.symbol, null, undefined])'
   input: 'string | number | bigint | boolean | symbol | Date | Error | { kind: "number"; value: number; } | { kind: "string"; value: string; } | { kind: "boolean"; value: boolean; } | { kind: "bigint"; value: bigint; } | null | undefined'
   output: 'string | number | bigint | boolean | symbol | { kind: "number"; value: number; } | { kind: "string"; value: string; } | { kind: "boolean"; value: boolean; } | { kind: "bigint"; value: bigint; } | null | undefined'
-  instantiations: 12754
+  instantiations: 12158
 jsonSchema:
   input: "Failed at value: Expected JSON, received bigint"
   output: "Failed at value: Expected JSON, received bigint"

--- a/packages/sury/specs/union-nan-discriminant.yaml
+++ b/packages/sury/specs/union-nan-discriminant.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({t: NaN, a: S.string}), S.schema({t: "b", b: S.number})]).with(S.to, S.jsonString)'
   input: '{ t: number; a: string; } | { t: "b"; b: number; }'
   output: string
-  instantiations: 8595
+  instantiations: 7781
 jsonSchema:
   input: "Failed at t: Expected JSON, received NaN"
   output: '{ type: "string", contentMediaType: "application/json" }'

--- a/packages/sury/specs/union2-broad-covers-blocked-by-refine.yaml
+++ b/packages/sury/specs/union2-broad-covers-blocked-by-refine.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.minLength, 3), S.string])
   input: string
   output: string
-  instantiations: 1418
+  instantiations: 1362
 jsonSchema:
   input: '{ anyOf: [{ type: "string", minLength: 3 }, { type: "string" }] }'
   output: '{ anyOf: [{ type: "string", minLength: 3 }, { type: "string" }] }'

--- a/packages/sury/specs/union2-opaque-literal-effect-boundary.yaml
+++ b/packages/sury/specs/union2-opaque-literal-effect-boundary.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.literal("a"), S.literal("b").with(S.to, S.json)])
   input: '"a" | "b"'
   output: JSON
-  instantiations: 6319
+  instantiations: 5474
 jsonSchema:
   input: '{ enum: ["a", "b"] }'
   output: '{ anyOf: [{ type: "string", const: "a" }, { type: "string", const: "b" }] }'

--- a/packages/sury/specs/union2-refine-throws.yaml
+++ b/packages/sury/specs/union2-refine-throws.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.refine, (v) => { throw new TypeError("predicate blew up") }), S.string])
   input: string
   output: string
-  instantiations: 5603
+  instantiations: 4978
 jsonSchema:
   input: '{ type: "string" }'
   output: '{ type: "string" }'

--- a/packages/sury/specs/union2-refined-literal-fallback.yaml
+++ b/packages/sury/specs/union2-refined-literal-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.minLength, 3), S.schema("x")])
   input: string
   output: string
-  instantiations: 1875
+  instantiations: 1819
 jsonSchema:
   input: '{ anyOf: [{ type: "string", minLength: 3 }, { type: "string", const: "x" }] }'
   output: '{ anyOf: [{ type: "string", minLength: 3 }, { type: "string", const: "x" }] }'

--- a/packages/sury/specs/union2-shared-discriminator-fallback.yaml
+++ b/packages/sury/specs/union2-shared-discriminator-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({ kind: S.schema("a"), value: S.number.with(S.gte, 2) }), S.schema({ kind: S.schema("a"), value: S.schema(1) })])'
   input: '{ kind: "a"; value: number; } | { kind: "a"; value: 1; }'
   output: '{ kind: "a"; value: number; } | { kind: "a"; value: 1; }'
-  instantiations: 4960
+  instantiations: 4904
 jsonSchema:
   input: '{ anyOf: [{ type: "object", properties: { kind: { type: "string", const: "a" }, value: { type: "number", minimum: 2 } }, required: ["kind", "value"] }, { type: "object", properties: { kind: { type: "string", const: "a" }, value: { type: "number", const: 1 } }, required: ["kind", "value"] }] }'
   output: '{ anyOf: [{ type: "object", properties: { kind: { type: "string", const: "a" }, value: { type: "number", minimum: 2 } }, required: ["kind", "value"] }, { type: "object", properties: { kind: { type: "string", const: "a" }, value: { type: "number", const: 1 } }, required: ["kind", "value"] }] }'

--- a/packages/sury/specs/union2-symbol-literal-fallback.yaml
+++ b/packages/sury/specs/union2-symbol-literal-fallback.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema(Symbol.for("union-fallback")).with(S.refine, () => false, { error: "first rejected" }), S.schema(Symbol.for("union-fallback"))])'
   input: symbol
   output: symbol
-  instantiations: 5788
+  instantiations: 1526
 jsonSchema:
   input: Expected JSON, received Symbol(union-fallback)
   output: Expected JSON, received Symbol(union-fallback)

--- a/packages/sury/specs/union3-broad-covers-blocked-by-codec.yaml
+++ b/packages/sury/specs/union3-broad-covers-blocked-by-codec.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema("apple"), S.string.with(S.to, S.number, { decode: Number, encode: String }), S.string])'
   input: string
   output: string | number
-  instantiations: 6672
+  instantiations: 5827
 jsonSchema:
   input: '{ anyOf: [{ type: "string", const: "apple" }, { type: "string" }] }'
   output: '{ anyOf: [{ type: "string", const: "apple" }, { type: "number" }, { type: "string" }] }'

--- a/packages/sury/specs/union3-instance-priority-order.yaml
+++ b/packages/sury/specs/union3-instance-priority-order.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.instance(Error).with(S.to, S.string, () => "error"), S.schema({ x: S.string }), S.instance(TypeError).with(S.to, S.string, () => "type-error")])'
   input: "Error | { x: string; }"
   output: "string | { x: string; }"
-  instantiations: 7901
+  instantiations: 7056
 jsonSchema:
   input: "Expected JSON, received Error | { x: string; } | TypeError"
   output: '{ anyOf: [{ type: "string" }, { type: "object", properties: { x: { type: "string" } }, required: ["x"] }] }'

--- a/packages/sury/specs/union3-overlap-group-barrier.yaml
+++ b/packages/sury/specs/union3-overlap-group-barrier.yaml
@@ -3,7 +3,7 @@ ts:
   schema: 'S.union([S.schema({ kind: "left", value: S.string }).with(S.refine, () => false, { error: "left member rejected" }), S.schema({ kind: S.string, value: S.string.with(S.pattern, /^broad-/, "broad member rejected") }), S.schema({ kind: "right", value: S.string.with(S.pattern, /^right-/, "right member rejected") })])'
   input: '{ kind: "left"; value: string; } | { kind: string; value: string; } | { kind: "right"; value: string; }'
   output: '{ kind: "left"; value: string; } | { kind: string; value: string; } | { kind: "right"; value: string; }'
-  instantiations: 10719
+  instantiations: 6523
 jsonSchema:
   input: '{ anyOf: [{ type: "object", properties: { kind: { type: "string", const: "left" }, value: { type: "string" } }, required: ["kind", "value"] }, { type: "object", properties: { kind: { type: "string" }, value: { type: "string", pattern: "^broad-" } }, required: ["kind", "value"] }, { type: "object", properties: { kind: { type: "string", const: "right" }, value: { type: "string", pattern: "^right-" } }, required: ["kind", "value"] }] }'
   output: '{ anyOf: [{ type: "object", properties: { kind: { type: "string", const: "left" }, value: { type: "string" } }, required: ["kind", "value"] }, { type: "object", properties: { kind: { type: "string" }, value: { type: "string", pattern: "^broad-" } }, required: ["kind", "value"] }, { type: "object", properties: { kind: { type: "string", const: "right" }, value: { type: "string", pattern: "^right-" } }, required: ["kind", "value"] }] }'

--- a/packages/sury/specs/union3-same-tag-effect-boundary.yaml
+++ b/packages/sury/specs/union3-same-tag-effect-boundary.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.minLength, 5), S.string.with(S.to, S.number), S.string.with(S.maxLength, 1)])
   input: string
   output: string | number
-  instantiations: 6804
+  instantiations: 5955
 jsonSchema:
   input: '{ anyOf: [{ type: "string", minLength: 5 }, { type: "string" }, { type: "string", maxLength: 1 }] }'
   output: '{ anyOf: [{ type: "string", minLength: 5 }, { type: "number" }, { type: "string", maxLength: 1 }] }'

--- a/packages/sury/specs/union3-same-tag-validation-group.yaml
+++ b/packages/sury/specs/union3-same-tag-validation-group.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.string.with(S.minLength, 4), S.string.with(S.maxLength, 1), S.string.with(S.length, 2)])
   input: string
   output: string
-  instantiations: 2050
+  instantiations: 1994
 jsonSchema:
   input: '{ anyOf: [{ type: "string", minLength: 4 }, { type: "string", maxLength: 1 }, { type: "string", minLength: 2, maxLength: 2 }] }'
   output: '{ anyOf: [{ type: "string", minLength: 4 }, { type: "string", maxLength: 1 }, { type: "string", minLength: 2, maxLength: 2 }] }'

--- a/packages/sury/specs/union5-env-boolean.yaml
+++ b/packages/sury/specs/union5-env-boolean.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.union([S.schema("t").with(S.to, S.schema(true)).with(S.to, S.boolean), S.schema("1").with(S.to, S.schema(true)).with(S.to, S.boolean), S.schema("f").with(S.to, S.schema(false)).with(S.to, S.boolean), S.schema("0").with(S.to, S.schema(false)).with(S.to, S.boolean), S.string.with(S.to, S.boolean)])
   input: string
   output: boolean
-  instantiations: 9475
+  instantiations: 8506
 jsonSchema:
   input: '{ anyOf: [{ type: "string", const: "t" }, { type: "string", const: "1" }, { type: "string", const: "f" }, { type: "string", const: "0" }, { type: "string" }] }'
   output: '{ anyOf: [{ type: "boolean", const: true }, { type: "boolean", const: false }, { type: "boolean" }] }'

--- a/packages/sury/specs/uri-https-only.yaml
+++ b/packages/sury/specs/uri-https-only.yaml
@@ -3,7 +3,7 @@ ts:
   schema: S.uri.with(S.pattern, /^https:\/\//)
   input: string
   output: string
-  instantiations: 596
+  instantiations: 573
 jsonSchema:
   input: '{ type: "string", format: "uri", pattern: "^https:\\/\\/" }'
   output: '{ type: "string", format: "uri", pattern: "^https:\\/\\/" }'

--- a/packages/sury/src/S.res
+++ b/packages/sury/src/S.res
@@ -489,7 +489,7 @@ type url
 
 // The public JS `refine` takes an options object; build it here from the
 // ReScript labeled args.
-type refineOptions = {error?: string, path?: array<string>}
+type refineOptions = {error?: string, path?: Path.t}
 @module("sury")
 external refine: (t<'value>, 'value => bool, refineOptions) => t<'value> = "refine"
 let refine = (schema, refiner, ~error=?, ~path=?) => refine(schema, refiner, {?error, ?path})

--- a/packages/sury/src/entry.ts
+++ b/packages/sury/src/entry.ts
@@ -36,6 +36,7 @@ import {
   objectTag,
   panic,
   pathEmpty,
+  type Path,
   stringify,
   stringTag,
   U,
@@ -434,7 +435,7 @@ export const to = (schema: Internal, target: Internal, custom?: unknown) => {
 export const refine = (
   schema: Internal,
   refineCheck: (value: unknown) => boolean,
-  refineOptions?: { error?: string; path?: string[] },
+  refineOptions?: { error?: string; path?: Path },
 ) => {
   const message = refineOptions?.error ?? "Refinement failed";
   const extraPath = refineOptions?.path !== U ? refineOptions.path : pathEmpty;

--- a/packages/sury/tests/S_Error_customConsolidation_test.res
+++ b/packages/sury/tests/S_Error_customConsolidation_test.res
@@ -68,7 +68,7 @@ test("S.refine with ~error produces InvalidInput with custom reason", t => {
 })
 
 test("S.refine with ~error and ~path applies path correctly", t => {
-  let schema = S.string->S.refine(_ => false, ~error="bad", ~path=["a", "b"])
+  let schema = S.string->S.refine(_ => false, ~error="bad", ~path=S.Path.fromArray(["a", "b"]))
   switch "hi"->S.parseOrThrow(~to=schema) {
   | _ => t->Assert.fail("Should have thrown")
   | exception S.Exn(error) =>
@@ -76,6 +76,20 @@ test("S.refine with ~error and ~path applies path correctly", t => {
     | InvalidInput({reason, path}) =>
       t->Assert.is(reason, "bad", ~message="reason")
       t->Assert.is(path->S.Path.toText, "a.b", ~message="path")
+    | _ => t->Assert.fail("Expected InvalidInput error")
+    }
+  }
+})
+
+test("S.refine ~path takes an array index as a number segment", t => {
+  let schema = S.string->S.refine(_ => false, ~error="bad", ~path=[String("items"), Number(0.)])
+  switch "hi"->S.parseOrThrow(~to=schema) {
+  | _ => t->Assert.fail("Should have thrown")
+  | exception S.Exn(error) =>
+    switch error->S.Error.classify {
+    | InvalidInput({path}) =>
+      t->Assert.deepEqual(path, [String("items"), Number(0.)], ~message="segments keep their kind")
+      t->Assert.is(path->S.Path.toText, "items[0]", ~message="path")
     | _ => t->Assert.fail("Expected InvalidInput error")
     }
   }

--- a/packages/sury/tests/S_refine_test.res
+++ b/packages/sury/tests/S_refine_test.res
@@ -15,7 +15,7 @@ test("Fails with default error message", t => {
 })
 
 test("Fails with custom path", t => {
-  let schema = S.int->S.refine(value => value >= 0, ~error="Should be positive", ~path=["confirm"])
+  let schema = S.int->S.refine(value => value >= 0, ~error="Should be positive", ~path=S.Path.fromArray(["confirm"]))
 
   t->U.assertThrowsMessage(
     () => %raw(`-12`)->S.parseOrThrow(~to=schema),

--- a/packages/sury/tests/S_test.ts
+++ b/packages/sury/tests/S_test.ts
@@ -633,8 +633,6 @@ test("Successfully parses undefined using the default value from callback", (t) 
   t.expect(value).toEqual("foo");
   t.expect(schema.default).toEqual(undefined);
 
-  //FIXME: This is broken
-  // @ts-expect-error
   expectSchemaType(schema).toBe<string | undefined, string>();
 });
 

--- a/packages/sury/tests/spec_errors_test.ts
+++ b/packages/sury/tests/spec_errors_test.ts
@@ -245,7 +245,7 @@ test("jsonSchema round-trip types are required when they diverge from the schema
         jsonSchema.fromOutputType: omitted, but S.fromJSONSchema(jsonSchema.output) infers "string[]" !== ts.output "[string, string, ...string[]]" — add \`fromOutputType\`.
         goldens stale — run \`pnpm spec check array-minLength --write\` (also formats canonically; use \`pnpm spec format\` for a formatting-only fix):
     @@ -6,7 +6,9 @@
-        instantiations: 1125
+        instantiations: 1121
       jsonSchema:
         input: '{ items: { type: "string" }, type: "array", minItems: 2 }'
     +   fromInputType: string[]
@@ -338,7 +338,7 @@ test("identity claimed but the operation doesn't actually compile to identity", 
         input: string
         output: string
     -   instantiations: 254
-    +   instantiations: 793
+    +   instantiations: 789
       jsonSchema:
     -   input: '{ type: "string" }'
     -   output: '{ type: "string" }'
@@ -420,7 +420,7 @@ test("eq-to-parse claimed but the operation doesn't actually compile to the same
     -   instantiations: 254
     +   input: string
     +   output: string
-    +   instantiations: 793
+    +   instantiations: 789
       jsonSchema:
     -   input: "{ not: {} }"
     -   output: "{ not: {} }"


### PR DESCRIPTION
## `.with` typing

`s.with(fn, ...args)` has always been `fn(s, ...args)` at runtime; the type had seven overloads to say so. Four now: `to` (unchanged), the callback overload for `S.shape`, one argument, and a rest tuple for zero or two-plus arguments.

The callback overload's `fn` gains a required third parameter, which is what finally makes `optional`/`nullable`'s trailing `_?: never` do its job: their lazy default `() => TOr` no longer matches `callback`, so `S.string.with(S.optional, () => "foo")` infers `Schema<string | undefined, string>` instead of losing the absent case. The `// FIXME: This is broken` in `tests/S_test.ts` is gone with it, and `specs/optional-default-lazy.yaml` pins the type.

Each shape was measured against the spec suite before settling:

- one argument through the rest tuple costs ~2 500 instantiations more per call than a dedicated overload, so it keeps one, constrained to `{} | null | undefined` so `.with(S.brand, "id")` and `.with(S.length, 2)` stay literal. A bare result type parameter there stops the overload matching generic modifiers at all.
- a dedicated `(fn, arg1, arg2)` overload leaves the arrow in `.with(S.refine, (v) => …, { error })` untyped, where the rest tuple, inferred from `fn`'s own parameter list, keeps it. That is why main needed a separate `refine` overload and this doesn't.
- a structured `SchemaLike` return on the rest tuple is what brings two arguments back to main's numbers.

**Metrics:** `ts.instantiations` 1 203 016 → 1 032 198 (-14.2%) across the suite, 240 specs improved, none regressed; codec and shape specs -16% to -45%, `string-refine-path` 5076 → 664. No generated code or bundle size change.

## `S.refine` path type

`S.refine`'s `path` was declared `string[]` in `index.d.ts` and `array<string>` in `S.res`, while error paths became `ReadonlyArray<string | number>` in #405 and the runtime splices the option straight onto `error.path`. An array index therefore had to be spelled `"0"`, and came out as the key `0` rather than the index `[0]`.

Both declarations now name the path type (`Path` / `S.Path.t`), so `path: ["items", 0]` and `~path=[String("items"), Number(0.)]` report `Failed at items[0]`. `specs/refine-path-index.yaml` pins the message and `S_Error_customConsolidation_test.res` the ReScript segments. ReScript call sites that passed a string array spell it `S.Path.fromArray([...])`, the idiom `s.fail(~path)` already used; the docs on both sides say what the segments are.

## Verification

- `pnpm spec check --write` (all goldens rederived; only `ts.instantiations` and the two new specs moved)
- `vitest run` in `packages/sury`: 5175 passed, typecheck clean
- `tsc --noEmit` in `packages/e2e` (genType consumer), `pnpm lint:deadcode`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KNnFLvhXXKxFQ8foQDgk8s

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNnFLvhXXKxFQ8foQDgk8s)_