### PR TITLE
Gate the escape-free fuzzer and typecheck the scripts that run it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,22 @@ jobs:
         run: ../../scripts/assert-no-drift.sh '*.res.mjs'
         working-directory: packages/sury
 
+      # `coverage` below typechecks only what vitest is pointed at
+      # (tests/**/*_test.ts). This covers src/ and scripts/ too — the fuzzers
+      # live in scripts/ and reach the library through its public entry, so
+      # without this a renamed export leaves them calling a name that no longer
+      # exists and nothing says so until someone runs them by hand.
+      - run: pnpm typecheck
+        working-directory: packages/sury
+
       - run: pnpm coverage
+        working-directory: packages/sury
+
+      # Guards the `escapeFree` flag, which switches jsonString to splicing a
+      # value between bare quotes with no escaping — so a format flagged wrongly
+      # emits syntactically broken JSON. That claim is a property of each
+      # format's regex, and nothing else in the suite checks it. Roughly 90s.
+      - run: pnpm fuzz:escfree
         working-directory: packages/sury
 
       # artifact_test.ts checks jsr.json against package.json; only JSR itself

--- a/packages/sury/package.json
+++ b/packages/sury/package.json
@@ -59,7 +59,7 @@
     "build": "pnpm rescript && tsx ./scripts/pack.ts for-publish",
     "res": "pnpm build:entry && rescript watch",
     "test": "pnpm build && vitest run",
-    "typecheck": "vitest run --typecheck.only",
+    "typecheck": "tsc --noEmit -p tsconfig.json && vitest run --typecheck.only",
     "lint:stdlib": "rescript-stdlib-vendorer lint --ignore-path=src",
     "prepublishOnly": "node -e \"console.error('Publish from ./artifacts (pnpm build), not the dev package.'); process.exit(1)\""
   },

--- a/packages/sury/scripts/escFreeFuzz.ts
+++ b/packages/sury/scripts/escFreeFuzz.ts
@@ -56,13 +56,26 @@ const SEEDS: Record<string, string[]> = {
   uri: ["https://example.com/a?b=c#d", "mailto:a@b.co", "urn:isbn:0451450523"],
   "uri-reference": ["/a/b?c#d", "https://example.com", "//host/path", "?q", "#f", ""],
   base64: ["ZGF0YQ==", "aGkh", "iVBORw==", ""],
+  base64url: ["ZGF0YQ", "aGkh", "a-b_", ""],
 };
 
-type Schema = { format?: string; type?: string; content?: unknown };
+// `S.Schema` is a union over the `type` variants, so the string arm's `format`
+// is only reachable once narrowed — which the filter below does at runtime.
+type StringSchema = S.Schema<string, string> & {
+  type: "string";
+  format: S.StringFormat;
+};
+
+// `content` is internal (it marks a bytes carrier), so it is the one field this
+// script has to reach past the public type for. Named rather than an `as any`
+// on the whole schema: everything else here goes through the public API, so a
+// rename of it is a compile error instead of a runtime surprise.
+const contentOf = (schema: StringSchema): unknown =>
+  (schema as unknown as { content?: unknown }).content;
 
 const stringFormatSchemas = Object.entries(S as Record<string, unknown>).filter(
-  (entry): entry is [string, Schema] => {
-    const v = entry[1] as Schema | null;
+  (entry): entry is [string, StringSchema] => {
+    const v = entry[1] as StringSchema | null;
     return (
       typeof v === "object" &&
       v !== null &&
@@ -73,35 +86,47 @@ const stringFormatSchemas = Object.entries(S as Record<string, unknown>).filter(
   },
 );
 
-const accepts = (schema: unknown, value: string): boolean => {
-  try {
-    return (S as any).is(schema, value);
-  } catch {
-    return false;
+// One compiled validator per schema: `inputValidator` builds an operation, and
+// building it per candidate would dominate a 400k-case run.
+const validators = new Map<StringSchema, (value: string) => boolean>();
+
+// No try/catch. A validator that fails to compile, or an API that stopped
+// existing, is a broken harness — it has to crash with a stack trace rather
+// than read as "this format rejected the value". Swallowing that is how a
+// rename left every format silently unfuzzed for nine commits.
+const accepts = (schema: StringSchema, value: string): boolean => {
+  let validate = validators.get(schema);
+  if (!validate) {
+    validate = S.inputValidator(schema);
+    validators.set(schema, validate);
   }
+  return validate(value);
 };
 
 const failures: string[] = [];
 const rows: string[][] = [];
+// Every format that reached the seeded phase, so the table below can be
+// checked against the set it is supposed to mirror.
+const rawSpliced = new Set<string>();
 
 for (const [name, schema] of stringFormatSchemas) {
-  const format = schema.format!;
+  const format = schema.format;
   // Ground truth: a raw-spliced format emits `"\""+i+"\""`, an escaped one a
   // call into the embedded helper.
   // A content format's link to jsonString has two readings (CONTENT_CODEC_SPEC.md)
   // and asks rather than guessing, so name the one this script is about: the
   // value spliced into a document.
   const emitted = String(
-    schema.content
-      ? (S as any).decoder(
-          (S as any).to(schema, (S as any).jsonString, { decode: "pack", encode: "unpack" }),
-        )
-      : (S as any).encoder(schema, (S as any).jsonString),
+    contentOf(schema)
+      ? S.decoder(S.to(schema, S.jsonString, { decode: "pack", encode: "unpack" }))
+      : S.encoder(schema, S.jsonString),
   );
   if (!emitted.includes(`"\\""+`)) {
     rows.push([name, format, "escape helper", "—"]);
     continue;
   }
+
+  rawSpliced.add(format);
 
   const seeds = (SEEDS[format] ?? []).filter((v) => accepts(schema, v));
   if (!seeds.length) {
@@ -147,6 +172,19 @@ for (const [name, schema] of stringFormatSchemas) {
   } else {
     failures.push(`${name} (${format}): accepts ${JSON.stringify(hit)}, which needs escaping`);
     rows.push([name, format, "RAW SPLICE", `ACCEPTS ${JSON.stringify(hit)}`]);
+  }
+}
+
+// The table has to mirror the raw-spliced set exactly. A missing key is caught
+// above, per format; a key for a format that stopped being raw-spliced (or
+// stopped existing) is caught here, so the table can't quietly rot into a list
+// of names nothing reads.
+for (const format of Object.keys(SEEDS)) {
+  if (!rawSpliced.has(format)) {
+    failures.push(
+      `${format}: seeds for a format that is not raw-spliced — drop them, or ` +
+        `restore the escFree flag in refinements.ts`,
+    );
   }
 }
 

--- a/packages/sury/specs/union-jsonstring-drops-validation.yaml
+++ b/packages/sury/specs/union-jsonstring-drops-validation.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=./spec.schema.json
+ts:
+  schema: 'S.union([S.jsonString, S.schema({ kind: "k0" })])'
+  input: 'string | { kind: "k0"; }'
+  output: 'string | { kind: "k0"; }'
+  instantiations: 2476
+jsonSchema:
+  input: '{ anyOf: [{ type: "string", contentMediaType: "application/json" }, { type: "object", properties: { kind: { type: "string", const: "k0" } }, required: ["kind"] }] }'
+  output: '{ anyOf: [{ type: "string", contentMediaType: "application/json" }, { type: "object", properties: { kind: { type: "string", const: "k0" } }, required: ["kind"] }] }'
+  openapi-3.0:
+    input: '{ anyOf: [{ type: "string" }, { type: "object", properties: { kind: { type: "string", enum: ["k0"] } }, required: ["kind"] }] }'
+    output: '{ anyOf: [{ type: "string" }, { type: "object", properties: { kind: { type: "string", enum: ["k0"] } }, required: ["kind"] }] }'
+vs:
+  zod:
+    _skip: not-applicable
+operations:
+  parse:
+    # FIXME: the union drops jsonString's JSON-validity check. Standalone,
+    # `S.jsonString` emits `try{JSON.parse(i)}catch(t){e[0](i)}`; here the
+    # string arm is only `typeof i==="string"`, so `"a"` — not JSON — is
+    # accepted and returned unchanged. Found by `pnpm fuzz:union`, which
+    # reports it as an `acceptance` diff against a sequential try of each
+    # variant. The goldens below record the wrong behavior so the fix has a
+    # before/after; they are not the contract.
+    expression: i=>{for(;;){if(typeof i==="string"){i=e[0](i);break}if(typeof i==="object"&&i&&!Array.isArray(i)&&i["kind"]==="k0"){i={kind:i["kind"]};break}e[1](i)}return i}
+    examples:
+      json-number:
+        input: '"1"'
+        output: '"\"1\""'
+      json-string:
+        input: '"\"x\""'
+        output: '"\"\\\"x\\\"\""'
+      not-json-at-all:
+        input: '"a"'
+        output: '"\"a\""'
+      unterminated-object:
+        input: '"{"'
+        output: '"\"{\""'
+      empty:
+        input: '""'
+        output: '"\"\""'
+      the-object-variant:
+        input: '{ kind: "k0" }'
+        output: '{ kind: "k0" }'
+  decode: identity
+  encode: identity


### PR DESCRIPTION
`fuzz:escfree` has been dead since #406 renamed `S.is` away — nine commits ago. It doesn't fail quietly, it fails *loudly and wrongly*: it reports all 27 raw-spliced formats as "no valid seed" and tells you to edit the seed table, which is the one place the bug isn't.

## Why CI missed it

Four independent layers had to fail. All four did.

1. **No workflow runs either fuzzer.** `grep -rn fuzz .github/workflows/` returns nothing. `coverage` is vitest, and `vitest.config.mjs` includes only `tests/**`; the fuzzers live in `scripts/` and are reachable only via `pnpm fuzz:*`.
2. **No workflow typechecks `scripts/`.** `typecheck` was vitest's, scoped by `typecheck.include` to `tests/**/*_test.ts` — and CI ran `coverage`, not `typecheck`, anyway.
3. **Even a full `tsc` would have passed**, because of `(S as any).is(...)`. Verified both ways: with the cast, `tsc --noEmit -p tsconfig.json` reports nothing for a nonexistent export; without it, `TS2339` on the spot.
4. **`accepts()` swallowed the evidence.** `try { … } catch { return false }` made `TypeError: S.is is not a function` indistinguishable from "this format rejected the seed".

## What this changes

**CI.** `typecheck` now runs `tsc --noEmit -p tsconfig.json` (covering `src/` and `scripts/`) before the vitest pass, and CI runs it. CI also gates `fuzz:escfree` — roughly 90s to guard `escapeFree`, which switches `jsonString` to splicing a value between bare quotes with no escaping, so a format flagged wrongly emits syntactically broken JSON. Nothing else in the suite checks that claim.

**The script.** The `as any` casts are gone, so the fuzzer now fails to *compile* rather than fails to *mean anything*. Typing the schemas properly immediately surfaced that `format` needs narrowing off the `S.Schema` union — something the cast had also been hiding. `accepts` builds one validator per schema (compiling per candidate would dominate a 400k-case run) and no longer catches: a harness that can't compile its target has to crash with a stack trace.

**The seed table**, which must mirror the raw-spliced set and was checked in one direction only:

- `base64url` gained `escFree` in #394 and never had a seed, so it has never actually been fuzzed. It has one now.
- A key for a format that stopped being raw-spliced was silently ignored; it now fails the run.

Both new guards were verified by deliberately breaking them: a bogus seed key fails with the stale-key message, and re-pointing `accepts` at a nonexistent export now produces a stack trace instead of 27 misleading "unseeded" lines.

## `fuzz:union` is also red on main

Not fixed here, and this is why the PR gates `escfree` and not `union`.

Every acceptance diff is a union containing `jsonString` accepting a string that isn't JSON. Reduced:

```js
S.parser(S.jsonString)("a")
// throws: Expected JSON string, received "a"
//   i=>{typeof i==="string"||e[1](i);try{JSON.parse(i)}catch(t){e[0](i)}return i}

S.parser(S.union([S.jsonString, S.schema({ kind: "k0" })]))("a")
// returns "a"
//   i=>{for(;;){if(typeof i==="string"){i=e[0](i);break} … }return i}
```

The union's string arm compiles to a bare `typeof i==="string"` and drops the `JSON.parse` guard, so it accepts input the schema rejects standalone. Recorded as `specs/union-jsonstring-drops-validation.yaml` with a `FIXME:`, per CLAUDE.md — the goldens record the wrong behaviour so a fix has a before/after, and are explicitly not the contract. It's a union-compiler bug, not CI hygiene, so it wants its own change.

## Verification

`lint:deadcode`, `build`, `typecheck`, `fuzz:escfree`, the drift check, and the full suite (5234 tests, 129 files) all pass.

One recommendation from the review was dropped: adding the fuzz scripts to knip's `entry` list. Knip already infers them from `package.json` scripts and flags the additions as redundant, so it made the config worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHvwnnKVfo1N3RNXpwxNyG

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHvwnnKVfo1N3RNXpwxNyG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated validation with TypeScript checks and fuzz testing for string escaping and formatting scenarios.
  * Added coverage for Base64 URL-safe inputs and checks that test seeds remain aligned with supported formats.
  * Documented an edge case where combining JSON-string validation with a union may accept non-JSON strings, preserving the observed behavior for regression tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->