### PR TITLE
Refresh generated-code examples after identifier field access

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Encoders take an extra `target` argument (the schema being coerced into): `(inpu
 
 A compilation-time representation of a value being processed. Key fields:
 
-- `inline`: The generated code expression (e.g., `i["foo"]`, `v0`)
+- `inline`: The generated code expression (e.g., `i.foo`, `v0`)
 - `var()`: Function to allocate/retrieve a variable name (use when value is referenced multiple times)
 - `schema`: The schema of the current value
 - `expected`: The schema we're trying to parse/convert into
@@ -87,7 +87,7 @@ Input Schema
 │     - continue the chain inside `.then(...)`                 │
 │                                                              │
 │  else if val.isOutput (decoded, may still have `.to`):       │
-│     - follow `.to`: run `expected.pr` (custom decoder)       │
+│     - follow `.to`: run `expected.parser` (custom decoder)       │
 │       or `refine` onto `.to` (default encoder coercion)      │
 │                                                              │
 │  else (not yet decoded):                                     │
@@ -114,7 +114,7 @@ For `S.object(s => s.field("foo", S.string))` the generated parse function is:
 ```javascript
 i => {
   typeof i === "object" && i || e[1](i); // object validation
-  let v0 = i["foo"];                     // field access
+  let v0 = i.foo;                        // field access
   typeof v0 === "string" || e[0](v0);    // string validation
   return v0;                             // return parsed value
 };

--- a/docs/js-usage.md
+++ b/docs/js-usage.md
@@ -877,13 +877,13 @@ Checkout the compiled code yourself:
 
 ```javascript
 (i) => {
-  let v4 = [new Array(i.length), new Array(i.length), new Array(i.length)];
-  for (let v3 = 0; v3 < i.length; ++v3) {
-    v4[0][v3] = i[v3]["id"];
-    v4[1][v3] = i[v3]["name"];
-    v4[2][v3] = i[v3]["deleted"];
+  let v3 = [new Array(i.length), new Array(i.length), new Array(i.length)];
+  for (let v2 = 0; v2 < i.length; ++v2) {
+    v3[0][v2] = i[v2].id;
+    v3[1][v2] = i[v2].name;
+    v3[2][v2] = i[v2].deleted;
   }
-  return v4;
+  return v3;
 };
 ```
 
@@ -1674,7 +1674,7 @@ The `Result` is compiled into the operation rather than wrapped around it, which
 
 ```ts
 S.parseAsResult(S.schema({ id: S.unknown }).with(S.noValidation, true)).toString();
-// => (i) => { return { success: true, value: { id: i["id"] }, error: void 0 } }
+// => (i) => { return { success: true, value: { id: i.id }, error: void 0 } }
 ```
 
 Both branches of a `Result` carry the same keys in the same order, so `const { value, error } = result` narrows and a consumer's `.success` read stays monomorphic.

--- a/docs/rescript-usage.md
+++ b/docs/rescript-usage.md
@@ -1108,13 +1108,13 @@ Checkout the compiled code yourself:
   for (let v0 = 0; v0 < i.length; ++v0) {
     let v3 = i[v0];
     try {
-      let v4 = v3["name"];
+      let v4 = v3.name;
       if (v4 === void 0) {
         v4 = null;
       }
-      v1[0][v0] = v3["id"];
+      v1[0][v0] = v3.id;
       v1[1][v0] = v4;
-      v1[2][v0] = v3["deleted"];
+      v1[2][v0] = v3.deleted;
     } catch (v2) {
       if (v2 && v2.s === s) {
         v2.path = [v0, ...v2.path];

--- a/packages/sury/README.md
+++ b/packages/sury/README.md
@@ -240,8 +240,8 @@ Here's what `parseEvent` from above actually runs - a function specialized for t
   }
   if (typeof v0 === "object" && v0 && !Array.isArray(v0)) {
     for (;;) {
-      if (v0["type"] === "user.created") {
-        let v2 = v0["id"], v3 = v0["tags"];
+      if (v0.type === "user.created") {
+        let v2 = v0.id, v3 = v0.tags;
         typeof v2 === "string" || e[2](v2);
         let v1;
         try {
@@ -252,10 +252,10 @@ Here's what `parseEvent` from above actually runs - a function specialized for t
         Array.isArray(v3) || e[6](v3);
         // ...validates each tag, tracking the error path
         v8.length > 0 || e[5](v8); // e[5] throws your nonEmpty message
-        v0 = { type: v0["type"], id: v1, tags: v8 };
+        v0 = { type: v0.type, id: v1, tags: v8 };
         break;
       }
-      if (v0["type"] === "user.deleted") {
+      if (v0.type === "user.deleted") {
         // ...one branch per variant, no loop over union members
       }
       e[9](v0);
@@ -278,9 +278,9 @@ The encoder builds the JSON text directly - no intermediate object, the structur
   if (typeof i === "object" && i && !Array.isArray(i)) {
     for (;;) {
       // ...one branch per variant
-      if (i["type"] === "user.deleted") {
-        let v6 = JSON.stringify(i["payload"]);
-        let v7 = '{"type":"user.deleted","id":"' + i["id"] + '"';
+      if (i.type === "user.deleted") {
+        let v6 = JSON.stringify(i.payload);
+        let v7 = '{"type":"user.deleted","id":"' + i.id + '"';
         if (v6 !== void 0) {
           v7 += ',"payload":' + v6;
         }


### PR DESCRIPTION
## Summary

#430 emits identifier field access (`i.id`, `i[0]`) instead of `i["id"]`. The README, JS/ReScript usage docs, and CONTRIBUTING still showed the quoted form.

## Test plan

- [x] Examples match `toString()` of the current compiler for the schemas they describe
- [ ] CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated code examples to reflect current generated output.
  - Replaced bracket notation with dot notation in JavaScript examples.
  - Updated documented terminology, including the parser property name.
  - Adjusted example variable names to match regenerated compiler output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->